### PR TITLE
Prepare for release v2020.12.10

### DIFF
--- a/docs/CHANGELOG-v2020.12.10.md
+++ b/docs/CHANGELOG-v2020.12.10.md
@@ -1,0 +1,318 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2020.12.10
+    name: Changelog-v2020.12.10
+    parent: welcome
+    weight: 20201210
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.12.10/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.12.10/
+---
+
+# KubeDB v2020.12.10 (2020-12-10)
+
+
+## [appscode/kubedb-enterprise](https://github.com/appscode/kubedb-enterprise)
+
+### [v0.2.2](https://github.com/appscode/kubedb-enterprise/releases/tag/v0.2.2)
+
+- [ade073c7](https://github.com/appscode/kubedb-enterprise/commit/ade073c7) Prepare for release v0.2.2 (#103)
+- [ed4b88de](https://github.com/appscode/kubedb-enterprise/commit/ed4b88de) Format shell scripts (#99)
+- [c792b1aa](https://github.com/appscode/kubedb-enterprise/commit/c792b1aa) Update CI
+
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.15.2](https://github.com/kubedb/apimachinery/releases/tag/v0.15.2)
+
+- [e0b8f4fa](https://github.com/kubedb/apimachinery/commit/e0b8f4fa) Use same request and limits for databases (#668)
+- [429b2e10](https://github.com/kubedb/apimachinery/commit/429b2e10) Update Kubernetes v1.18.9 dependencies (#667)
+- [0e4574eb](https://github.com/kubedb/apimachinery/commit/0e4574eb) Add Elasticsearch helper methods for StatefulSet names (#665)
+- [5917f095](https://github.com/kubedb/apimachinery/commit/5917f095) Update default resource limits and requests for MySQL (#664)
+- [89b09825](https://github.com/kubedb/apimachinery/commit/89b09825) Update Kubernetes v1.18.9 dependencies (#661)
+- [a022a502](https://github.com/kubedb/apimachinery/commit/a022a502) Format shell scripts (#660)
+- [03a5a9a7](https://github.com/kubedb/apimachinery/commit/03a5a9a7) Update for release Stash@v2020.11.17 (#656)
+- [94392a27](https://github.com/kubedb/apimachinery/commit/94392a27) Set default resource limits for Elasticsearch (#655)
+- [b2fb44c8](https://github.com/kubedb/apimachinery/commit/b2fb44c8) Add requireSSL field to MySQLOpsRequest (#654)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.15.2](https://github.com/kubedb/cli/releases/tag/v0.15.2)
+
+- [d436f0de](https://github.com/kubedb/cli/commit/d436f0de) Prepare for release v0.15.2 (#564)
+- [8eaff25c](https://github.com/kubedb/cli/commit/8eaff25c) Fix nil pointer panic (#563)
+- [1ec791eb](https://github.com/kubedb/cli/commit/1ec791eb) Update KubeDB api (#562)
+- [aa54326a](https://github.com/kubedb/cli/commit/aa54326a) Update Kubernetes v1.18.9 dependencies (#561)
+- [0dc1847a](https://github.com/kubedb/cli/commit/0dc1847a) Update KubeDB api (#560)
+- [dbe633dc](https://github.com/kubedb/cli/commit/dbe633dc) Update KubeDB api (#559)
+- [82f6be65](https://github.com/kubedb/cli/commit/82f6be65) Update KubeDB api (#558)
+- [251eb867](https://github.com/kubedb/cli/commit/251eb867) Update Kubernetes v1.18.9 dependencies (#557)
+- [870efaec](https://github.com/kubedb/cli/commit/870efaec) Update KubeDB api (#556)
+- [20503198](https://github.com/kubedb/cli/commit/20503198) Format shell scripts (#555)
+- [446734ba](https://github.com/kubedb/cli/commit/446734ba) Update KubeDB api (#554)
+- [eb1648f0](https://github.com/kubedb/cli/commit/eb1648f0) Update for release Stash@v2020.11.17 (#553)
+- [2e8667da](https://github.com/kubedb/cli/commit/2e8667da) Update KubeDB api (#552)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.15.2](https://github.com/kubedb/elasticsearch/releases/tag/v0.15.2)
+
+- [12af2fe4](https://github.com/kubedb/elasticsearch/commit/12af2fe4) Prepare for release v0.15.2 (#434)
+- [ade7c7e3](https://github.com/kubedb/elasticsearch/commit/ade7c7e3) Update KubeDB api (#433)
+- [f9290a40](https://github.com/kubedb/elasticsearch/commit/f9290a40) Update Kubernetes v1.18.9 dependencies (#432)
+- [3fe4723d](https://github.com/kubedb/elasticsearch/commit/3fe4723d) Update KubeDB api (#431)
+- [07a09623](https://github.com/kubedb/elasticsearch/commit/07a09623) Add validation for minimum memory request (heap size) (#429)
+- [0132b8cd](https://github.com/kubedb/elasticsearch/commit/0132b8cd) Remove resource allocation from init container (#427)
+- [9fdef46d](https://github.com/kubedb/elasticsearch/commit/9fdef46d) Update KubeDB api (#428)
+- [166cbc51](https://github.com/kubedb/elasticsearch/commit/166cbc51) Update KubeDB api (#426)
+- [3a4f29b8](https://github.com/kubedb/elasticsearch/commit/3a4f29b8) Update Kubernetes v1.18.9 dependencies (#425)
+- [9ed6e723](https://github.com/kubedb/elasticsearch/commit/9ed6e723) Fix health checker (#417)
+- [28314536](https://github.com/kubedb/elasticsearch/commit/28314536) Update e2e workflow (#424)
+- [bd961e58](https://github.com/kubedb/elasticsearch/commit/bd961e58) Update KubeDB api (#423)
+- [450df760](https://github.com/kubedb/elasticsearch/commit/450df760) Format shell scripts (#422)
+- [ad67a75e](https://github.com/kubedb/elasticsearch/commit/ad67a75e) Update KubeDB api (#421)
+- [353f2031](https://github.com/kubedb/elasticsearch/commit/353f2031) Update for release Stash@v2020.11.17 (#420)
+- [999b1e0d](https://github.com/kubedb/elasticsearch/commit/999b1e0d) Update KubeDB api (#419)
+- [73d6618c](https://github.com/kubedb/elasticsearch/commit/73d6618c) Update repository config (#418)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v0.15.2](https://github.com/kubedb/installer/releases/tag/v0.15.2)
+
+- [2da95dc](https://github.com/kubedb/installer/commit/2da95dc) Prepare for release v0.15.2 (#211)
+- [b6b0d98](https://github.com/kubedb/installer/commit/b6b0d98) Update repository config (#210)
+- [d560f29](https://github.com/kubedb/installer/commit/d560f29) Update Kubernetes v1.18.9 dependencies (#209)
+- [8e061ed](https://github.com/kubedb/installer/commit/8e061ed) Use apiregistration.k8s.io/v1 (#207)
+- [842e577](https://github.com/kubedb/installer/commit/842e577) Update repository config (#206)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.8.2](https://github.com/kubedb/memcached/releases/tag/v0.8.2)
+
+- [2f458585](https://github.com/kubedb/memcached/commit/2f458585) Prepare for release v0.8.2 (#258)
+- [0c16e3fa](https://github.com/kubedb/memcached/commit/0c16e3fa) Update KubeDB api (#257)
+- [2601e91b](https://github.com/kubedb/memcached/commit/2601e91b) Update Kubernetes v1.18.9 dependencies (#256)
+- [fa1b08b7](https://github.com/kubedb/memcached/commit/fa1b08b7) Update KubeDB api (#255)
+- [61395e02](https://github.com/kubedb/memcached/commit/61395e02) Update KubeDB api (#254)
+- [7ea6ec8e](https://github.com/kubedb/memcached/commit/7ea6ec8e) Update KubeDB api (#253)
+- [005f33c1](https://github.com/kubedb/memcached/commit/005f33c1) Update Kubernetes v1.18.9 dependencies (#252)
+- [a4bc28bd](https://github.com/kubedb/memcached/commit/a4bc28bd) Update e2e workflow (#251)
+- [11286227](https://github.com/kubedb/memcached/commit/11286227) Update KubeDB api (#250)
+- [c6a704fe](https://github.com/kubedb/memcached/commit/c6a704fe) Format shell scripts (#249)
+- [c88fd651](https://github.com/kubedb/memcached/commit/c88fd651) Update KubeDB api (#248)
+- [df511335](https://github.com/kubedb/memcached/commit/df511335) Update KubeDB api (#247)
+- [991933af](https://github.com/kubedb/memcached/commit/991933af) Update repository config (#246)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.8.2](https://github.com/kubedb/mongodb/releases/tag/v0.8.2)
+
+- [63ec5d5f](https://github.com/kubedb/mongodb/commit/63ec5d5f) Prepare for release v0.8.2 (#334)
+- [b26e3b38](https://github.com/kubedb/mongodb/commit/b26e3b38) Update KubeDB api (#333)
+- [e7b60f5d](https://github.com/kubedb/mongodb/commit/e7b60f5d) Update Kubernetes v1.18.9 dependencies (#332)
+- [c492a1e6](https://github.com/kubedb/mongodb/commit/c492a1e6) Update KubeDB api (#331)
+- [4ca053a1](https://github.com/kubedb/mongodb/commit/4ca053a1) Update KubeDB api (#330)
+- [40224cad](https://github.com/kubedb/mongodb/commit/40224cad) Update KubeDB api (#329)
+- [a54933b8](https://github.com/kubedb/mongodb/commit/a54933b8) Update Kubernetes v1.18.9 dependencies (#328)
+- [ab77019b](https://github.com/kubedb/mongodb/commit/ab77019b) Wait until crd names are accepted
+- [9cc7c869](https://github.com/kubedb/mongodb/commit/9cc7c869) Prevent a specific failing matrix job from failing a workflow run
+- [fb8491d7](https://github.com/kubedb/mongodb/commit/fb8491d7) Update e2e workflow (#325)
+- [abf1ae72](https://github.com/kubedb/mongodb/commit/abf1ae72) Update KubeDB api (#327)
+- [b138bc3d](https://github.com/kubedb/mongodb/commit/b138bc3d) Format shell scripts (#326)
+- [f1c913c6](https://github.com/kubedb/mongodb/commit/f1c913c6) Update e2e CI
+- [3b5d2e5c](https://github.com/kubedb/mongodb/commit/3b5d2e5c) Update github actions for e2e tests (#304)
+- [c49e535a](https://github.com/kubedb/mongodb/commit/c49e535a) Update KubeDB api (#324)
+- [f3c138e1](https://github.com/kubedb/mongodb/commit/f3c138e1) Update for release Stash@v2020.11.17 (#323)
+- [d4e18d81](https://github.com/kubedb/mongodb/commit/d4e18d81) Update KubeDB api (#322)
+- [9e8fc523](https://github.com/kubedb/mongodb/commit/9e8fc523) Update repository config (#321)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.8.2](https://github.com/kubedb/mysql/releases/tag/v0.8.2)
+
+- [d3b3f9c3](https://github.com/kubedb/mysql/commit/d3b3f9c3) Prepare for release v0.8.2 (#321)
+- [a6564cc1](https://github.com/kubedb/mysql/commit/a6564cc1) Update KubeDB api (#320)
+- [2e0fe5f9](https://github.com/kubedb/mysql/commit/2e0fe5f9) Update Kubernetes v1.18.9 dependencies (#319)
+- [a6731a86](https://github.com/kubedb/mysql/commit/a6731a86) Update KubeDB api (#318)
+- [2fb04f16](https://github.com/kubedb/mysql/commit/2fb04f16) Update KubeDB api (#317)
+- [3432a00a](https://github.com/kubedb/mysql/commit/3432a00a) Update KubeDB api (#316)
+- [5f51a466](https://github.com/kubedb/mysql/commit/5f51a466) Update Kubernetes v1.18.9 dependencies (#315)
+- [b0dbbac4](https://github.com/kubedb/mysql/commit/b0dbbac4) Update e2e workflow (#314)
+- [a0864e5d](https://github.com/kubedb/mysql/commit/a0864e5d) Update KubeDB api (#313)
+- [cc80a56f](https://github.com/kubedb/mysql/commit/cc80a56f) Format shell scripts (#312)
+- [3ac83778](https://github.com/kubedb/mysql/commit/3ac83778) Update KubeDB api (#311)
+- [d87bc74a](https://github.com/kubedb/mysql/commit/d87bc74a) Update for release Stash@v2020.11.17 (#310)
+- [353d6795](https://github.com/kubedb/mysql/commit/353d6795) Update KubeDB api (#309)
+- [8b9b7009](https://github.com/kubedb/mysql/commit/8b9b7009) Update repository config (#308)
+
+
+
+## [kubedb/operator](https://github.com/kubedb/operator)
+
+### [v0.15.2](https://github.com/kubedb/operator/releases/tag/v0.15.2)
+
+- [06945cc9](https://github.com/kubedb/operator/commit/06945cc9) Prepare for release v0.15.2 (#365)
+- [6a3dacd4](https://github.com/kubedb/operator/commit/6a3dacd4) Update KubeDB api (#364)
+- [6a0626b1](https://github.com/kubedb/operator/commit/6a0626b1) Update Kubernetes v1.18.9 dependencies (#363)
+- [e72fbf89](https://github.com/kubedb/operator/commit/e72fbf89) Update KubeDB api (#362)
+- [a27078cd](https://github.com/kubedb/operator/commit/a27078cd) Update KubeDB api (#361)
+- [5547a0bd](https://github.com/kubedb/operator/commit/5547a0bd) Update KubeDB api (#360)
+- [53225795](https://github.com/kubedb/operator/commit/53225795) Update Kubernetes v1.18.9 dependencies (#359)
+- [d9ba1ba9](https://github.com/kubedb/operator/commit/d9ba1ba9) Update e2e workflow (#358)
+- [68171e01](https://github.com/kubedb/operator/commit/68171e01) Update KubeDB api (#357)
+- [6411ccdb](https://github.com/kubedb/operator/commit/6411ccdb) Format shell scripts (#356)
+- [b666a8d2](https://github.com/kubedb/operator/commit/b666a8d2) Update KubeDB api (#355)
+- [5b280e2b](https://github.com/kubedb/operator/commit/5b280e2b) Update KubeDB api (#354)
+- [3732fe26](https://github.com/kubedb/operator/commit/3732fe26) Update repository config (#353)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.2.2](https://github.com/kubedb/percona-xtradb/releases/tag/v0.2.2)
+
+- [354ec7a7](https://github.com/kubedb/percona-xtradb/commit/354ec7a7) Prepare for release v0.2.2 (#154)
+- [927cb07d](https://github.com/kubedb/percona-xtradb/commit/927cb07d) Update KubeDB api (#153)
+- [28463a62](https://github.com/kubedb/percona-xtradb/commit/28463a62) Update Kubernetes v1.18.9 dependencies (#152)
+- [a7e8e78a](https://github.com/kubedb/percona-xtradb/commit/a7e8e78a) Update KubeDB api (#151)
+- [fdcb3a74](https://github.com/kubedb/percona-xtradb/commit/fdcb3a74) Update KubeDB api (#150)
+- [18b128e1](https://github.com/kubedb/percona-xtradb/commit/18b128e1) Update KubeDB api (#149)
+- [15d0c5e3](https://github.com/kubedb/percona-xtradb/commit/15d0c5e3) Update Kubernetes v1.18.9 dependencies (#148)
+- [e953b6c1](https://github.com/kubedb/percona-xtradb/commit/e953b6c1) Update e2e workflow (#147)
+- [85d96fe5](https://github.com/kubedb/percona-xtradb/commit/85d96fe5) Update KubeDB api (#146)
+- [1f02228b](https://github.com/kubedb/percona-xtradb/commit/1f02228b) Format shell scripts (#145)
+- [a832a4c1](https://github.com/kubedb/percona-xtradb/commit/a832a4c1) Update KubeDB api (#144)
+- [ec085e9a](https://github.com/kubedb/percona-xtradb/commit/ec085e9a) Update for release Stash@v2020.11.17 (#143)
+- [4b22cc6c](https://github.com/kubedb/percona-xtradb/commit/4b22cc6c) Update KubeDB api (#142)
+- [70a0c092](https://github.com/kubedb/percona-xtradb/commit/70a0c092) Update repository config (#141)
+
+
+
+## [kubedb/pg-leader-election](https://github.com/kubedb/pg-leader-election)
+
+### [v0.3.2](https://github.com/kubedb/pg-leader-election/releases/tag/v0.3.2)
+
+- [e5413e4](https://github.com/kubedb/pg-leader-election/commit/e5413e4) Update Kubernetes v1.18.9 dependencies (#42)
+- [aff7ccb](https://github.com/kubedb/pg-leader-election/commit/aff7ccb) Update Kubernetes v1.18.9 dependencies (#41)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.2.2](https://github.com/kubedb/pgbouncer/releases/tag/v0.2.2)
+
+- [390e35d5](https://github.com/kubedb/pgbouncer/commit/390e35d5) Prepare for release v0.2.2 (#123)
+- [0629a632](https://github.com/kubedb/pgbouncer/commit/0629a632) Update KubeDB api (#122)
+- [452bbff4](https://github.com/kubedb/pgbouncer/commit/452bbff4) Update Kubernetes v1.18.9 dependencies (#121)
+- [8f9f8691](https://github.com/kubedb/pgbouncer/commit/8f9f8691) Update KubeDB api (#120)
+- [10016a15](https://github.com/kubedb/pgbouncer/commit/10016a15) Update KubeDB api (#119)
+- [301da718](https://github.com/kubedb/pgbouncer/commit/301da718) Update KubeDB api (#118)
+- [cfdcb3ae](https://github.com/kubedb/pgbouncer/commit/cfdcb3ae) Update Kubernetes v1.18.9 dependencies (#117)
+- [ba4f9abf](https://github.com/kubedb/pgbouncer/commit/ba4f9abf) Update e2e workflow (#116)
+- [6b6fa1ce](https://github.com/kubedb/pgbouncer/commit/6b6fa1ce) Update KubeDB api (#115)
+- [644264ce](https://github.com/kubedb/pgbouncer/commit/644264ce) Format shell scripts (#114)
+- [300b8885](https://github.com/kubedb/pgbouncer/commit/300b8885) Update KubeDB api (#113)
+- [74f43dd6](https://github.com/kubedb/pgbouncer/commit/74f43dd6) Update KubeDB api (#112)
+- [762c0c39](https://github.com/kubedb/pgbouncer/commit/762c0c39) Update repository config (#111)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.15.2](https://github.com/kubedb/postgres/releases/tag/v0.15.2)
+
+- [4dbc020f](https://github.com/kubedb/postgres/commit/4dbc020f) Prepare for release v0.15.2 (#440)
+- [2e498528](https://github.com/kubedb/postgres/commit/2e498528) Update KubeDB api (#439)
+- [d1a36ba5](https://github.com/kubedb/postgres/commit/d1a36ba5) Update Kubernetes v1.18.9 dependencies (#438)
+- [5e992258](https://github.com/kubedb/postgres/commit/5e992258) Update KubeDB api (#437)
+- [3e690087](https://github.com/kubedb/postgres/commit/3e690087) Update KubeDB api (#436)
+- [c6b5cdea](https://github.com/kubedb/postgres/commit/c6b5cdea) Update KubeDB api (#435)
+- [a580560c](https://github.com/kubedb/postgres/commit/a580560c) Update Kubernetes v1.18.9 dependencies (#434)
+- [baba93f2](https://github.com/kubedb/postgres/commit/baba93f2) Update e2e workflow (#433)
+- [87ccb1df](https://github.com/kubedb/postgres/commit/87ccb1df) Update KubeDB api (#432)
+- [56cd9e3a](https://github.com/kubedb/postgres/commit/56cd9e3a) Format shell scripts (#431)
+- [9f042958](https://github.com/kubedb/postgres/commit/9f042958) Update KubeDB api (#430)
+- [a922ba6f](https://github.com/kubedb/postgres/commit/a922ba6f) Update for release Stash@v2020.11.17 (#429)
+- [8de84f76](https://github.com/kubedb/postgres/commit/8de84f76) Update KubeDB api (#428)
+- [5971da91](https://github.com/kubedb/postgres/commit/5971da91) Update repository config (#427)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.2.2](https://github.com/kubedb/proxysql/releases/tag/v0.2.2)
+
+- [f0491c46](https://github.com/kubedb/proxysql/commit/f0491c46) Prepare for release v0.2.2 (#136)
+- [cf45d773](https://github.com/kubedb/proxysql/commit/cf45d773) Update KubeDB api (#135)
+- [fdf01a09](https://github.com/kubedb/proxysql/commit/fdf01a09) Update Kubernetes v1.18.9 dependencies (#134)
+- [e47042b6](https://github.com/kubedb/proxysql/commit/e47042b6) Update KubeDB api (#133)
+- [29fde3f7](https://github.com/kubedb/proxysql/commit/29fde3f7) Update KubeDB api (#132)
+- [af7aba87](https://github.com/kubedb/proxysql/commit/af7aba87) Update KubeDB api (#131)
+- [f9f8dcd3](https://github.com/kubedb/proxysql/commit/f9f8dcd3) Update Kubernetes v1.18.9 dependencies (#130)
+- [6e7b1226](https://github.com/kubedb/proxysql/commit/6e7b1226) Update e2e workflow (#129)
+- [00839667](https://github.com/kubedb/proxysql/commit/00839667) Update KubeDB api (#128)
+- [f05cfd4b](https://github.com/kubedb/proxysql/commit/f05cfd4b) Format shell scripts (#127)
+- [5b349d7e](https://github.com/kubedb/proxysql/commit/5b349d7e) Update KubeDB api (#126)
+- [6ae465b8](https://github.com/kubedb/proxysql/commit/6ae465b8) Update for release Stash@v2020.11.17 (#125)
+- [d0b8b205](https://github.com/kubedb/proxysql/commit/d0b8b205) Update KubeDB api (#124)
+- [9230e1f6](https://github.com/kubedb/proxysql/commit/9230e1f6) Update repository config (#123)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.8.2](https://github.com/kubedb/redis/releases/tag/v0.8.2)
+
+- [fdf40740](https://github.com/kubedb/redis/commit/fdf40740) Prepare for release v0.8.2 (#277)
+- [0aa17291](https://github.com/kubedb/redis/commit/0aa17291) Update KubeDB api (#276)
+- [35a9ba9b](https://github.com/kubedb/redis/commit/35a9ba9b) Update Kubernetes v1.18.9 dependencies (#275)
+- [effea60f](https://github.com/kubedb/redis/commit/effea60f) Update KubeDB api (#274)
+- [fd043549](https://github.com/kubedb/redis/commit/fd043549) Update KubeDB api (#273)
+- [2406649f](https://github.com/kubedb/redis/commit/2406649f) Update KubeDB api (#272)
+- [33185a6a](https://github.com/kubedb/redis/commit/33185a6a) Update Kubernetes v1.18.9 dependencies (#271)
+- [0472eb34](https://github.com/kubedb/redis/commit/0472eb34) Update e2e workflow (#270)
+- [42799a81](https://github.com/kubedb/redis/commit/42799a81) Update KubeDB api (#269)
+- [46fdd08f](https://github.com/kubedb/redis/commit/46fdd08f) Format shell scripts (#268)
+- [da81ecdf](https://github.com/kubedb/redis/commit/da81ecdf) Update KubeDB api (#267)
+- [dd157e35](https://github.com/kubedb/redis/commit/dd157e35) Update KubeDB api (#266)
+- [effd3fc2](https://github.com/kubedb/redis/commit/effd3fc2) Update repository config (#265)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.2.2](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.2.2)
+
+- [e2cb2bf](https://github.com/kubedb/replication-mode-detector/commit/e2cb2bf) Prepare for release v0.2.2 (#104)
+- [973442a](https://github.com/kubedb/replication-mode-detector/commit/973442a) Update KubeDB api (#103)
+- [8758ccf](https://github.com/kubedb/replication-mode-detector/commit/8758ccf) Update Kubernetes v1.18.9 dependencies (#102)
+- [21be65b](https://github.com/kubedb/replication-mode-detector/commit/21be65b) Update KubeDB api (#101)
+- [3c87bcb](https://github.com/kubedb/replication-mode-detector/commit/3c87bcb) Update KubeDB api (#100)
+- [a6bbd6b](https://github.com/kubedb/replication-mode-detector/commit/a6bbd6b) Update KubeDB api (#99)
+- [dedab95](https://github.com/kubedb/replication-mode-detector/commit/dedab95) Update Kubernetes v1.18.9 dependencies (#98)
+- [3c884d7](https://github.com/kubedb/replication-mode-detector/commit/3c884d7) Update KubeDB api (#97)
+- [5c96baa](https://github.com/kubedb/replication-mode-detector/commit/5c96baa) Update KubeDB api (#96)
+- [aef3623](https://github.com/kubedb/replication-mode-detector/commit/aef3623) Update KubeDB api (#95)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.12.10
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/26
Signed-off-by: 1gtm <1gtm@appscode.com>