### PR TITLE
fix for k8s v1.16

### DIFF
--- a/docs/examples/mysql/quickstart/demo-1.yaml
+++ b/docs/examples/mysql/quickstart/demo-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -7,6 +7,9 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: myadmin
   template:
     metadata:
       labels:


### PR DESCRIPTION
> In 1.16 if you submit a Deployment to the API server and specify extensions/v1beta1 as the API group it will be rejected with:
`error: unable to recognize "deployment": no matches for kind "Deployment" in version "extensions/v1beta1"`