### PR TITLE
Prepare for release v2020.10.26-beta.0

### DIFF
--- a/docs/CHANGELOG-v2020.10.26-beta.0.md
+++ b/docs/CHANGELOG-v2020.10.26-beta.0.md
@@ -1,0 +1,218 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2020.10.26-beta.0
+    name: Changelog-v2020.10.26-beta.0
+    parent: welcome
+    weight: 20201026
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.10.26-beta.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.10.26-beta.0/
+---
+
+# KubeDB v2020.10.26-beta.0 (2020-10-27)
+
+
+## [appscode/kubedb-enterprise](https://github.com/appscode/kubedb-enterprise)
+
+### [v0.1.0-beta.5](https://github.com/appscode/kubedb-enterprise/releases/tag/v0.1.0-beta.5)
+
+- [c7bf3943](https://github.com/appscode/kubedb-enterprise/commit/c7bf3943) Prepare for release v0.1.0-beta.5 (#81)
+- [1bf37b01](https://github.com/appscode/kubedb-enterprise/commit/1bf37b01) Update KubeDB api (#80)
+- [a99c4e9f](https://github.com/appscode/kubedb-enterprise/commit/a99c4e9f) Update readme
+- [2ad24272](https://github.com/appscode/kubedb-enterprise/commit/2ad24272) Update repository config (#79)
+
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.14.0-beta.5](https://github.com/kubedb/apimachinery/releases/tag/v0.14.0-beta.5)
+
+- [b72968d5](https://github.com/kubedb/apimachinery/commit/b72968d5) Add port constants (#635)
+- [6ce39fbe](https://github.com/kubedb/apimachinery/commit/6ce39fbe) Create separate governing service for each database (#634)
+- [ecfb5d85](https://github.com/kubedb/apimachinery/commit/ecfb5d85) Update readme
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.14.0-beta.5](https://github.com/kubedb/cli/releases/tag/v0.14.0-beta.5)
+
+- [a4af36b9](https://github.com/kubedb/cli/commit/a4af36b9) Prepare for release v0.14.0-beta.5 (#529)
+- [2f1cb09d](https://github.com/kubedb/cli/commit/2f1cb09d) Update KubeDB api (#528)
+- [87eb5ad3](https://github.com/kubedb/cli/commit/87eb5ad3) Update readme
+- [4dfe0da7](https://github.com/kubedb/cli/commit/4dfe0da7) Update KubeDB api (#527)
+- [5448e521](https://github.com/kubedb/cli/commit/5448e521) Update repository config (#526)
+- [e1e9dbe2](https://github.com/kubedb/cli/commit/e1e9dbe2) Update KubeDB api (#525)
+- [e49d303a](https://github.com/kubedb/cli/commit/e49d303a) Update Kubernetes v1.18.9 dependencies (#524)
+- [9f54a783](https://github.com/kubedb/cli/commit/9f54a783) Update KubeDB api (#523)
+- [ad764956](https://github.com/kubedb/cli/commit/ad764956) Update for release Stash@v2020.10.21 (#522)
+- [46ae22cd](https://github.com/kubedb/cli/commit/46ae22cd) Update KubeDB api (#521)
+- [2914b270](https://github.com/kubedb/cli/commit/2914b270) Update KubeDB api (#520)
+- [87ce0033](https://github.com/kubedb/cli/commit/87ce0033) Update Kubernetes v1.18.9 dependencies (#519)
+- [ab524afe](https://github.com/kubedb/cli/commit/ab524afe) Update KubeDB api (#518)
+- [899e2b21](https://github.com/kubedb/cli/commit/899e2b21) Update KubeDB api (#517)
+- [37a5da4b](https://github.com/kubedb/cli/commit/37a5da4b) Update KubeDB api (#516)
+- [5c87d6e8](https://github.com/kubedb/cli/commit/5c87d6e8) Update KubeDB api (#515)
+- [dfc9e245](https://github.com/kubedb/cli/commit/dfc9e245) Update Kubernetes v1.18.9 dependencies (#514)
+- [c0650bb7](https://github.com/kubedb/cli/commit/c0650bb7) Update KubeDB api (#513)
+- [278dccbe](https://github.com/kubedb/cli/commit/278dccbe) Update KubeDB api (#512)
+- [221be742](https://github.com/kubedb/cli/commit/221be742) Update KubeDB api (#511)
+- [2a301cd0](https://github.com/kubedb/cli/commit/2a301cd0) Don't update krew manifest for pre-releases
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.14.0-beta.5](https://github.com/kubedb/elasticsearch/releases/tag/v0.14.0-beta.5)
+
+- [97f34417](https://github.com/kubedb/elasticsearch/commit/97f34417) Prepare for release v0.14.0-beta.5 (#391)
+- [a3e9a733](https://github.com/kubedb/elasticsearch/commit/a3e9a733) Create separate governing service for each database (#390)
+- [ce8f80b5](https://github.com/kubedb/elasticsearch/commit/ce8f80b5) Update KubeDB api (#389)
+- [0fe8d617](https://github.com/kubedb/elasticsearch/commit/0fe8d617) Update readme
+- [657797fe](https://github.com/kubedb/elasticsearch/commit/657797fe) Update repository config (#388)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v0.14.0-beta.5](https://github.com/kubedb/installer/releases/tag/v0.14.0-beta.5)
+
+- [5ae7fce](https://github.com/kubedb/installer/commit/5ae7fce) Prepare for release v0.14.0-beta.5 (#170)
+- [127eda0](https://github.com/kubedb/installer/commit/127eda0) Update Kubernetes v1.18.9 dependencies (#169)
+- [984c86f](https://github.com/kubedb/installer/commit/984c86f) Update KubeDB api (#168)
+- [8956af1](https://github.com/kubedb/installer/commit/8956af1) Update readme
+- [a1eea93](https://github.com/kubedb/installer/commit/a1eea93) Update Kubernetes v1.18.9 dependencies (#167)
+- [2c7ab1e](https://github.com/kubedb/installer/commit/2c7ab1e) Update KubeDB api (#166)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.7.0-beta.5](https://github.com/kubedb/memcached/releases/tag/v0.7.0-beta.5)
+
+- [0fbfc766](https://github.com/kubedb/memcached/commit/0fbfc766) Prepare for release v0.7.0-beta.5 (#224)
+- [7a01e878](https://github.com/kubedb/memcached/commit/7a01e878) Create separate governing service for each database (#223)
+- [6cecdfec](https://github.com/kubedb/memcached/commit/6cecdfec) Update KubeDB api (#222)
+- [5942b1ff](https://github.com/kubedb/memcached/commit/5942b1ff) Update readme
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.7.0-beta.5](https://github.com/kubedb/mongodb/releases/tag/v0.7.0-beta.5)
+
+- [f1818bb1](https://github.com/kubedb/mongodb/commit/f1818bb1) Prepare for release v0.7.0-beta.5 (#292)
+- [7d1586f7](https://github.com/kubedb/mongodb/commit/7d1586f7) Create separate governing service for each database (#291)
+- [1e281abb](https://github.com/kubedb/mongodb/commit/1e281abb) Update KubeDB api (#290)
+- [23d8785f](https://github.com/kubedb/mongodb/commit/23d8785f) Update readme
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.7.0-beta.5](https://github.com/kubedb/mysql/releases/tag/v0.7.0-beta.5)
+
+- [8dbd64c9](https://github.com/kubedb/mysql/commit/8dbd64c9) Prepare for release v0.7.0-beta.5 (#284)
+- [ee4285c1](https://github.com/kubedb/mysql/commit/ee4285c1) Create separate governing service for each database (#283)
+- [8e2fcbf4](https://github.com/kubedb/mysql/commit/8e2fcbf4) Update KubeDB api (#282)
+- [ae962768](https://github.com/kubedb/mysql/commit/ae962768) Update readme
+
+
+
+## [kubedb/mysql-replication-mode-detector](https://github.com/kubedb/mysql-replication-mode-detector)
+
+### [v0.1.0-beta.5](https://github.com/kubedb/mysql-replication-mode-detector/releases/tag/v0.1.0-beta.5)
+
+- [e251fd6](https://github.com/kubedb/mysql-replication-mode-detector/commit/e251fd6) Prepare for release v0.1.0-beta.5 (#72)
+- [633ba00](https://github.com/kubedb/mysql-replication-mode-detector/commit/633ba00) Update KubeDB api (#71)
+
+
+
+## [kubedb/operator](https://github.com/kubedb/operator)
+
+### [v0.14.0-beta.5](https://github.com/kubedb/operator/releases/tag/v0.14.0-beta.5)
+
+- [bcada180](https://github.com/kubedb/operator/commit/bcada180) Prepare for release v0.14.0-beta.5 (#331)
+- [07d63285](https://github.com/kubedb/operator/commit/07d63285) Enable PgBoucner & ProxySQL for enterprise license (#330)
+- [35b75a05](https://github.com/kubedb/operator/commit/35b75a05) Update readme.md
+- [14304e05](https://github.com/kubedb/operator/commit/14304e05) Update KubeDB api (#329)
+- [df61aae3](https://github.com/kubedb/operator/commit/df61aae3) Update readme
+- [c9882619](https://github.com/kubedb/operator/commit/c9882619) Format readme
+- [73b725e3](https://github.com/kubedb/operator/commit/73b725e3) Update readme (#328)
+- [541c2460](https://github.com/kubedb/operator/commit/541c2460) Update repository config (#327)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.1.0-beta.5](https://github.com/kubedb/percona-xtradb/releases/tag/v0.1.0-beta.5)
+
+- [9866a420](https://github.com/kubedb/percona-xtradb/commit/9866a420) Prepare for release v0.1.0-beta.5 (#116)
+- [f92081d1](https://github.com/kubedb/percona-xtradb/commit/f92081d1) Create separate governing service for each database (#115)
+- [6010b189](https://github.com/kubedb/percona-xtradb/commit/6010b189) Update KubeDB api (#114)
+- [95b57c72](https://github.com/kubedb/percona-xtradb/commit/95b57c72) Update readme
+
+
+
+## [kubedb/pg-leader-election](https://github.com/kubedb/pg-leader-election)
+
+### [v0.2.0-beta.5](https://github.com/kubedb/pg-leader-election/releases/tag/v0.2.0-beta.5)
+
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.1.0-beta.5](https://github.com/kubedb/pgbouncer/releases/tag/v0.1.0-beta.5)
+
+- [96144773](https://github.com/kubedb/pgbouncer/commit/96144773) Prepare for release v0.1.0-beta.5 (#89)
+- [bb574108](https://github.com/kubedb/pgbouncer/commit/bb574108) Create separate governing service for each database (#88)
+- [28f29e3c](https://github.com/kubedb/pgbouncer/commit/28f29e3c) Update KubeDB api (#87)
+- [79a3e3f7](https://github.com/kubedb/pgbouncer/commit/79a3e3f7) Update readme
+- [f42d28f9](https://github.com/kubedb/pgbouncer/commit/f42d28f9) Update repository config (#86)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.14.0-beta.5](https://github.com/kubedb/postgres/releases/tag/v0.14.0-beta.5)
+
+- [c6e802a7](https://github.com/kubedb/postgres/commit/c6e802a7) Prepare for release v0.14.0-beta.5 (#401)
+- [4da12584](https://github.com/kubedb/postgres/commit/4da12584) Simplify port assignment (#400)
+- [71420f2b](https://github.com/kubedb/postgres/commit/71420f2b) Create separate governing service for each database (#399)
+- [49792ddb](https://github.com/kubedb/postgres/commit/49792ddb) Update KubeDB api (#398)
+- [721f5e16](https://github.com/kubedb/postgres/commit/721f5e16) Update readme
+- [c036ee15](https://github.com/kubedb/postgres/commit/c036ee15) Update Kubernetes v1.18.9 dependencies (#397)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.1.0-beta.5](https://github.com/kubedb/proxysql/releases/tag/v0.1.0-beta.5)
+
+- [4269db9c](https://github.com/kubedb/proxysql/commit/4269db9c) Prepare for release v0.1.0-beta.5 (#98)
+- [e48bd006](https://github.com/kubedb/proxysql/commit/e48bd006) Create separate governing service for each database (#97)
+- [23f1c6de](https://github.com/kubedb/proxysql/commit/23f1c6de) Update KubeDB api (#96)
+- [13abe9ff](https://github.com/kubedb/proxysql/commit/13abe9ff) Update readme
+- [78ef0d29](https://github.com/kubedb/proxysql/commit/78ef0d29) Update repository config (#95)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.7.0-beta.5](https://github.com/kubedb/redis/releases/tag/v0.7.0-beta.5)
+
+- [57743070](https://github.com/kubedb/redis/commit/57743070) Prepare for release v0.7.0-beta.5 (#243)
+- [5e8f1a25](https://github.com/kubedb/redis/commit/5e8f1a25) Create separate governing service for each database (#242)
+- [ebeda2c7](https://github.com/kubedb/redis/commit/ebeda2c7) Update KubeDB api (#241)
+- [b0a39a3c](https://github.com/kubedb/redis/commit/b0a39a3c) Update readme
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.26-beta.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/16
Signed-off-by: 1gtm <1gtm@appscode.com>