### PR TITLE
Prepare for release v2020.10.27-rc.0

### DIFF
--- a/docs/CHANGELOG-v2020.10.27-rc.0.md
+++ b/docs/CHANGELOG-v2020.10.27-rc.0.md
@@ -1,0 +1,170 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2020.10.27-rc.0
+    name: Changelog-v2020.10.27-rc.0
+    parent: welcome
+    weight: 20201027
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.10.27-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.10.27-rc.0/
+---
+
+# KubeDB v2020.10.27-rc.0 (2020-10-27)
+
+
+## [appscode/kubedb-enterprise](https://github.com/appscode/kubedb-enterprise)
+
+### [v0.1.0-beta.6](https://github.com/appscode/kubedb-enterprise/releases/tag/v0.1.0-beta.6)
+
+- [5df3d1e9](https://github.com/appscode/kubedb-enterprise/commit/5df3d1e9) Prepare for release v0.1.0-beta.6 (#82)
+
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.14.0-beta.6](https://github.com/kubedb/apimachinery/releases/tag/v0.14.0-beta.6)
+
+- [cd358dda](https://github.com/kubedb/apimachinery/commit/cd358dda) Update MergeServicePort and PatchServicePort apis
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.14.0-beta.6](https://github.com/kubedb/cli/releases/tag/v0.14.0-beta.6)
+
+- [39c4d5a0](https://github.com/kubedb/cli/commit/39c4d5a0) Prepare for release v0.14.0-beta.6 (#531)
+- [a7a8dfc0](https://github.com/kubedb/cli/commit/a7a8dfc0) Update KubeDB api (#530)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.14.0-beta.6](https://github.com/kubedb/elasticsearch/releases/tag/v0.14.0-beta.6)
+
+- [58dac2ba](https://github.com/kubedb/elasticsearch/commit/58dac2ba) Prepare for release v0.14.0-beta.6 (#394)
+- [5d4ad40c](https://github.com/kubedb/elasticsearch/commit/5d4ad40c) Update MergeServicePort and PatchServicePort apis (#393)
+- [992edb90](https://github.com/kubedb/elasticsearch/commit/992edb90) Always set protocol for service ports
+- [0f408cbf](https://github.com/kubedb/elasticsearch/commit/0f408cbf) Create SRV records for governing service (#392)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v0.14.0-beta.6](https://github.com/kubedb/installer/releases/tag/v0.14.0-beta.6)
+
+- [0ac5eb3](https://github.com/kubedb/installer/commit/0ac5eb3) Prepare for release v0.14.0-beta.6 (#174)
+- [f6407c7](https://github.com/kubedb/installer/commit/f6407c7) Update KubeDB api (#173)
+- [d3e28a7](https://github.com/kubedb/installer/commit/d3e28a7) Use kubedb-community release name for community chart
+- [98553cb](https://github.com/kubedb/installer/commit/98553cb) Update Kubernetes v1.18.9 dependencies (#172)
+- [1b35dfb](https://github.com/kubedb/installer/commit/1b35dfb) Update KubeDB api (#171)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.7.0-beta.6](https://github.com/kubedb/memcached/releases/tag/v0.7.0-beta.6)
+
+- [704cf9f2](https://github.com/kubedb/memcached/commit/704cf9f2) Prepare for release v0.7.0-beta.6 (#226)
+- [47039c68](https://github.com/kubedb/memcached/commit/47039c68) Create SRV records for governing service (#225)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.7.0-beta.6](https://github.com/kubedb/mongodb/releases/tag/v0.7.0-beta.6)
+
+- [0d32b697](https://github.com/kubedb/mongodb/commit/0d32b697) Prepare for release v0.7.0-beta.6 (#296)
+- [1f75de65](https://github.com/kubedb/mongodb/commit/1f75de65) Update MergeServicePort and PatchServicePort apis (#295)
+- [984fd7c2](https://github.com/kubedb/mongodb/commit/984fd7c2) Create SRV records for governing service (#294)
+- [fc973dd0](https://github.com/kubedb/mongodb/commit/fc973dd0) Make database's phase NotReady as soon as the halted is removed (#293)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.7.0-beta.6](https://github.com/kubedb/mysql/releases/tag/v0.7.0-beta.6)
+
+- [680da825](https://github.com/kubedb/mysql/commit/680da825) Prepare for release v0.7.0-beta.6 (#286)
+- [a5066552](https://github.com/kubedb/mysql/commit/a5066552) Create SRV records for governing service (#285)
+
+
+
+## [kubedb/mysql-replication-mode-detector](https://github.com/kubedb/mysql-replication-mode-detector)
+
+### [v0.1.0-beta.6](https://github.com/kubedb/mysql-replication-mode-detector/releases/tag/v0.1.0-beta.6)
+
+- [67ec09b](https://github.com/kubedb/mysql-replication-mode-detector/commit/67ec09b) Prepare for release v0.1.0-beta.6 (#74)
+- [724eaa9](https://github.com/kubedb/mysql-replication-mode-detector/commit/724eaa9) Update KubeDB api (#73)
+
+
+
+## [kubedb/operator](https://github.com/kubedb/operator)
+
+### [v0.14.0-beta.6](https://github.com/kubedb/operator/releases/tag/v0.14.0-beta.6)
+
+- [7c0e97a2](https://github.com/kubedb/operator/commit/7c0e97a2) Prepare for release v0.14.0-beta.6 (#334)
+- [17b42fd3](https://github.com/kubedb/operator/commit/17b42fd3) Update KubeDB api (#333)
+- [6dbde882](https://github.com/kubedb/operator/commit/6dbde882) Update Kubernetes v1.18.9 dependencies (#332)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.1.0-beta.6](https://github.com/kubedb/percona-xtradb/releases/tag/v0.1.0-beta.6)
+
+- [397607a3](https://github.com/kubedb/percona-xtradb/commit/397607a3) Prepare for release v0.1.0-beta.6 (#118)
+- [a3b7642d](https://github.com/kubedb/percona-xtradb/commit/a3b7642d) Create SRV records for governing service (#117)
+
+
+
+## [kubedb/pg-leader-election](https://github.com/kubedb/pg-leader-election)
+
+### [v0.2.0-beta.6](https://github.com/kubedb/pg-leader-election/releases/tag/v0.2.0-beta.6)
+
+- [4635eab](https://github.com/kubedb/pg-leader-election/commit/4635eab) Update KubeDB api (#37)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.1.0-beta.6](https://github.com/kubedb/pgbouncer/releases/tag/v0.1.0-beta.6)
+
+- [e82f1017](https://github.com/kubedb/pgbouncer/commit/e82f1017) Prepare for release v0.1.0-beta.6 (#91)
+- [8d2fa953](https://github.com/kubedb/pgbouncer/commit/8d2fa953) Create SRV records for governing service (#90)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.14.0-beta.6](https://github.com/kubedb/postgres/releases/tag/v0.14.0-beta.6)
+
+- [9e1a642e](https://github.com/kubedb/postgres/commit/9e1a642e) Prepare for release v0.14.0-beta.6 (#404)
+- [8b869c02](https://github.com/kubedb/postgres/commit/8b869c02) Create SRV records for governing service (#402)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.1.0-beta.6](https://github.com/kubedb/proxysql/releases/tag/v0.1.0-beta.6)
+
+- [d01512de](https://github.com/kubedb/proxysql/commit/d01512de) Prepare for release v0.1.0-beta.6 (#100)
+- [6a0d52ff](https://github.com/kubedb/proxysql/commit/6a0d52ff) Create SRV records for governing service (#99)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.7.0-beta.6](https://github.com/kubedb/redis/releases/tag/v0.7.0-beta.6)
+
+- [50f709bf](https://github.com/kubedb/redis/commit/50f709bf) Prepare for release v0.7.0-beta.6 (#245)
+- [d4aaaf38](https://github.com/kubedb/redis/commit/d4aaaf38) Create SRV records for governing service (#244)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.27-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/17
Signed-off-by: 1gtm <1gtm@appscode.com>