### PR TITLE
Prepare for release v2021.01.15

### DIFF
--- a/docs/CHANGELOG-v2021.01.15.md
+++ b/docs/CHANGELOG-v2021.01.15.md
@@ -1,0 +1,168 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2021.01.15
+    name: Changelog-v2021.01.15
+    parent: welcome
+    weight: 20210115
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.01.15/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.01.15/
+---
+
+# KubeDB v2021.01.15 (2021-01-15)
+
+
+## [appscode/kubedb-autoscaler](https://github.com/appscode/kubedb-autoscaler)
+
+### [v0.1.1](https://github.com/appscode/kubedb-autoscaler/releases/tag/v0.1.1)
+
+- [844b159](https://github.com/appscode/kubedb-autoscaler/commit/844b159) Prepare for release v0.1.1 (#10)
+
+
+
+## [appscode/kubedb-enterprise](https://github.com/appscode/kubedb-enterprise)
+
+### [v0.3.1](https://github.com/appscode/kubedb-enterprise/releases/tag/v0.3.1)
+
+- [48e08e31](https://github.com/appscode/kubedb-enterprise/commit/48e08e31) Prepare for release v0.3.1 (#122)
+- [be921811](https://github.com/appscode/kubedb-enterprise/commit/be921811) Update Elasticsearch Vertical Scaling (#120)
+- [85ad0e77](https://github.com/appscode/kubedb-enterprise/commit/85ad0e77) Fix mongodb config directory name constants (#121)
+
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.16.1](https://github.com/kubedb/apimachinery/releases/tag/v0.16.1)
+
+- [ef0b4ef2](https://github.com/kubedb/apimachinery/commit/ef0b4ef2) Fix mongodb config directory name constants (#687)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.16.1](https://github.com/kubedb/cli/releases/tag/v0.16.1)
+
+- [8576b8cf](https://github.com/kubedb/cli/commit/8576b8cf) Prepare for release v0.16.1 (#579)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.16.1](https://github.com/kubedb/elasticsearch/releases/tag/v0.16.1)
+
+- [90ef17eb](https://github.com/kubedb/elasticsearch/commit/90ef17eb) Prepare for release v0.16.1 (#457)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v0.16.1](https://github.com/kubedb/installer/releases/tag/v0.16.1)
+
+- [f870039](https://github.com/kubedb/installer/commit/f870039) Prepare for release v0.16.1 (#225)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.9.1](https://github.com/kubedb/memcached/releases/tag/v0.9.1)
+
+- [f066d0f3](https://github.com/kubedb/memcached/commit/f066d0f3) Prepare for release v0.9.1 (#273)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.9.1](https://github.com/kubedb/mongodb/releases/tag/v0.9.1)
+
+- [fd7b45bd](https://github.com/kubedb/mongodb/commit/fd7b45bd) Prepare for release v0.9.1 (#356)
+- [c805f612](https://github.com/kubedb/mongodb/commit/c805f612) Fix mongodb config directory name constants (#355)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.9.1](https://github.com/kubedb/mysql/releases/tag/v0.9.1)
+
+- [3ed0d709](https://github.com/kubedb/mysql/commit/3ed0d709) Prepare for release v0.9.1 (#344)
+
+
+
+## [kubedb/operator](https://github.com/kubedb/operator)
+
+### [v0.16.1](https://github.com/kubedb/operator/releases/tag/v0.16.1)
+
+- [0d140975](https://github.com/kubedb/operator/commit/0d140975) Prepare for release v0.16.1 (#381)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.3.1](https://github.com/kubedb/percona-xtradb/releases/tag/v0.3.1)
+
+- [bbe4cd92](https://github.com/kubedb/percona-xtradb/commit/bbe4cd92) Prepare for release v0.3.1 (#168)
+
+
+
+## [kubedb/pg-leader-election](https://github.com/kubedb/pg-leader-election)
+
+### [v0.4.1](https://github.com/kubedb/pg-leader-election/releases/tag/v0.4.1)
+
+- [42d7aef](https://github.com/kubedb/pg-leader-election/commit/42d7aef) Update readme
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.3.1](https://github.com/kubedb/pgbouncer/releases/tag/v0.3.1)
+
+- [98fd0585](https://github.com/kubedb/pgbouncer/commit/98fd0585) Prepare for release v0.3.1 (#134)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.16.1](https://github.com/kubedb/postgres/releases/tag/v0.16.1)
+
+- [6802d07e](https://github.com/kubedb/postgres/commit/6802d07e) Prepare for release v0.16.1 (#457)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.3.1](https://github.com/kubedb/proxysql/releases/tag/v0.3.1)
+
+- [9ad8e766](https://github.com/kubedb/proxysql/commit/9ad8e766) Prepare for release v0.3.1 (#149)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.9.1](https://github.com/kubedb/redis/releases/tag/v0.9.1)
+
+- [3c1bf4b6](https://github.com/kubedb/redis/commit/3c1bf4b6) Prepare for release v0.9.1 (#295)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.3.1](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.3.1)
+
+- [a5e82a9](https://github.com/kubedb/replication-mode-detector/commit/a5e82a9) Prepare for release v0.3.1 (#119)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.1.1](https://github.com/kubedb/tests/releases/tag/v0.1.1)
+
+- [4b8b17a](https://github.com/kubedb/tests/commit/4b8b17a) Prepare for release v0.1.1 (#89)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.01.15
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/30
Signed-off-by: 1gtm <1gtm@appscode.com>