### PR TITLE
Change default termination policy as Delete

### DIFF
--- a/docs/concepts/databases/elasticsearch.md
+++ b/docs/concepts/databases/elasticsearch.md
@@ -478,8 +478,8 @@ You can specify [update strategy](https://kubernetes.io/docs/concepts/workloads/
 `terminationPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `Elasticsearch` crd or which resources KubeDB should keep or delete when you delete `Elasticsearch` crd. KubeDB provides following four termination policies:
 
 - DoNotTerminate
-- Pause (`Default`)
-- Delete
+- Pause
+- Delete (`Default`)
 - WipeOut
 
 When, `terminationPolicy` is `DoNotTerminate`, KubeDB takes advantage of `ValidationWebhook` feature in Kubernetes 1.9.0 or later clusters to provide safety from accidental deletion of database. If admission webhook is enabled, KubeDB prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`.

--- a/docs/concepts/databases/memcached.md
+++ b/docs/concepts/databases/memcached.md
@@ -206,8 +206,8 @@ You can specify [update strategy](https://kubernetes.io/docs/concepts/workloads/
 `terminationPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `Memcached` crd or which resources KubeDB should keep or delete when you delete `Memcached` crd. KubeDB provides following four termination policies:
 
 - DoNotTerminate
-- Pause (`Default`)
-- Delete
+- Pause
+- Delete (`Default`)
 - WipeOut
 
 When, `terminationPolicy` is `DoNotTerminate`, KubeDB takes advantage of `ValidationWebhook` feature in Kubernetes 1.9.0 or later clusters to implement `DoNotTerminate` feature. If admission webhook is enabled, `DoNotTerminate` prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`.

--- a/docs/concepts/databases/mongodb.md
+++ b/docs/concepts/databases/mongodb.md
@@ -539,8 +539,8 @@ You can specify [update strategy](https://kubernetes.io/docs/concepts/workloads/
 `terminationPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `MongoDB` crd or which resources KubeDB should keep or delete when you delete `MongoDB` crd. KubeDB provides following four termination policies:
 
 - DoNotTerminate
-- Pause (`Default`)
-- Delete
+- Pause
+- Delete (`Default`)
 - WipeOut
 
 When, `terminationPolicy` is `DoNotTerminate`, KubeDB takes advantage of `ValidationWebhook` feature in Kubernetes 1.9.0 or later clusters to implement `DoNotTerminate` feature. If admission webhook is enabled, `DoNotTerminate` prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`.

--- a/docs/concepts/databases/mysql.md
+++ b/docs/concepts/databases/mysql.md
@@ -382,8 +382,8 @@ You can specify [update strategy](https://kubernetes.io/docs/concepts/workloads/
 `terminationPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `MySQL` crd or which resources KubeDB should keep or delete when you delete `MySQL` crd. KubeDB provides following four termination policies:
 
 - DoNotTerminate
-- Pause (`Default`)
-- Delete
+- Pause
+- Delete (`Default`)
 - WipeOut
 
 When, `terminationPolicy` is `DoNotTerminate`, KubeDB takes advantage of `ValidationWebhook` feature in Kubernetes 1.9.0 or later clusters to implement `DoNotTerminate` feature. If admission webhook is enabled, `DoNotTerminate` prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`.

--- a/docs/concepts/databases/postgres.md
+++ b/docs/concepts/databases/postgres.md
@@ -487,8 +487,8 @@ You can specify [update strategy](https://kubernetes.io/docs/concepts/workloads/
 `terminationPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `Postgres` crd or which resources KubeDB should keep or delete when you delete `Postgres` crd. KubeDB provides following four termination policies:
 
 - DoNotTerminate
-- Pause (`Default`)
-- Delete
+- Pause
+- Delete (`Default`)
 - WipeOut
 
 When, `terminationPolicy` is `DoNotTerminate`, KubeDB takes advantage of `ValidationWebhook` feature in Kubernetes 1.9.0 or later clusters to provide safety from accidental deletion of database. If admission webhook is enabled, KubeDB prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`.

--- a/docs/concepts/databases/redis.md
+++ b/docs/concepts/databases/redis.md
@@ -241,8 +241,8 @@ You can specify [update strategy](https://kubernetes.io/docs/concepts/workloads/
 `terminationPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `Redis` crd or which resources KubeDB should keep or delete when you delete `Redis` crd. KubeDB provides following four termination policies:
 
 - DoNotTerminate
-- Pause (`Default`)
-- Delete
+- Pause
+- Delete (`Default`)
 - WipeOut
 
 When, `terminationPolicy` is `DoNotTerminate`, KubeDB takes advantage of `ValidationWebhook` feature in Kubernetes 1.9.0 or later clusters to implement `DoNotTerminate` feature. If admission webhook is enabled, `DoNotTerminate` prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`.


### PR DESCRIPTION
Before if no termination policy was set, we will consider it as DoNotTerminate.
I think this is too restrictive. This blocks namespace deletion.
Now, we only consider explicitly set termination policy.

Signed-off-by: Tamal Saha <tamal@appscode.com>