### PR TITLE
Prepare for release v2020.11.12

### DIFF
--- a/docs/CHANGELOG-v2020.11.12.md
+++ b/docs/CHANGELOG-v2020.11.12.md
@@ -1,0 +1,165 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2020.11.12
+    name: Changelog-v2020.11.12
+    parent: welcome
+    weight: 20201112
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.11.12/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.11.12/
+---
+
+# KubeDB v2020.11.12 (2020-11-12)
+
+
+## [appscode/kubedb-enterprise](https://github.com/appscode/kubedb-enterprise)
+
+### [v0.2.1](https://github.com/appscode/kubedb-enterprise/releases/tag/v0.2.1)
+
+- [9aa1860e](https://github.com/appscode/kubedb-enterprise/commit/9aa1860e) Prepare for release v0.2.1 (#97)
+
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.15.1](https://github.com/kubedb/apimachinery/releases/tag/v0.15.1)
+
+- [ea20944b](https://github.com/kubedb/apimachinery/commit/ea20944b) Set default resource requests = 1/2 * limits (#653)
+- [fb8a454c](https://github.com/kubedb/apimachinery/commit/fb8a454c) Fix serviceTemplate inline json (#652)
+- [44d1f43b](https://github.com/kubedb/apimachinery/commit/44d1f43b) Add MariaDB patch util
+- [cb21bb09](https://github.com/kubedb/apimachinery/commit/cb21bb09) Add MariaDB constants (#651)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.15.1](https://github.com/kubedb/cli/releases/tag/v0.15.1)
+
+- [81e8fb7a](https://github.com/kubedb/cli/commit/81e8fb7a) Prepare for release v0.15.1 (#551)
+- [7152cf5d](https://github.com/kubedb/cli/commit/7152cf5d) Update KubeDB api (#550)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.15.1](https://github.com/kubedb/elasticsearch/releases/tag/v0.15.1)
+
+- [27111d23](https://github.com/kubedb/elasticsearch/commit/27111d23) Prepare for release v0.15.1 (#416)
+- [f23b33ee](https://github.com/kubedb/elasticsearch/commit/f23b33ee) Update KubeDB api (#415)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v0.15.1](https://github.com/kubedb/installer/releases/tag/v0.15.1)
+
+- [4129755](https://github.com/kubedb/installer/commit/4129755) Prepare for release v0.15.1 (#205)
+- [26dbe8e](https://github.com/kubedb/installer/commit/26dbe8e) Update NOTE.txt with helm 3 command (#203)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.8.1](https://github.com/kubedb/memcached/releases/tag/v0.8.1)
+
+- [00eda07f](https://github.com/kubedb/memcached/commit/00eda07f) Prepare for release v0.8.1 (#245)
+- [a32f158d](https://github.com/kubedb/memcached/commit/a32f158d) Update KubeDB api (#244)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.8.1](https://github.com/kubedb/mongodb/releases/tag/v0.8.1)
+
+- [19f17fb9](https://github.com/kubedb/mongodb/commit/19f17fb9) Prepare for release v0.8.1 (#320)
+- [bee38ded](https://github.com/kubedb/mongodb/commit/bee38ded) Update KubeDB api (#319)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.8.1](https://github.com/kubedb/mysql/releases/tag/v0.8.1)
+
+- [8a41db5d](https://github.com/kubedb/mysql/commit/8a41db5d) Prepare for release v0.8.1 (#307)
+- [e224e887](https://github.com/kubedb/mysql/commit/e224e887) Update KubeDB api (#306)
+
+
+
+## [kubedb/operator](https://github.com/kubedb/operator)
+
+### [v0.15.1](https://github.com/kubedb/operator/releases/tag/v0.15.1)
+
+- [bed5f88c](https://github.com/kubedb/operator/commit/bed5f88c) Prepare for release v0.15.1 (#351)
+- [4ee7d2fb](https://github.com/kubedb/operator/commit/4ee7d2fb) Update KubeDB api (#350)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.2.1](https://github.com/kubedb/percona-xtradb/releases/tag/v0.2.1)
+
+- [6e13a0a0](https://github.com/kubedb/percona-xtradb/commit/6e13a0a0) Prepare for release v0.2.1 (#140)
+- [7afb8aee](https://github.com/kubedb/percona-xtradb/commit/7afb8aee) Update KubeDB api (#139)
+
+
+
+## [kubedb/pg-leader-election](https://github.com/kubedb/pg-leader-election)
+
+### [v0.3.1](https://github.com/kubedb/pg-leader-election/releases/tag/v0.3.1)
+
+- [2bc569c](https://github.com/kubedb/pg-leader-election/commit/2bc569c) Update README.md
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.2.1](https://github.com/kubedb/pgbouncer/releases/tag/v0.2.1)
+
+- [c04b66ab](https://github.com/kubedb/pgbouncer/commit/c04b66ab) Prepare for release v0.2.1 (#110)
+- [082be68e](https://github.com/kubedb/pgbouncer/commit/082be68e) Update KubeDB api (#109)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.15.1](https://github.com/kubedb/postgres/releases/tag/v0.15.1)
+
+- [c83549ae](https://github.com/kubedb/postgres/commit/c83549ae) Prepare for release v0.15.1 (#426)
+- [cbb19a1c](https://github.com/kubedb/postgres/commit/cbb19a1c) Update KubeDB api (#425)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.2.1](https://github.com/kubedb/proxysql/releases/tag/v0.2.1)
+
+- [2c20cd82](https://github.com/kubedb/proxysql/commit/2c20cd82) Prepare for release v0.2.1 (#122)
+- [6b268324](https://github.com/kubedb/proxysql/commit/6b268324) Update KubeDB api (#121)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.8.1](https://github.com/kubedb/redis/releases/tag/v0.8.1)
+
+- [5d378ec3](https://github.com/kubedb/redis/commit/5d378ec3) Prepare for release v0.8.1 (#264)
+- [b7cf4380](https://github.com/kubedb/redis/commit/b7cf4380) Update KubeDB api (#263)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.2.1](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.2.1)
+
+- [8c0e92f](https://github.com/kubedb/replication-mode-detector/commit/8c0e92f) Prepare for release v0.2.1 (#94)
+- [b0bf4e9](https://github.com/kubedb/replication-mode-detector/commit/b0bf4e9) Update KubeDB api (#93)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.11.12
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/24
Signed-off-by: 1gtm <1gtm@appscode.com>