### PR TITLE
Prepare for release v2021.03.17

### DIFF
--- a/docs/CHANGELOG-v2021.03.17.md
+++ b/docs/CHANGELOG-v2021.03.17.md
@@ -1,0 +1,198 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2021.03.17
+    name: Changelog-v2021.03.17
+    parent: welcome
+    weight: 20210317
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.03.17/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.03.17/
+---
+
+# KubeDB v2021.03.17 (2021-03-19)
+
+
+## [appscode/kubedb-autoscaler](https://github.com/appscode/kubedb-autoscaler)
+
+### [v0.2.1](https://github.com/appscode/kubedb-autoscaler/releases/tag/v0.2.1)
+
+- [731b46c](https://github.com/appscode/kubedb-autoscaler/commit/731b46c) Prepare for release v0.2.1 (#19)
+
+
+
+## [appscode/kubedb-enterprise](https://github.com/appscode/kubedb-enterprise)
+
+### [v0.4.1](https://github.com/appscode/kubedb-enterprise/releases/tag/v0.4.1)
+
+- [2665db85](https://github.com/appscode/kubedb-enterprise/commit/2665db85) Prepare for release v0.4.1 (#158)
+- [a3d8a50d](https://github.com/appscode/kubedb-enterprise/commit/a3d8a50d) Fix Various Issues (#156)
+- [19896fdf](https://github.com/appscode/kubedb-enterprise/commit/19896fdf) Add individual certificate issuer (#155)
+
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.17.1](https://github.com/kubedb/apimachinery/releases/tag/v0.17.1)
+
+- [12d0f980](https://github.com/kubedb/apimachinery/commit/12d0f980) Add secretName to Elasticsearch userSpec (#725)
+- [b2345eb8](https://github.com/kubedb/apimachinery/commit/b2345eb8) Add printable Distribution field for DB Versions (#723)
+- [3fc568ac](https://github.com/kubedb/apimachinery/commit/3fc568ac) Add default organizational unit (#726)
+- [e96fc066](https://github.com/kubedb/apimachinery/commit/e96fc066) Update for release Stash@v2021.03.11 (#724)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.17.1](https://github.com/kubedb/cli/releases/tag/v0.17.1)
+
+- [6b41bfb1](https://github.com/kubedb/cli/commit/6b41bfb1) Prepare for release v0.17.1 (#596)
+- [ace78977](https://github.com/kubedb/cli/commit/ace78977) Update for release Stash@v2021.03.11 (#595)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.17.1](https://github.com/kubedb/elasticsearch/releases/tag/v0.17.1)
+
+- [ed002c9d](https://github.com/kubedb/elasticsearch/commit/ed002c9d) Prepare for release v0.17.1 (#486)
+- [4a1978ff](https://github.com/kubedb/elasticsearch/commit/4a1978ff) Use user provided secret for Elasticsearch internal users (#485)
+- [821d5b65](https://github.com/kubedb/elasticsearch/commit/821d5b65) Update for release Stash@v2021.03.11 (#484)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v0.17.1](https://github.com/kubedb/installer/releases/tag/v0.17.1)
+
+- [4a1edf0](https://github.com/kubedb/installer/commit/4a1edf0) Prepare for release v0.17.1 (#289)
+- [602be5c](https://github.com/kubedb/installer/commit/602be5c) Default enable mutating webhook for KubeDB Enterprise (#288)
+- [26b5379](https://github.com/kubedb/installer/commit/26b5379) Add Elasticsearch and Redis OpsRequest Validator (#287)
+- [18344ee](https://github.com/kubedb/installer/commit/18344ee) Update perconaxtradb task names
+- [599831f](https://github.com/kubedb/installer/commit/599831f) Add MongoDBOpsRequest Validator (#286)
+- [5bb89cd](https://github.com/kubedb/installer/commit/5bb89cd) Update kubedb chart values (#285)
+- [ad07333](https://github.com/kubedb/installer/commit/ad07333) Allow overriding official registry in catalog (#284)
+- [b1da884](https://github.com/kubedb/installer/commit/b1da884) Update stash task names (#282)
+- [30a168b](https://github.com/kubedb/installer/commit/30a168b) Pass registry parameter from unified chart (#283)
+- [322d15e](https://github.com/kubedb/installer/commit/322d15e) Use stash catalog from installer repo (#281)
+- [818f50f](https://github.com/kubedb/installer/commit/818f50f) Remove namespace from db version crs (#280)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.1.1](https://github.com/kubedb/mariadb/releases/tag/v0.1.1)
+
+- [0dc99818](https://github.com/kubedb/mariadb/commit/0dc99818) Prepare for release v0.1.1 (#58)
+- [f09dda5a](https://github.com/kubedb/mariadb/commit/f09dda5a) Update for release Stash@v2021.03.11 (#57)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.10.1](https://github.com/kubedb/memcached/releases/tag/v0.10.1)
+
+- [72ae2ba4](https://github.com/kubedb/memcached/commit/72ae2ba4) Prepare for release v0.10.1 (#292)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.10.1](https://github.com/kubedb/mongodb/releases/tag/v0.10.1)
+
+- [21486cc6](https://github.com/kubedb/mongodb/commit/21486cc6) Prepare for release v0.10.1 (#385)
+- [afdf4296](https://github.com/kubedb/mongodb/commit/afdf4296) Update for release Stash@v2021.03.11 (#383)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.10.1](https://github.com/kubedb/mysql/releases/tag/v0.10.1)
+
+- [4f487d21](https://github.com/kubedb/mysql/commit/4f487d21) Prepare for release v0.10.1 (#378)
+- [9c5a24d8](https://github.com/kubedb/mysql/commit/9c5a24d8) Update for release Stash@v2021.03.11 (#376)
+
+
+
+## [kubedb/operator](https://github.com/kubedb/operator)
+
+### [v0.17.1](https://github.com/kubedb/operator/releases/tag/v0.17.1)
+
+- [5f73f990](https://github.com/kubedb/operator/commit/5f73f990) Prepare for release v0.17.1 (#400)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.4.1](https://github.com/kubedb/percona-xtradb/releases/tag/v0.4.1)
+
+- [7208b811](https://github.com/kubedb/percona-xtradb/commit/7208b811) Prepare for release v0.4.1 (#192)
+- [7d3513b2](https://github.com/kubedb/percona-xtradb/commit/7d3513b2) Update for release Stash@v2021.03.11 (#191)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.1.1](https://github.com/kubedb/pg-coordinator/releases/tag/v0.1.1)
+
+- [aa770b0](https://github.com/kubedb/pg-coordinator/commit/aa770b0) Prepare for release v0.1.1 (#14)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.4.1](https://github.com/kubedb/pgbouncer/releases/tag/v0.4.1)
+
+- [babd54a8](https://github.com/kubedb/pgbouncer/commit/babd54a8) Prepare for release v0.4.1 (#153)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.17.1](https://github.com/kubedb/postgres/releases/tag/v0.17.1)
+
+- [24d9e117](https://github.com/kubedb/postgres/commit/24d9e117) Prepare for release v0.17.1 (#483)
+- [6d1b8b6b](https://github.com/kubedb/postgres/commit/6d1b8b6b) Update for release Stash@v2021.03.11 (#482)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.4.1](https://github.com/kubedb/proxysql/releases/tag/v0.4.1)
+
+- [8ba592d2](https://github.com/kubedb/proxysql/commit/8ba592d2) Prepare for release v0.4.1 (#171)
+- [a3db83e3](https://github.com/kubedb/proxysql/commit/a3db83e3) Update for release Stash@v2021.03.11 (#170)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.10.1](https://github.com/kubedb/redis/releases/tag/v0.10.1)
+
+- [baef9fd9](https://github.com/kubedb/redis/commit/baef9fd9) Prepare for release v0.10.1 (#315)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.4.1](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.4.1)
+
+- [b115b51](https://github.com/kubedb/replication-mode-detector/commit/b115b51) Prepare for release v0.4.1 (#133)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.2.1](https://github.com/kubedb/tests/releases/tag/v0.2.1)
+
+- [eca46b5](https://github.com/kubedb/tests/commit/eca46b5) Prepare for release v0.2.1 (#111)
+- [a58b54f](https://github.com/kubedb/tests/commit/a58b54f) Don't explicitly set RestoreSession labels (#110)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.03.17
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/35
Signed-off-by: 1gtm <1gtm@appscode.com>