### PR TITLE
Prepare for release v2020.11.08

### DIFF
--- a/docs/CHANGELOG-v2020.11.08.md
+++ b/docs/CHANGELOG-v2020.11.08.md
@@ -1,0 +1,300 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2020.11.08
+    name: Changelog-v2020.11.08
+    parent: welcome
+    weight: 20201108
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.11.08/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.11.08/
+---
+
+# KubeDB v2020.11.08 (2020-11-09)
+
+
+## [appscode/kubedb-enterprise](https://github.com/appscode/kubedb-enterprise)
+
+### [v0.1.1](https://github.com/appscode/kubedb-enterprise/releases/tag/v0.1.1)
+
+- [99f6b7cf](https://github.com/appscode/kubedb-enterprise/commit/99f6b7cf) Prepare for release v0.1.1 (#94)
+- [ef26ef08](https://github.com/appscode/kubedb-enterprise/commit/ef26ef08) Fix elasticsearch cert-manager integration (#87)
+- [775a4b1c](https://github.com/appscode/kubedb-enterprise/commit/775a4b1c) Update license
+- [424dcade](https://github.com/appscode/kubedb-enterprise/commit/424dcade) Update Kubernetes v1.18.9 dependencies (#93)
+- [4b3a348b](https://github.com/appscode/kubedb-enterprise/commit/4b3a348b) Update Kubernetes v1.18.9 dependencies (#92)
+- [ec81a2c9](https://github.com/appscode/kubedb-enterprise/commit/ec81a2c9) Update Kubernetes v1.18.9 dependencies (#85)
+- [fcdf8afe](https://github.com/appscode/kubedb-enterprise/commit/fcdf8afe) Update KubeDB api (#89)
+
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.14.1](https://github.com/kubedb/apimachinery/releases/tag/v0.14.1)
+
+- [52b04a20](https://github.com/kubedb/apimachinery/commit/52b04a20) Update Kubernetes v1.18.9 dependencies (#643)
+- [1c8d3ff8](https://github.com/kubedb/apimachinery/commit/1c8d3ff8) Update for release Stash@v2020.11.06 (#642)
+- [750e5762](https://github.com/kubedb/apimachinery/commit/750e5762) Update Kubernetes v1.18.9 dependencies (#641)
+- [f74effb9](https://github.com/kubedb/apimachinery/commit/f74effb9) Use modified UpdateStatus & Invoker utils (#640)
+- [92af33bd](https://github.com/kubedb/apimachinery/commit/92af33bd) Update for release Stash@v2020.10.30 (#638)
+- [a0cc0f91](https://github.com/kubedb/apimachinery/commit/a0cc0f91) Update for release Stash@v2020.10.29 (#637)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.14.1](https://github.com/kubedb/cli/releases/tag/v0.14.1)
+
+- [bfd7e528](https://github.com/kubedb/cli/commit/bfd7e528) Prepare for release v0.14.1 (#545)
+- [594d1972](https://github.com/kubedb/cli/commit/594d1972) Update KubeDB api (#544)
+- [feece297](https://github.com/kubedb/cli/commit/feece297) Update Kubernetes v1.18.9 dependencies (#543)
+- [ce8bfd0d](https://github.com/kubedb/cli/commit/ce8bfd0d) Update KubeDB api (#542)
+- [3b9ee772](https://github.com/kubedb/cli/commit/3b9ee772) Update for release Stash@v2020.11.06 (#541)
+- [8b2623a6](https://github.com/kubedb/cli/commit/8b2623a6) Update Kubernetes v1.18.9 dependencies (#540)
+- [4d348dbd](https://github.com/kubedb/cli/commit/4d348dbd) Replace appscode/go with gomodules.xyz/x
+- [aeaa8c4f](https://github.com/kubedb/cli/commit/aeaa8c4f) Update KubeDB api (#539)
+- [1b4beb54](https://github.com/kubedb/cli/commit/1b4beb54) Update KubeDB api (#538)
+- [5f42fa04](https://github.com/kubedb/cli/commit/5f42fa04) Update for release Stash@v2020.10.30 (#537)
+- [af3f537d](https://github.com/kubedb/cli/commit/af3f537d) Update KubeDB api (#536)
+- [ca9941f5](https://github.com/kubedb/cli/commit/ca9941f5) Update for release Stash@v2020.10.29 (#535)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.14.1](https://github.com/kubedb/elasticsearch/releases/tag/v0.14.1)
+
+- [833f9a84](https://github.com/kubedb/elasticsearch/commit/833f9a84) Prepare for release v0.14.1 (#410)
+- [3451691f](https://github.com/kubedb/elasticsearch/commit/3451691f) Update Kubernetes v1.18.9 dependencies (#409)
+- [0106be92](https://github.com/kubedb/elasticsearch/commit/0106be92) Update KubeDB api (#408)
+- [04047c59](https://github.com/kubedb/elasticsearch/commit/04047c59) Update Kubernetes v1.18.9 dependencies (#407)
+- [237b74b8](https://github.com/kubedb/elasticsearch/commit/237b74b8) Update KubeDB api (#406)
+- [a607ca4f](https://github.com/kubedb/elasticsearch/commit/a607ca4f) Update for release Stash@v2020.11.06 (#405)
+- [8a34c770](https://github.com/kubedb/elasticsearch/commit/8a34c770) Update Kubernetes v1.18.9 dependencies (#404)
+- [6cad9476](https://github.com/kubedb/elasticsearch/commit/6cad9476) Update KubeDB api (#403)
+- [a8694072](https://github.com/kubedb/elasticsearch/commit/a8694072) Update KubeDB api (#401)
+- [5d89e4e4](https://github.com/kubedb/elasticsearch/commit/5d89e4e4) Update for release Stash@v2020.10.30 (#400)
+- [389007fa](https://github.com/kubedb/elasticsearch/commit/389007fa) Update KubeDB api (#399)
+- [7214b539](https://github.com/kubedb/elasticsearch/commit/7214b539) Update for release Stash@v2020.10.29 (#398)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v0.14.1](https://github.com/kubedb/installer/releases/tag/v0.14.1)
+
+- [0554b96](https://github.com/kubedb/installer/commit/0554b96) Prepare for release v0.14.1 (#200)
+- [abb9984](https://github.com/kubedb/installer/commit/abb9984) Update Kubernetes v1.18.9 dependencies (#199)
+- [cd8a787](https://github.com/kubedb/installer/commit/cd8a787) Update Kubernetes v1.18.9 dependencies (#198)
+- [06394de](https://github.com/kubedb/installer/commit/06394de) Replace appscode/go with gomodules.xyz/x (#197)
+- [94aef68](https://github.com/kubedb/installer/commit/94aef68) Update KubeDB api (#196)
+- [881688a](https://github.com/kubedb/installer/commit/881688a) Update Kubernetes v1.18.9 dependencies (#195)
+- [933af3d](https://github.com/kubedb/installer/commit/933af3d) Update KubeDB api (#194)
+- [377d367](https://github.com/kubedb/installer/commit/377d367) Update Kubernetes v1.18.9 dependencies (#193)
+- [a8f33f4](https://github.com/kubedb/installer/commit/a8f33f4) Update KubeDB api (#192)
+- [3120c97](https://github.com/kubedb/installer/commit/3120c97) Update Kubernetes v1.18.9 dependencies (#191)
+- [abd119e](https://github.com/kubedb/installer/commit/abd119e) Update KubeDB api (#190)
+- [a63008c](https://github.com/kubedb/installer/commit/a63008c) Update Kubernetes v1.18.9 dependencies (#189)
+- [ae97c7e](https://github.com/kubedb/installer/commit/ae97c7e) Update KubeDB api (#188)
+- [e698985](https://github.com/kubedb/installer/commit/e698985) Update Kubernetes v1.18.9 dependencies (#187)
+- [42b8da0](https://github.com/kubedb/installer/commit/42b8da0) Update KubeDB api (#186)
+- [51b229c](https://github.com/kubedb/installer/commit/51b229c) Update Kubernetes v1.18.9 dependencies (#185)
+- [0bf41c1](https://github.com/kubedb/installer/commit/0bf41c1) Update KubeDB api (#184)
+- [cd8e61e](https://github.com/kubedb/installer/commit/cd8e61e) Update Kubernetes v1.18.9 dependencies (#183)
+- [57da8dc](https://github.com/kubedb/installer/commit/57da8dc) Update KubeDB api (#182)
+- [c087bab](https://github.com/kubedb/installer/commit/c087bab) Update Kubernetes v1.18.9 dependencies (#181)
+- [209a567](https://github.com/kubedb/installer/commit/209a567) Update KubeDB api (#180)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.7.1](https://github.com/kubedb/memcached/releases/tag/v0.7.1)
+
+- [f54d5d75](https://github.com/kubedb/memcached/commit/f54d5d75) Prepare for release v0.7.1 (#239)
+- [75a22c4b](https://github.com/kubedb/memcached/commit/75a22c4b) Update Kubernetes v1.18.9 dependencies (#238)
+- [8b891213](https://github.com/kubedb/memcached/commit/8b891213) Update KubeDB api (#237)
+- [6f712c71](https://github.com/kubedb/memcached/commit/6f712c71) Update Kubernetes v1.18.9 dependencies (#236)
+- [78dfd6e4](https://github.com/kubedb/memcached/commit/78dfd6e4) Update KubeDB api (#235)
+- [07c3ef2c](https://github.com/kubedb/memcached/commit/07c3ef2c) Update Kubernetes v1.18.9 dependencies (#234)
+- [d9093f08](https://github.com/kubedb/memcached/commit/d9093f08) Update KubeDB api (#232)
+- [7ba3816d](https://github.com/kubedb/memcached/commit/7ba3816d) Update KubeDB api (#231)
+- [bdd430ea](https://github.com/kubedb/memcached/commit/bdd430ea) Update KubeDB api (#230)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.7.1](https://github.com/kubedb/mongodb/releases/tag/v0.7.1)
+
+- [0ab674f8](https://github.com/kubedb/mongodb/commit/0ab674f8) Prepare for release v0.7.1 (#313)
+- [9ef6fd1f](https://github.com/kubedb/mongodb/commit/9ef6fd1f) Update Kubernetes v1.18.9 dependencies (#312)
+- [6a943688](https://github.com/kubedb/mongodb/commit/6a943688) Update KubeDB api (#311)
+- [15cbc825](https://github.com/kubedb/mongodb/commit/15cbc825) Update Kubernetes v1.18.9 dependencies (#310)
+- [92b6f366](https://github.com/kubedb/mongodb/commit/92b6f366) Update KubeDB api (#309)
+- [218a9ff5](https://github.com/kubedb/mongodb/commit/218a9ff5) Update for release Stash@v2020.11.06 (#308)
+- [9f4bade4](https://github.com/kubedb/mongodb/commit/9f4bade4) Update Kubernetes v1.18.9 dependencies (#307)
+- [4e088452](https://github.com/kubedb/mongodb/commit/4e088452) Update KubeDB api (#306)
+- [f06df599](https://github.com/kubedb/mongodb/commit/f06df599) Update KubeDB api (#303)
+- [3b402637](https://github.com/kubedb/mongodb/commit/3b402637) Update for release Stash@v2020.10.30 (#302)
+- [29fb006f](https://github.com/kubedb/mongodb/commit/29fb006f) Update KubeDB api (#301)
+- [dcbd397b](https://github.com/kubedb/mongodb/commit/dcbd397b) Update for release Stash@v2020.10.29 (#300)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.7.1](https://github.com/kubedb/mysql/releases/tag/v0.7.1)
+
+- [e7cd0f88](https://github.com/kubedb/mysql/commit/e7cd0f88) Prepare for release v0.7.1 (#302)
+- [9eac462f](https://github.com/kubedb/mysql/commit/9eac462f) Update Kubernetes v1.18.9 dependencies (#301)
+- [b2e6ecf0](https://github.com/kubedb/mysql/commit/b2e6ecf0) Update KubeDB api (#300)
+- [79fd9699](https://github.com/kubedb/mysql/commit/79fd9699) Update Kubernetes v1.18.9 dependencies (#299)
+- [b5973719](https://github.com/kubedb/mysql/commit/b5973719) Update KubeDB api (#298)
+- [499082d5](https://github.com/kubedb/mysql/commit/499082d5) Update for release Stash@v2020.11.06 (#297)
+- [7528f7a5](https://github.com/kubedb/mysql/commit/7528f7a5) Update Kubernetes v1.18.9 dependencies (#296)
+- [99beba22](https://github.com/kubedb/mysql/commit/99beba22) Update KubeDB api (#294)
+- [ec714efd](https://github.com/kubedb/mysql/commit/ec714efd) Update KubeDB api (#293)
+- [4c0b30a3](https://github.com/kubedb/mysql/commit/4c0b30a3) Update for release Stash@v2020.10.30 (#292)
+- [e307ecb3](https://github.com/kubedb/mysql/commit/e307ecb3) Update KubeDB api (#291)
+- [05c64bd6](https://github.com/kubedb/mysql/commit/05c64bd6) Update for release Stash@v2020.10.29 (#290)
+
+
+
+## [kubedb/mysql-replication-mode-detector](https://github.com/kubedb/mysql-replication-mode-detector)
+
+### [v0.1.1](https://github.com/kubedb/mysql-replication-mode-detector/releases/tag/v0.1.1)
+
+- [deb9723](https://github.com/kubedb/mysql-replication-mode-detector/commit/deb9723) Prepare for release v0.1.1 (#87)
+- [b3d2d53](https://github.com/kubedb/mysql-replication-mode-detector/commit/b3d2d53) Replace appscode/go with gomodules.xyz/x (#82)
+- [4ae0f5e](https://github.com/kubedb/mysql-replication-mode-detector/commit/4ae0f5e) Update KubeDB api (#86)
+- [e65fdbf](https://github.com/kubedb/mysql-replication-mode-detector/commit/e65fdbf) Update Kubernetes v1.18.9 dependencies (#85)
+- [21db0b0](https://github.com/kubedb/mysql-replication-mode-detector/commit/21db0b0) Update KubeDB api (#84)
+- [ca326c2](https://github.com/kubedb/mysql-replication-mode-detector/commit/ca326c2) Update Kubernetes v1.18.9 dependencies (#83)
+- [1387bd2](https://github.com/kubedb/mysql-replication-mode-detector/commit/1387bd2) Update KubeDB api (#81)
+- [4fd3dc6](https://github.com/kubedb/mysql-replication-mode-detector/commit/4fd3dc6) Remove primary role from previous master pod and update query  (#80)
+- [552b9b9](https://github.com/kubedb/mysql-replication-mode-detector/commit/552b9b9) Update KubeDB api (#79)
+- [72c4b51](https://github.com/kubedb/mysql-replication-mode-detector/commit/72c4b51) Update KubeDB api (#78)
+
+
+
+## [kubedb/operator](https://github.com/kubedb/operator)
+
+### [v0.14.1](https://github.com/kubedb/operator/releases/tag/v0.14.1)
+
+- [fb31bcf3](https://github.com/kubedb/operator/commit/fb31bcf3) Prepare for release v0.14.1 (#347)
+- [f9e6e5eb](https://github.com/kubedb/operator/commit/f9e6e5eb) Update Kubernetes v1.18.9 dependencies (#346)
+- [0cd46325](https://github.com/kubedb/operator/commit/0cd46325) Update KubeDB api (#345)
+- [782c00c6](https://github.com/kubedb/operator/commit/782c00c6) Update Kubernetes v1.18.9 dependencies (#344)
+- [33765457](https://github.com/kubedb/operator/commit/33765457) Update KubeDB api (#343)
+- [ff815850](https://github.com/kubedb/operator/commit/ff815850) Update Kubernetes v1.18.9 dependencies (#342)
+- [9e12a91f](https://github.com/kubedb/operator/commit/9e12a91f) Update KubeDB api (#340)
+- [729298df](https://github.com/kubedb/operator/commit/729298df) Update KubeDB api (#339)
+- [ccc55504](https://github.com/kubedb/operator/commit/ccc55504) Update KubeDB api (#338)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.1.1](https://github.com/kubedb/percona-xtradb/releases/tag/v0.1.1)
+
+- [aa216cf5](https://github.com/kubedb/percona-xtradb/commit/aa216cf5) Prepare for release v0.1.1 (#134)
+- [d43b87a3](https://github.com/kubedb/percona-xtradb/commit/d43b87a3) Update Kubernetes v1.18.9 dependencies (#133)
+- [1a354dba](https://github.com/kubedb/percona-xtradb/commit/1a354dba) Update KubeDB api (#132)
+- [808366cc](https://github.com/kubedb/percona-xtradb/commit/808366cc) Update Kubernetes v1.18.9 dependencies (#131)
+- [adb44379](https://github.com/kubedb/percona-xtradb/commit/adb44379) Update KubeDB api (#130)
+- [6d6188de](https://github.com/kubedb/percona-xtradb/commit/6d6188de) Update for release Stash@v2020.11.06 (#129)
+- [8d3eaa37](https://github.com/kubedb/percona-xtradb/commit/8d3eaa37) Update Kubernetes v1.18.9 dependencies (#128)
+- [5f7253b6](https://github.com/kubedb/percona-xtradb/commit/5f7253b6) Update KubeDB api (#126)
+- [43f10d83](https://github.com/kubedb/percona-xtradb/commit/43f10d83) Update KubeDB api (#125)
+- [91940395](https://github.com/kubedb/percona-xtradb/commit/91940395) Update for release Stash@v2020.10.30 (#124)
+- [eba69286](https://github.com/kubedb/percona-xtradb/commit/eba69286) Update KubeDB api (#123)
+- [a4dd87ba](https://github.com/kubedb/percona-xtradb/commit/a4dd87ba) Update for release Stash@v2020.10.29 (#122)
+
+
+
+## [kubedb/pg-leader-election](https://github.com/kubedb/pg-leader-election)
+
+### [v0.2.1](https://github.com/kubedb/pg-leader-election/releases/tag/v0.2.1)
+
+- [bb6b5d6](https://github.com/kubedb/pg-leader-election/commit/bb6b5d6) Update Kubernetes v1.18.9 dependencies (#40)
+- [1291b2f](https://github.com/kubedb/pg-leader-election/commit/1291b2f) Update Kubernetes v1.18.9 dependencies (#39)
+- [41dc2c9](https://github.com/kubedb/pg-leader-election/commit/41dc2c9) Update KubeDB api (#38)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.1.1](https://github.com/kubedb/pgbouncer/releases/tag/v0.1.1)
+
+- [1b646d91](https://github.com/kubedb/pgbouncer/commit/1b646d91) Prepare for release v0.1.1 (#104)
+- [3c48a58e](https://github.com/kubedb/pgbouncer/commit/3c48a58e) Update Kubernetes v1.18.9 dependencies (#103)
+- [906649e4](https://github.com/kubedb/pgbouncer/commit/906649e4) Update KubeDB api (#102)
+- [5b245f73](https://github.com/kubedb/pgbouncer/commit/5b245f73) Update Kubernetes v1.18.9 dependencies (#101)
+- [41f6c693](https://github.com/kubedb/pgbouncer/commit/41f6c693) Update KubeDB api (#100)
+- [63cbbc07](https://github.com/kubedb/pgbouncer/commit/63cbbc07) Update Kubernetes v1.18.9 dependencies (#99)
+- [36a100b6](https://github.com/kubedb/pgbouncer/commit/36a100b6) Update KubeDB api (#97)
+- [dd9beb65](https://github.com/kubedb/pgbouncer/commit/dd9beb65) Update KubeDB api (#96)
+- [2e24a612](https://github.com/kubedb/pgbouncer/commit/2e24a612) Update KubeDB api (#95)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.14.1](https://github.com/kubedb/postgres/releases/tag/v0.14.1)
+
+- [0482db11](https://github.com/kubedb/postgres/commit/0482db11) Prepare for release v0.14.1 (#420)
+- [ac8eeb4b](https://github.com/kubedb/postgres/commit/ac8eeb4b) Update Kubernetes v1.18.9 dependencies (#419)
+- [9fdb427e](https://github.com/kubedb/postgres/commit/9fdb427e) Update KubeDB api (#418)
+- [fbed9716](https://github.com/kubedb/postgres/commit/fbed9716) Update Kubernetes v1.18.9 dependencies (#417)
+- [a0a639c0](https://github.com/kubedb/postgres/commit/a0a639c0) Update KubeDB api (#416)
+- [c6a6416a](https://github.com/kubedb/postgres/commit/c6a6416a) Update for release Stash@v2020.11.06 (#415)
+- [0f5ad475](https://github.com/kubedb/postgres/commit/0f5ad475) Update Kubernetes v1.18.9 dependencies (#414)
+- [7db04cdd](https://github.com/kubedb/postgres/commit/7db04cdd) Update KubeDB api (#412)
+- [3ce64913](https://github.com/kubedb/postgres/commit/3ce64913) Update KubeDB api (#411)
+- [12cf4b77](https://github.com/kubedb/postgres/commit/12cf4b77) Update for release Stash@v2020.10.30 (#410)
+- [f319590f](https://github.com/kubedb/postgres/commit/f319590f) Update KubeDB api (#409)
+- [6bd61adf](https://github.com/kubedb/postgres/commit/6bd61adf) Update for release Stash@v2020.10.29 (#408)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.1.1](https://github.com/kubedb/proxysql/releases/tag/v0.1.1)
+
+- [a196a5bf](https://github.com/kubedb/proxysql/commit/a196a5bf) Prepare for release v0.1.1 (#116)
+- [eaba8cd8](https://github.com/kubedb/proxysql/commit/eaba8cd8) Update Kubernetes v1.18.9 dependencies (#115)
+- [c6042baf](https://github.com/kubedb/proxysql/commit/c6042baf) Update KubeDB api (#114)
+- [4ad769e3](https://github.com/kubedb/proxysql/commit/4ad769e3) Update Kubernetes v1.18.9 dependencies (#113)
+- [f57b4971](https://github.com/kubedb/proxysql/commit/f57b4971) Update KubeDB api (#112)
+- [b44e67be](https://github.com/kubedb/proxysql/commit/b44e67be) Update for release Stash@v2020.11.06 (#111)
+- [f3f33efa](https://github.com/kubedb/proxysql/commit/f3f33efa) Update Kubernetes v1.18.9 dependencies (#110)
+- [dff77ecf](https://github.com/kubedb/proxysql/commit/dff77ecf) Update KubeDB api (#108)
+- [7cbcfeee](https://github.com/kubedb/proxysql/commit/7cbcfeee) Update KubeDB api (#107)
+- [49099b45](https://github.com/kubedb/proxysql/commit/49099b45) Update for release Stash@v2020.10.30 (#106)
+- [4b337417](https://github.com/kubedb/proxysql/commit/4b337417) Update KubeDB api (#105)
+- [cebf6eee](https://github.com/kubedb/proxysql/commit/cebf6eee) Update for release Stash@v2020.10.29 (#104)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.7.1](https://github.com/kubedb/redis/releases/tag/v0.7.1)
+
+- [5827be9a](https://github.com/kubedb/redis/commit/5827be9a) Prepare for release v0.7.1 (#258)
+- [893f4573](https://github.com/kubedb/redis/commit/893f4573) Update Kubernetes v1.18.9 dependencies (#257)
+- [1f3ba044](https://github.com/kubedb/redis/commit/1f3ba044) Update KubeDB api (#256)
+- [b824d122](https://github.com/kubedb/redis/commit/b824d122) Update Kubernetes v1.18.9 dependencies (#255)
+- [5783c135](https://github.com/kubedb/redis/commit/5783c135) Update KubeDB api (#254)
+- [dc7e3986](https://github.com/kubedb/redis/commit/dc7e3986) Update Kubernetes v1.18.9 dependencies (#253)
+- [83acb92a](https://github.com/kubedb/redis/commit/83acb92a) Update KubeDB api (#252)
+- [ee967c20](https://github.com/kubedb/redis/commit/ee967c20) Update KubeDB api (#251)
+- [9706ea8e](https://github.com/kubedb/redis/commit/9706ea8e) Update KubeDB api (#249)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.11.08
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/22
Signed-off-by: 1gtm <1gtm@appscode.com>