### PR TITLE
chore: replica alert typo

### DIFF
--- a/vendor/kubedb.dev/redis/pkg/admission/validator.go
+++ b/vendor/kubedb.dev/redis/pkg/admission/validator.go
@@ -158,7 +158,7 @@ func ValidateRedis(client kubernetes.Interface, extClient cs.Interface, redis *a
 	}
 
 	if redis.Spec.Mode == api.RedisModeCluster && *redis.Spec.Cluster.Replicas == 0 {
-		return fmt.Errorf(`spec.cluster.replicas "%v" invalid. Value must be > 0`, redis.Spec.Cluster.Master)
+		return fmt.Errorf(`spec.cluster.replicas "%v" invalid. Value must be > 0`, redis.Spec.Cluster.Replicas)
 	}
 
 	if redis.Spec.StorageType == "" {


### PR DESCRIPTION
Dear Owner, 
I have found a typo and submit this PR to fix

On the other hand, I wish to ask why master number MUST be larger than 3 for redis cluster?
In our use case, we wish to create a redis cluster with minimum resources for development environment, so I feel the requirement is too strict

Thank you