### PR TITLE
Use FQDN for kube-apiserver in AKS

### DIFF
--- a/pkg/cmds/server/start.go
+++ b/pkg/cmds/server/start.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 
+	"github.com/appscode/kutil/tools/clientcmd"
 	"github.com/kubedb/operator/pkg/controller"
 	"github.com/kubedb/operator/pkg/server"
 	"github.com/spf13/pflag"
@@ -60,7 +61,7 @@ func (o KubeDBServerOptions) Config() (*server.KubeDBServerConfig, error) {
 	if err := o.RecommendedOptions.ApplyTo(serverConfig, server.Scheme); err != nil {
 		return nil, err
 	}
-	serverConfig.EnableMetrics = true
+	clientcmd.Fix(serverConfig.ClientConfig)
 
 	controllerConfig := controller.NewOperatorConfig(serverConfig.ClientConfig)
 	if err := o.ExtraOptions.ApplyTo(controllerConfig); err != nil {


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>