### PR TITLE
Change apiVersion for deployment

### DIFF
--- a/docs/examples/mysql/quickstart/demo-1.yaml
+++ b/docs/examples/mysql/quickstart/demo-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -7,6 +7,9 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: myadmin
   template:
     metadata:
       labels:


### PR DESCRIPTION
the apiVersion: extensions/v1beta has been removed in kubernetes 1.16 in favour of apps/v1. https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/