### PR TITLE
Prepare for release v2020.10.27-rc.2

### DIFF
--- a/docs/CHANGELOG-v2020.10.27-rc.2.md
+++ b/docs/CHANGELOG-v2020.10.27-rc.2.md
@@ -1,0 +1,148 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2020.10.27-rc.2
+    name: Changelog-v2020.10.27-rc.2
+    parent: welcome
+    weight: 20201027
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.10.27-rc.2/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.10.27-rc.2/
+---
+
+# KubeDB v2020.10.27-rc.2 (2020-10-28)
+
+
+## [appscode/kubedb-enterprise](https://github.com/appscode/kubedb-enterprise)
+
+### [v0.1.0-rc.2](https://github.com/appscode/kubedb-enterprise/releases/tag/v0.1.0-rc.2)
+
+- [c2e95f74](https://github.com/appscode/kubedb-enterprise/commit/c2e95f74) Prepare for release v0.1.0-rc.2 (#84)
+
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.14.0-rc.2](https://github.com/kubedb/apimachinery/releases/tag/v0.14.0-rc.2)
+
+- [dbc93cda](https://github.com/kubedb/apimachinery/commit/dbc93cda) Add dnsConfig and dnsPolicy to podTemplate (#636)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.14.0-rc.2](https://github.com/kubedb/cli/releases/tag/v0.14.0-rc.2)
+
+- [b00a2123](https://github.com/kubedb/cli/commit/b00a2123) Prepare for release v0.14.0-rc.2 (#533)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.14.0-rc.2](https://github.com/kubedb/elasticsearch/releases/tag/v0.14.0-rc.2)
+
+- [846ea8ee](https://github.com/kubedb/elasticsearch/commit/846ea8ee) Prepare for release v0.14.0-rc.2 (#396)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v0.14.0-rc.2](https://github.com/kubedb/installer/releases/tag/v0.14.0-rc.2)
+
+- [262439e](https://github.com/kubedb/installer/commit/262439e) Prepare for release v0.14.0-rc.2 (#176)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.7.0-rc.2](https://github.com/kubedb/memcached/releases/tag/v0.7.0-rc.2)
+
+- [a63e015b](https://github.com/kubedb/memcached/commit/a63e015b) Prepare for release v0.7.0-rc.2 (#228)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.7.0-rc.2](https://github.com/kubedb/mongodb/releases/tag/v0.7.0-rc.2)
+
+- [d87c55bb](https://github.com/kubedb/mongodb/commit/d87c55bb) Prepare for release v0.7.0-rc.2 (#298)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.7.0-rc.2](https://github.com/kubedb/mysql/releases/tag/v0.7.0-rc.2)
+
+- [921327d1](https://github.com/kubedb/mysql/commit/921327d1) Prepare for release v0.7.0-rc.2 (#288)
+
+
+
+## [kubedb/mysql-replication-mode-detector](https://github.com/kubedb/mysql-replication-mode-detector)
+
+### [v0.1.0-rc.2](https://github.com/kubedb/mysql-replication-mode-detector/releases/tag/v0.1.0-rc.2)
+
+- [b49e098](https://github.com/kubedb/mysql-replication-mode-detector/commit/b49e098) Prepare for release v0.1.0-rc.2 (#76)
+
+
+
+## [kubedb/operator](https://github.com/kubedb/operator)
+
+### [v0.14.0-rc.2](https://github.com/kubedb/operator/releases/tag/v0.14.0-rc.2)
+
+- [a06c98d1](https://github.com/kubedb/operator/commit/a06c98d1) Prepare for release v0.14.0-rc.2 (#336)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.1.0-rc.2](https://github.com/kubedb/percona-xtradb/releases/tag/v0.1.0-rc.2)
+
+- [ae82716f](https://github.com/kubedb/percona-xtradb/commit/ae82716f) Prepare for release v0.1.0-rc.2 (#120)
+
+
+
+## [kubedb/pg-leader-election](https://github.com/kubedb/pg-leader-election)
+
+### [v0.2.0-rc.2](https://github.com/kubedb/pg-leader-election/releases/tag/v0.2.0-rc.2)
+
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.1.0-rc.2](https://github.com/kubedb/pgbouncer/releases/tag/v0.1.0-rc.2)
+
+- [c4083972](https://github.com/kubedb/pgbouncer/commit/c4083972) Prepare for release v0.1.0-rc.2 (#93)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.14.0-rc.2](https://github.com/kubedb/postgres/releases/tag/v0.14.0-rc.2)
+
+- [2ed7a29c](https://github.com/kubedb/postgres/commit/2ed7a29c) Prepare for release v0.14.0-rc.2 (#406)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.1.0-rc.2](https://github.com/kubedb/proxysql/releases/tag/v0.1.0-rc.2)
+
+- [8a5443d9](https://github.com/kubedb/proxysql/commit/8a5443d9) Prepare for release v0.1.0-rc.2 (#102)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.7.0-rc.2](https://github.com/kubedb/redis/releases/tag/v0.7.0-rc.2)
+
+- [ac0d5b08](https://github.com/kubedb/redis/commit/ac0d5b08) Prepare for release v0.7.0-rc.2 (#247)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.27-rc.2
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/19
Signed-off-by: 1gtm <1gtm@appscode.com>