### PR TITLE
Prepare for release v2021.06.21-rc.0

### DIFF
--- a/docs/CHANGELOG-v2021.06.21-rc.0.md
+++ b/docs/CHANGELOG-v2021.06.21-rc.0.md
@@ -1,0 +1,358 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2021.06.21-rc.0
+    name: Changelog-v2021.06.21-rc.0
+    parent: welcome
+    weight: 20210621
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.06.21-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.06.21-rc.0/
+---
+
+# KubeDB v2021.06.21-rc.0 (2021-06-22)
+
+
+## [appscode/kubedb-autoscaler](https://github.com/appscode/kubedb-autoscaler)
+
+### [v0.4.0-rc.0](https://github.com/appscode/kubedb-autoscaler/releases/tag/v0.4.0-rc.0)
+
+- [fe37e94](https://github.com/appscode/kubedb-autoscaler/commit/fe37e94) Prepare for release v0.4.0-rc.0 (#25)
+- [f81237c](https://github.com/appscode/kubedb-autoscaler/commit/f81237c) Update audit lib (#24)
+- [ed8c87b](https://github.com/appscode/kubedb-autoscaler/commit/ed8c87b) Send audit events if analytics enabled
+- [c0a03d5](https://github.com/appscode/kubedb-autoscaler/commit/c0a03d5) Create auditor if license file is provided (#23)
+- [2775227](https://github.com/appscode/kubedb-autoscaler/commit/2775227) Publish audit events (#22)
+- [636d3a7](https://github.com/appscode/kubedb-autoscaler/commit/636d3a7) Use kglog helper
+- [6a64bb1](https://github.com/appscode/kubedb-autoscaler/commit/6a64bb1) Use k8s 1.21.0 toolchain (#21)
+
+
+
+## [appscode/kubedb-enterprise](https://github.com/appscode/kubedb-enterprise)
+
+### [v0.6.0-rc.0](https://github.com/appscode/kubedb-enterprise/releases/tag/v0.6.0-rc.0)
+
+- [97749287](https://github.com/appscode/kubedb-enterprise/commit/97749287) Prepare for release v0.6.0-rc.0 (#199)
+- [401cfc86](https://github.com/appscode/kubedb-enterprise/commit/401cfc86) Update audit lib (#197)
+- [4378d35a](https://github.com/appscode/kubedb-enterprise/commit/4378d35a) Add MariaDB OpsReq [Restart, Upgrade, Scaling, Volume Expansion, Reconfigure Custom Config] (#179)
+- [f879e934](https://github.com/appscode/kubedb-enterprise/commit/f879e934) Postgres Ops Req (Upgrade, Horizontal, Vertical, Volume Expansion, Reconfigure, Reconfigure TLS, Restart) (#193)
+- [79b51d25](https://github.com/appscode/kubedb-enterprise/commit/79b51d25) Skip stash checks if stash CRD doesn't exist (#196)
+- [3efc4ee8](https://github.com/appscode/kubedb-enterprise/commit/3efc4ee8) Refactor MongoDB Scale Down Shard (#189)
+- [64962f36](https://github.com/appscode/kubedb-enterprise/commit/64962f36) Add timeout for Elasticsearch ops request (#183)
+- [4ed736b8](https://github.com/appscode/kubedb-enterprise/commit/4ed736b8) Send audit events if analytics enabled
+- [498ef67b](https://github.com/appscode/kubedb-enterprise/commit/498ef67b) Create auditor if license file is provided (#195)
+- [a61965cc](https://github.com/appscode/kubedb-enterprise/commit/a61965cc) Publish audit events (#194)
+- [cdc0ee37](https://github.com/appscode/kubedb-enterprise/commit/cdc0ee37) Fix log level issue with klog (#187)
+- [356c6965](https://github.com/appscode/kubedb-enterprise/commit/356c6965) Use kglog helper
+- [d7248cfd](https://github.com/appscode/kubedb-enterprise/commit/d7248cfd) Update Kubernetes toolchain to v1.21.0 (#181)
+- [b8493083](https://github.com/appscode/kubedb-enterprise/commit/b8493083) Only restart the changed pods while VerticalScaling Elasticsearch (#174)
+
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.19.0-rc.0](https://github.com/kubedb/apimachinery/releases/tag/v0.19.0-rc.0)
+
+- [c885fc2d](https://github.com/kubedb/apimachinery/commit/c885fc2d) Postgres DB Container's RunAsGroup As FSGroup (#769)
+- [29cb0260](https://github.com/kubedb/apimachinery/commit/29cb0260) Add fixes to helper method (#768)
+- [b20b40c2](https://github.com/kubedb/apimachinery/commit/b20b40c2) Use Stash v2021.06.23
+- [e98fb31f](https://github.com/kubedb/apimachinery/commit/e98fb31f) Update audit event publisher (#767)
+- [81e26637](https://github.com/kubedb/apimachinery/commit/81e26637) Add MariaDB Constants (#766)
+- [532b6982](https://github.com/kubedb/apimachinery/commit/532b6982) Update Elasticsearch API to support various node roles including hot-warm-cold (#764)
+- [a9979e15](https://github.com/kubedb/apimachinery/commit/a9979e15) Update for release Stash@v2021.6.18 (#765)
+- [d20c46a2](https://github.com/kubedb/apimachinery/commit/d20c46a2) Fix locking in ResourceMapper
+- [3a597982](https://github.com/kubedb/apimachinery/commit/3a597982) Send audit events if analytics enabled
+- [27cc118e](https://github.com/kubedb/apimachinery/commit/27cc118e) Add auditor to shared Controller (#761)
+- [eb13a94f](https://github.com/kubedb/apimachinery/commit/eb13a94f) Rename TimeoutSeconds to Timeout in MongoDBOpsRequest (#759)
+- [29627ec6](https://github.com/kubedb/apimachinery/commit/29627ec6) Add timeout for each step of ES ops request (#742)
+- [cc6b9690](https://github.com/kubedb/apimachinery/commit/cc6b9690) Add MariaDB OpsRequest Types (#743)
+- [6fb2646e](https://github.com/kubedb/apimachinery/commit/6fb2646e) Update default resource limits for databases (#755)
+- [161b3fe3](https://github.com/kubedb/apimachinery/commit/161b3fe3) Add UpdateMariaDBOpsRequestStatus function (#727)
+- [98cd75f0](https://github.com/kubedb/apimachinery/commit/98cd75f0) Add Fields, Constant, Func  For Ops Request Postgres (#758)
+- [722656b7](https://github.com/kubedb/apimachinery/commit/722656b7) Add Innodb Group Replication Mode (#750)
+- [eb8e5883](https://github.com/kubedb/apimachinery/commit/eb8e5883) Replace go-bindata with //go:embed (#753)
+- [df570f7b](https://github.com/kubedb/apimachinery/commit/df570f7b) Add HealthCheckInterval constant (#752)
+- [e982e590](https://github.com/kubedb/apimachinery/commit/e982e590) Use kglog helper
+- [e725873d](https://github.com/kubedb/apimachinery/commit/e725873d) Fix tests (#749)
+- [11d1c306](https://github.com/kubedb/apimachinery/commit/11d1c306) Cleanup dependencies
+- [7030bd8f](https://github.com/kubedb/apimachinery/commit/7030bd8f) Update crds
+- [766fa11f](https://github.com/kubedb/apimachinery/commit/766fa11f) Update Kubernetes toolchain to v1.21.0 (#746)
+- [12014667](https://github.com/kubedb/apimachinery/commit/12014667) Add Elasticsearch vertical scaling constants (#741)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.19.0-rc.0](https://github.com/kubedb/cli/releases/tag/v0.19.0-rc.0)
+
+- [b367d2a5](https://github.com/kubedb/cli/commit/b367d2a5) Prepare for release v0.19.0-rc.0 (#609)
+- [b9214d6a](https://github.com/kubedb/cli/commit/b9214d6a) Use Kubernetes 1.21.1 toolchain (#608)
+- [36866cf5](https://github.com/kubedb/cli/commit/36866cf5) Use kglog helper
+- [e4ee9973](https://github.com/kubedb/cli/commit/e4ee9973) Cleanup dependencies (#607)
+- [07999fc2](https://github.com/kubedb/cli/commit/07999fc2) Use Kubernetes v1.21.0 toolchain (#606)
+- [05e3b7e5](https://github.com/kubedb/cli/commit/05e3b7e5) Use Kubernetes v1.21.0 toolchain (#605)
+- [44f4188e](https://github.com/kubedb/cli/commit/44f4188e) Use Kubernetes v1.21.0 toolchain (#604)
+- [82cd8399](https://github.com/kubedb/cli/commit/82cd8399) Use Kubernetes v1.21.0 toolchain (#603)
+- [998506cd](https://github.com/kubedb/cli/commit/998506cd) Use Kubernetes v1.21.0 toolchain (#602)
+- [4ff64f94](https://github.com/kubedb/cli/commit/4ff64f94) Use Kubernetes v1.21.0 toolchain (#601)
+- [19b257f1](https://github.com/kubedb/cli/commit/19b257f1) Update Kubernetes toolchain to v1.21.0 (#600)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.19.0-rc.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.19.0-rc.0)
+
+- [aed0fcb4](https://github.com/kubedb/elasticsearch/commit/aed0fcb4) Prepare for release v0.19.0-rc.0 (#502)
+- [630d6940](https://github.com/kubedb/elasticsearch/commit/630d6940) Update audit lib (#501)
+- [df4c9a0d](https://github.com/kubedb/elasticsearch/commit/df4c9a0d) Do not create user credentials when security is disabled (#500)
+- [3b656b57](https://github.com/kubedb/elasticsearch/commit/3b656b57) Add support for various node roles for ElasticStack (#499)
+- [64133cb6](https://github.com/kubedb/elasticsearch/commit/64133cb6) Send audit events if analytics enabled
+- [21caa38f](https://github.com/kubedb/elasticsearch/commit/21caa38f) Create auditor if license file is provided (#498)
+- [8319ba70](https://github.com/kubedb/elasticsearch/commit/8319ba70) Publish audit events (#497)
+- [5f08d1b2](https://github.com/kubedb/elasticsearch/commit/5f08d1b2) Skip health check for halted DB (#494)
+- [6a23d464](https://github.com/kubedb/elasticsearch/commit/6a23d464) Disable flow control if api is not enabled (#495)
+- [a23c5481](https://github.com/kubedb/elasticsearch/commit/a23c5481) Fix log level issue with klog (#496)
+- [38dbddda](https://github.com/kubedb/elasticsearch/commit/38dbddda) Limit health checker go-routine for specific DB object (#491)
+- [0aefd5f7](https://github.com/kubedb/elasticsearch/commit/0aefd5f7) Use kglog helper
+- [03255078](https://github.com/kubedb/elasticsearch/commit/03255078) Cleanup glog dependency
+- [57bb1bf1](https://github.com/kubedb/elasticsearch/commit/57bb1bf1) Update dependencies
+- [69fdfde7](https://github.com/kubedb/elasticsearch/commit/69fdfde7) Update Kubernetes toolchain to v1.21.0 (#492)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2021.06.21-rc.0](https://github.com/kubedb/installer/releases/tag/v2021.06.21-rc.0)
+
+- [823feb3](https://github.com/kubedb/installer/commit/823feb3) Prepare for release v2021.06.21-rc.0 (#315)
+- [946dc13](https://github.com/kubedb/installer/commit/946dc13) Use Stash v2021.06.23
+- [77a54a1](https://github.com/kubedb/installer/commit/77a54a1) Use Kubernetes 1.21.1 toolchain (#314)
+- [2b15157](https://github.com/kubedb/installer/commit/2b15157) Add support for Elasticsearch v7.13.2 (#313)
+- [a11d7d0](https://github.com/kubedb/installer/commit/a11d7d0) Support MongoDB Version 4.4.6 (#312)
+- [4c79e1a](https://github.com/kubedb/installer/commit/4c79e1a) Update Elasticsearch versions to support various node roles (#308)
+- [8e52114](https://github.com/kubedb/installer/commit/8e52114) Update for release Stash@v2021.6.18 (#311)
+- [95aa010](https://github.com/kubedb/installer/commit/95aa010) Update to MariaDB init docker version 0.2.0 (#310)
+- [1659b91](https://github.com/kubedb/installer/commit/1659b91) Fix: Update Ops Request yaml for Reconfigure TLS in Postgres (#307)
+- [b2a806b](https://github.com/kubedb/installer/commit/b2a806b) Use mongodb-exporter v0.20.4 (#305)
+- [12e720a](https://github.com/kubedb/installer/commit/12e720a) Update Kubernetes toolchain to v1.21.0 (#302)
+- [3ff3bc3](https://github.com/kubedb/installer/commit/3ff3bc3) Add monitoring values to global chart (#301)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.3.0-rc.0](https://github.com/kubedb/mariadb/releases/tag/v0.3.0-rc.0)
+
+- [9b982f74](https://github.com/kubedb/mariadb/commit/9b982f74) Prepare for release v0.3.0-rc.0 (#77)
+- [0ad0022c](https://github.com/kubedb/mariadb/commit/0ad0022c) Update audit lib (#75)
+- [501a2e61](https://github.com/kubedb/mariadb/commit/501a2e61) Update custom config mount path for MariaDB Cluster (#59)
+- [d00cf65b](https://github.com/kubedb/mariadb/commit/d00cf65b) Separate Reconcile functionality in a new function ReconcileNode (#68)
+- [e9239d4f](https://github.com/kubedb/mariadb/commit/e9239d4f) Limit Go routines in Health Checker (#73)
+- [d695adf1](https://github.com/kubedb/mariadb/commit/d695adf1) Send audit events if analytics enabled (#74)
+- [070a0f79](https://github.com/kubedb/mariadb/commit/070a0f79) Create auditor if license file is provided (#72)
+- [fc9046c3](https://github.com/kubedb/mariadb/commit/fc9046c3) Publish audit events (#71)
+- [3a1f08a9](https://github.com/kubedb/mariadb/commit/3a1f08a9) Fix log level issue with klog for MariaDB (#70)
+- [b6075e5d](https://github.com/kubedb/mariadb/commit/b6075e5d) Use kglog helper
+- [f510e375](https://github.com/kubedb/mariadb/commit/f510e375) Use klog/v2
+- [c009905e](https://github.com/kubedb/mariadb/commit/c009905e) Update Kubernetes toolchain to v1.21.0 (#66)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.12.0-rc.0](https://github.com/kubedb/memcached/releases/tag/v0.12.0-rc.0)
+
+- [99ab26b5](https://github.com/kubedb/memcached/commit/99ab26b5) Prepare for release v0.12.0-rc.0 (#299)
+- [213807d5](https://github.com/kubedb/memcached/commit/213807d5) Update audit lib (#298)
+- [29054b5b](https://github.com/kubedb/memcached/commit/29054b5b) Send audit events if analytics enabled (#297)
+- [a4888446](https://github.com/kubedb/memcached/commit/a4888446) Publish audit events (#296)
+- [236d6108](https://github.com/kubedb/memcached/commit/236d6108) Use kglog helper
+- [7ffe5c73](https://github.com/kubedb/memcached/commit/7ffe5c73) Use klog/v2
+- [fb34645b](https://github.com/kubedb/memcached/commit/fb34645b) Update Kubernetes toolchain to v1.21.0 (#294)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.12.0-rc.0](https://github.com/kubedb/mongodb/releases/tag/v0.12.0-rc.0)
+
+- [11eb6ee8](https://github.com/kubedb/mongodb/commit/11eb6ee8) Prepare for release v0.12.0-rc.0 (#400)
+- [dbf5cd16](https://github.com/kubedb/mongodb/commit/dbf5cd16) Update audit lib (#399)
+- [a55bf1d5](https://github.com/kubedb/mongodb/commit/a55bf1d5) Limit go routine in health check (#394)
+- [0a61c733](https://github.com/kubedb/mongodb/commit/0a61c733) Update TLS args for Exporter (#395)
+- [80d3fec2](https://github.com/kubedb/mongodb/commit/80d3fec2) Send audit events if analytics enabled (#398)
+- [8ac51d7e](https://github.com/kubedb/mongodb/commit/8ac51d7e) Create auditor if license file is provided (#397)
+- [c6c4b380](https://github.com/kubedb/mongodb/commit/c6c4b380) Publish audit events (#396)
+- [e261937a](https://github.com/kubedb/mongodb/commit/e261937a) Fix log level issue with klog (#393)
+- [426afbfc](https://github.com/kubedb/mongodb/commit/426afbfc) Use kglog helper
+- [24b7976c](https://github.com/kubedb/mongodb/commit/24b7976c) Use klog/v2
+- [0ace005d](https://github.com/kubedb/mongodb/commit/0ace005d) Update Kubernetes toolchain to v1.21.0 (#391)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.12.0-rc.0](https://github.com/kubedb/mysql/releases/tag/v0.12.0-rc.0)
+
+- [9533c528](https://github.com/kubedb/mysql/commit/9533c528) Prepare for release v0.12.0-rc.0 (#392)
+- [f0313b17](https://github.com/kubedb/mysql/commit/f0313b17) Limit Health Checker goroutines (#385)
+- [ab601a28](https://github.com/kubedb/mysql/commit/ab601a28) Use gomodules.xyz/password-generator v0.2.7
+- [782362db](https://github.com/kubedb/mysql/commit/782362db) Update audit library (#390)
+- [1d36bacb](https://github.com/kubedb/mysql/commit/1d36bacb) Send audit events if analytics enabled (#389)
+- [55a903a3](https://github.com/kubedb/mysql/commit/55a903a3) Create auditor if license file is provided (#388)
+- [dc6f6ea5](https://github.com/kubedb/mysql/commit/dc6f6ea5) Publish audit events (#387)
+- [75bd1a1c](https://github.com/kubedb/mysql/commit/75bd1a1c) Fix log level issue with klog for mysql (#386)
+- [1014a393](https://github.com/kubedb/mysql/commit/1014a393) Use kglog helper
+- [728fa299](https://github.com/kubedb/mysql/commit/728fa299) Use klog/v2
+- [80581df4](https://github.com/kubedb/mysql/commit/80581df4) Update Kubernetes toolchain to v1.21.0 (#383)
+
+
+
+## [kubedb/operator](https://github.com/kubedb/operator)
+
+### [v0.19.0-rc.0](https://github.com/kubedb/operator/releases/tag/v0.19.0-rc.0)
+
+- [08daa22a](https://github.com/kubedb/operator/commit/08daa22a) Prepare for release v0.19.0-rc.0 (#407)
+- [203ffa38](https://github.com/kubedb/operator/commit/203ffa38) Update audit lib (#406)
+- [704a774f](https://github.com/kubedb/operator/commit/704a774f) Send audit events if analytics enabled (#405)
+- [7e8f1be0](https://github.com/kubedb/operator/commit/7e8f1be0) Stop using gomodules.xyz/version
+- [49d7d7f2](https://github.com/kubedb/operator/commit/49d7d7f2) Publish audit events (#404)
+- [820d7372](https://github.com/kubedb/operator/commit/820d7372) Use kglog helper
+- [396ae75f](https://github.com/kubedb/operator/commit/396ae75f) Update Kubernetes toolchain to v1.21.0 (#403)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.6.0-rc.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.6.0-rc.0)
+
+- [870e08df](https://github.com/kubedb/percona-xtradb/commit/870e08df) Prepare for release v0.6.0-rc.0 (#201)
+- [f163f637](https://github.com/kubedb/percona-xtradb/commit/f163f637) Update audit lib (#200)
+- [c42c3401](https://github.com/kubedb/percona-xtradb/commit/c42c3401) Send audit events if analytics enabled (#199)
+- [e2ce3664](https://github.com/kubedb/percona-xtradb/commit/e2ce3664) Create auditor if license file is provided (#198)
+- [3e85edb2](https://github.com/kubedb/percona-xtradb/commit/3e85edb2) Publish audit events (#197)
+- [6f23031c](https://github.com/kubedb/percona-xtradb/commit/6f23031c) Use kglog helper
+- [cc0e270a](https://github.com/kubedb/percona-xtradb/commit/cc0e270a) Use klog/v2
+- [a44e3347](https://github.com/kubedb/percona-xtradb/commit/a44e3347) Update Kubernetes toolchain to v1.21.0 (#195)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.3.0-rc.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.3.0-rc.0)
+
+- [3ca5f67](https://github.com/kubedb/pg-coordinator/commit/3ca5f67) Prepare for release v0.3.0-rc.0 (#25)
+- [4ef7d95](https://github.com/kubedb/pg-coordinator/commit/4ef7d95) Update Client TLS Path for Postgres (#24)
+- [7208199](https://github.com/kubedb/pg-coordinator/commit/7208199) Raft Version Update And Ops Request Fix (#23)
+- [5adb304](https://github.com/kubedb/pg-coordinator/commit/5adb304) Use klog/v2 (#19)
+- [a9b3f16](https://github.com/kubedb/pg-coordinator/commit/a9b3f16) Use klog/v2
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.6.0-rc.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.6.0-rc.0)
+
+- [cbba6969](https://github.com/kubedb/pgbouncer/commit/cbba6969) Prepare for release v0.6.0-rc.0 (#161)
+- [bc6428cd](https://github.com/kubedb/pgbouncer/commit/bc6428cd) Update audit lib (#160)
+- [442f0635](https://github.com/kubedb/pgbouncer/commit/442f0635) Send audit events if analytics enabled (#159)
+- [2ebaf4bb](https://github.com/kubedb/pgbouncer/commit/2ebaf4bb) Create auditor if license file is provided (#158)
+- [4e3f115d](https://github.com/kubedb/pgbouncer/commit/4e3f115d) Publish audit events (#157)
+- [1ed2f883](https://github.com/kubedb/pgbouncer/commit/1ed2f883) Use kglog helper
+- [870cf108](https://github.com/kubedb/pgbouncer/commit/870cf108) Use klog/v2
+- [11c2ac03](https://github.com/kubedb/pgbouncer/commit/11c2ac03) Update Kubernetes toolchain to v1.21.0 (#155)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.19.0-rc.0](https://github.com/kubedb/postgres/releases/tag/v0.19.0-rc.0)
+
+- [06fcab6e](https://github.com/kubedb/postgres/commit/06fcab6e) Prepare for release v0.19.0-rc.0 (#508)
+- [5c0e0fa2](https://github.com/kubedb/postgres/commit/5c0e0fa2) Run All DB Pod's Container with Custom-UID (#507)
+- [9496dadf](https://github.com/kubedb/postgres/commit/9496dadf) Update audit lib (#506)
+- [d51cdfdd](https://github.com/kubedb/postgres/commit/d51cdfdd) Limit Health Check for Postgres (#504)
+- [24851ba8](https://github.com/kubedb/postgres/commit/24851ba8) Send audit events if analytics enabled (#505)
+- [faecf01d](https://github.com/kubedb/postgres/commit/faecf01d) Create auditor if license file is provided (#503)
+- [8d4bf26b](https://github.com/kubedb/postgres/commit/8d4bf26b) Stop using gomodules.xyz/version (#501)
+- [906c678e](https://github.com/kubedb/postgres/commit/906c678e) Publish audit events (#500)
+- [c6afe209](https://github.com/kubedb/postgres/commit/c6afe209) Fix: Log Level Issue with klog (#496)
+- [2a910034](https://github.com/kubedb/postgres/commit/2a910034) Use kglog helper
+- [a4e685d6](https://github.com/kubedb/postgres/commit/a4e685d6) Use klog/v2
+- [ee9a9d15](https://github.com/kubedb/postgres/commit/ee9a9d15) Update Kubernetes toolchain to v1.21.0 (#492)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.6.0-rc.0](https://github.com/kubedb/proxysql/releases/tag/v0.6.0-rc.0)
+
+- [ba5ec48b](https://github.com/kubedb/proxysql/commit/ba5ec48b) Prepare for release v0.6.0-rc.0 (#179)
+- [9770fa0d](https://github.com/kubedb/proxysql/commit/9770fa0d) Update audit lib (#178)
+- [3e307411](https://github.com/kubedb/proxysql/commit/3e307411) Send audit events if analytics enabled (#177)
+- [790b57ed](https://github.com/kubedb/proxysql/commit/790b57ed) Create auditor if license file is provided (#176)
+- [6e6c9ba1](https://github.com/kubedb/proxysql/commit/6e6c9ba1) Publish audit events (#175)
+- [df2937ed](https://github.com/kubedb/proxysql/commit/df2937ed) Use kglog helper
+- [2ca12e48](https://github.com/kubedb/proxysql/commit/2ca12e48) Use klog/v2
+- [3796f730](https://github.com/kubedb/proxysql/commit/3796f730) Update Kubernetes toolchain to v1.21.0 (#173)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.12.0-rc.0](https://github.com/kubedb/redis/releases/tag/v0.12.0-rc.0)
+
+- [0c15054c](https://github.com/kubedb/redis/commit/0c15054c) Prepare for release v0.12.0-rc.0 (#324)
+- [5a5ec318](https://github.com/kubedb/redis/commit/5a5ec318) Update audit lib (#323)
+- [6673f940](https://github.com/kubedb/redis/commit/6673f940) Limit Health Check go-routine Redis (#321)
+- [e945029e](https://github.com/kubedb/redis/commit/e945029e) Send audit events if analytics enabled (#322)
+- [3715ff10](https://github.com/kubedb/redis/commit/3715ff10) Create auditor if license file is provided (#320)
+- [9d5d90a9](https://github.com/kubedb/redis/commit/9d5d90a9) Add auditor handler
+- [5004f56c](https://github.com/kubedb/redis/commit/5004f56c) Publish audit events (#319)
+- [146b3863](https://github.com/kubedb/redis/commit/146b3863) Use kglog helper
+- [71d8ced8](https://github.com/kubedb/redis/commit/71d8ced8) Use klog/v2
+- [4900a564](https://github.com/kubedb/redis/commit/4900a564) Update Kubernetes toolchain to v1.21.0 (#317)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.6.0-rc.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.6.0-rc.0)
+
+- [1382382](https://github.com/kubedb/replication-mode-detector/commit/1382382) Prepare for release v0.6.0-rc.0 (#143)
+- [feba070](https://github.com/kubedb/replication-mode-detector/commit/feba070) Remove glog dependency
+- [fd757b4](https://github.com/kubedb/replication-mode-detector/commit/fd757b4) Use kglog helper
+- [8ba20a3](https://github.com/kubedb/replication-mode-detector/commit/8ba20a3) Update repository config (#142)
+- [eece885](https://github.com/kubedb/replication-mode-detector/commit/eece885) Use klog/v2
+- [e30c050](https://github.com/kubedb/replication-mode-detector/commit/e30c050) Use Kubernetes v1.21.0 toolchain (#140)
+- [8e7b7c2](https://github.com/kubedb/replication-mode-detector/commit/8e7b7c2) Use Kubernetes v1.21.0 toolchain (#139)
+- [6bceb2f](https://github.com/kubedb/replication-mode-detector/commit/6bceb2f) Use Kubernetes v1.21.0 toolchain (#138)
+- [0fe720e](https://github.com/kubedb/replication-mode-detector/commit/0fe720e) Use Kubernetes v1.21.0 toolchain (#137)
+- [8c54b2a](https://github.com/kubedb/replication-mode-detector/commit/8c54b2a) Update Kubernetes toolchain to v1.21.0 (#136)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.4.0-rc.0](https://github.com/kubedb/tests/releases/tag/v0.4.0-rc.0)
+
+- [b6b4be3](https://github.com/kubedb/tests/commit/b6b4be3) Prepare for release v0.4.0-rc.0 (#124)
+- [62e6b50](https://github.com/kubedb/tests/commit/62e6b50) Fix locking in ResourceMapper (#123)
+- [a855fab](https://github.com/kubedb/tests/commit/a855fab) Update dependencies (#122)
+- [7d5b1a4](https://github.com/kubedb/tests/commit/7d5b1a4) Use kglog helper
+- [a08eee4](https://github.com/kubedb/tests/commit/a08eee4) Use klog/v2
+- [ed1afd4](https://github.com/kubedb/tests/commit/ed1afd4) Use Kubernetes v1.21.0 toolchain (#120)
+- [ccb54f1](https://github.com/kubedb/tests/commit/ccb54f1) Use Kubernetes v1.21.0 toolchain (#119)
+- [2a6f06d](https://github.com/kubedb/tests/commit/2a6f06d) Use Kubernetes v1.21.0 toolchain (#118)
+- [7fb99f7](https://github.com/kubedb/tests/commit/7fb99f7) Use Kubernetes v1.21.0 toolchain (#117)
+- [aaa0647](https://github.com/kubedb/tests/commit/aaa0647) Update Kubernetes toolchain to v1.21.0 (#116)
+- [79d815d](https://github.com/kubedb/tests/commit/79d815d) Fix Elasticsearch status check while creating the client (#114)
+
+
+
+

--- a/docs/examples/mysql/Initialization/demo-1.yaml
+++ b/docs/examples/mysql/Initialization/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-init-script
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/mysql/cli/mysql-demo.yaml
+++ b/docs/examples/mysql/cli/mysql-demo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-demo
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/mysql/clustering/demo-1.yaml
+++ b/docs/examples/mysql/clustering/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/configuration/mysql-custom.yaml
+++ b/docs/examples/mysql/configuration/mysql-custom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-mysql
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   configSecret:
     name: my-custom-config
   storage:

--- a/docs/examples/mysql/configuration/mysql-misc-config.yaml
+++ b/docs/examples/mysql/configuration/mysql-misc-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-misc-config
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   storageType: "Durable"
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/custom-rbac/my-custom-db-two.yaml
+++ b/docs/examples/mysql/custom-rbac/my-custom-db-two.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minute-mysql
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/examples/mysql/custom-rbac/my-custom-db.yaml
+++ b/docs/examples/mysql/custom-rbac/my-custom-db.yaml
@@ -4,7 +4,7 @@ metadata:
   name: quick-mysql
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/examples/mysql/horizontalscaling/group_replication.yaml
+++ b/docs/examples/mysql/horizontalscaling/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/monitoring/builtin-prom-mysql.yaml
+++ b/docs/examples/mysql/monitoring/builtin-prom-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-mysql
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/monitoring/coreos-prom-mysql.yaml
+++ b/docs/examples/mysql/monitoring/coreos-prom-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coreos-prom-mysql
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/private-registry/demo-2.yaml
+++ b/docs/examples/mysql/private-registry/demo-2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-pvt-reg
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/mysql/quickstart/demo-2.yaml
+++ b/docs/examples/mysql/quickstart/demo-2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/tls/tls-group.yaml
+++ b/docs/examples/mysql/tls/tls-group.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group-tls
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/tls/tls-standalone.yaml
+++ b/docs/examples/mysql/tls/tls-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone-tls
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/upgrading/majorversion/group_replication.yaml
+++ b/docs/examples/mysql/upgrading/majorversion/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/upgrading/majorversion/standalone.yaml
+++ b/docs/examples/mysql/upgrading/majorversion/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/upgrading/majorversion/upgrade_major_version_group.yaml
+++ b/docs/examples/mysql/upgrading/majorversion/upgrade_major_version_group.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: my-group
   upgrade:
-    targetVersion: "8.0.21-v1"
+    targetVersion: "8.0.21-v2"

--- a/docs/examples/mysql/upgrading/majorversion/upgrade_major_version_standalone.yaml
+++ b/docs/examples/mysql/upgrading/majorversion/upgrade_major_version_standalone.yaml
@@ -8,4 +8,4 @@ spec:
     name: my-standalone
   type: Upgrade
   upgrade:
-    targetVersion: "8.0.21-v1"
+    targetVersion: "8.0.21-v2"

--- a/docs/examples/mysql/upgrading/minorversion/group_replication.yaml
+++ b/docs/examples/mysql/upgrading/minorversion/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/upgrading/minorversion/standalone.yaml
+++ b/docs/examples/mysql/upgrading/minorversion/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/upgrading/minorversion/upgrade_minor_version_group.yaml
+++ b/docs/examples/mysql/upgrading/minorversion/upgrade_minor_version_group.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: my-group
   upgrade:
-    targetVersion: "5.7.33"
+    targetVersion: "5.7.33-v1"

--- a/docs/examples/mysql/upgrading/minorversion/upgrade_minor_version_standalone.yaml
+++ b/docs/examples/mysql/upgrading/minorversion/upgrade_minor_version_standalone.yaml
@@ -8,4 +8,4 @@ spec:
     name: my-standalone
   type: Upgrade
   upgrade:
-    targetVersion: "5.7.31-v1"
+    targetVersion: "5.7.31-v2"

--- a/docs/examples/mysql/verticalscaling/group_replication.yaml
+++ b/docs/examples/mysql/verticalscaling/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/verticalscaling/standalone.yaml
+++ b/docs/examples/mysql/verticalscaling/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/proxysql/demo-my-group.yaml
+++ b/docs/examples/proxysql/demo-my-group.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/backup/standalone/examples/restored-mysql.yaml
+++ b/docs/guides/mysql/backup/standalone/examples/restored-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restored-mysql
   namespace: demo
 spec:
-  version: "8.0.21-v1"
+  version: "8.0.21-v2"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/standalone/examples/sample-mysql.yaml
+++ b/docs/guides/mysql/backup/standalone/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.0.21-v1"
+  version: "8.0.21-v2"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/standalone/index.md
+++ b/docs/guides/mysql/backup/standalone/index.md
@@ -56,7 +56,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.0.21-v1"
+  version: "8.0.21-v2"
   replicas: 1
   storageType: Durable
   storage:
@@ -416,7 +416,7 @@ metadata:
   name: restored-mysql
   namespace: demo
 spec:
-  version: "8.0.21-v1"
+  version: "8.0.21-v2"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/cli/index.md
+++ b/docs/guides/mysql/cli/index.md
@@ -47,8 +47,8 @@ cat mysql-demo.yaml | kubectl create -f -
 ```bash
 $ kubectl get mysql
 NAME         VERSION   STATUS    AGE
-mysql-demo   8.0.23    Running   5m1s
-mysql-dev    5.7.33    Running   10m1s
+mysql-demo   8.0.23-v1    Running   5m1s
+mysql-dev    5.7.33-v1 Running   10m1s
 ```
 
 To get YAML of an object, use `--output=yaml` flag.
@@ -106,7 +106,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   terminationPolicy: Delete
-  version: 8.0.23
+  version: 8.0.23-v1
 ```
 
 To get JSON of an object, use `--output=json` flag.
@@ -127,13 +127,13 @@ service/mysql-demo        ClusterIP   10.107.205.135   <none>        3306/TCP   
 service/mysql-demo-pods   ClusterIP   None             <none>        3306/TCP   2m17s   app.kubernetes.io/instance=mysql-demo,app.kubernetes.io/managed-by=kubedb.com,app.kubernetes.io/name=mysqls.kubedb.com
 
 NAME                          READY   AGE     CONTAINERS   IMAGES
-statefulset.apps/mysql-demo   1/1     2m17s   mysql        kubedb/mysql:8.0.23
+statefulset.apps/mysql-demo   1/1     2m17s   mysql        kubedb/mysql:8.0.23-v1
 
 NAME                                            TYPE               VERSION   AGE
-appbinding.appcatalog.appscode.com/mysql-demo   kubedb.com/mysql   8.0.23    2m17s
+appbinding.appcatalog.appscode.com/mysql-demo   kubedb.com/mysql   8.0.23-v1    2m17s
 
 NAME                          VERSION   STATUS   AGE
-mysql.kubedb.com/mysql-demo   8.0.23    Ready    2m17s
+mysql.kubedb.com/mysql-demo   8.0.23-v1    Ready    2m17s
 ```
 
 Flag `--output=wide` is used to print additional information.
@@ -226,7 +226,7 @@ Auth Secret:
 AppBinding:
   Metadata:
     Annotations:
-      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-demo","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"version":"8.0.23"}}
+      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-demo","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"version":"8.0.23-v1"}}
 
     Creation Timestamp:  2021-03-15T11:53:48Z
     Labels:
@@ -250,13 +250,13 @@ AppBinding:
       Stash:
         Addon:
           Backup Task:
-            Name:  mysql-backup-8.0.21-v1
+            Name:  mysql-backup-8.0.21-v2
           Restore Task:
-            Name:  mysql-restore-8.0.21-v1
+            Name:  mysql-restore-8.0.21-v2
     Secret:
       Name:   mysql-demo-auth
     Type:     kubedb.com/mysql
-    Version:  8.0.23
+    Version:  8.0.23-v1
 
 Events:
   Type    Reason      Age   From             Message

--- a/docs/guides/mysql/cli/yamls/mysql-demo.yaml
+++ b/docs/guides/mysql/cli/yamls/mysql-demo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-demo
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mysql/clients/index.md
+++ b/docs/guides/mysql/clients/index.md
@@ -48,7 +48,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -84,7 +84,7 @@ $ watch -n 3 kubectl get my -n demo my-group
 Every 3.0s: kubectl get my -n demo my-group                      suaas-appscode: Wed Sep  9 10:54:34 2020
 
 NAME       VERSION   STATUS    AGE
-my-group   8.0.23    Running   16m
+my-group   8.0.23-v1    Running   16m
 
 $ watch -n 3 kubectl get sts -n demo my-group
 ery 3.0s: kubectl get sts -n demo my-group                     suaas-appscode: Wed Sep  9 10:53:52 2020
@@ -183,7 +183,7 @@ Auth Secret:
 AppBinding:
   Metadata:
     Annotations:
-      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"my-group","namespace":"demo"},"spec":{"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"WipeOut","topology":{"group":{"name":"dc002fc3-c412-4d18-b1d4-66c1fbfbbc9b"},"mode":"GroupReplication"},"version":"8.0.23"}}
+      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"my-group","namespace":"demo"},"spec":{"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"WipeOut","topology":{"group":{"name":"dc002fc3-c412-4d18-b1d4-66c1fbfbbc9b"},"mode":"GroupReplication"},"version":"8.0.23-v1"}}
 
     Creation Timestamp:  2021-03-15T12:18:35Z
     Labels:
@@ -207,16 +207,16 @@ AppBinding:
       Stash:
         Addon:
           Backup Task:
-            Name:  mysql-backup-8.0.21-v1
+            Name:  mysql-backup-8.0.21-v2
             Params:
               Name:   args
               Value:  --all-databases --set-gtid-purged=OFF
           Restore Task:
-            Name:  mysql-restore-8.0.21-v1
+            Name:  mysql-restore-8.0.21-v2
     Secret:
       Name:   my-group-auth
     Type:     kubedb.com/mysql
-    Version:  8.0.23
+    Version:  8.0.23-v1
 
 Events:
   Type    Reason      Age   From             Message

--- a/docs/guides/mysql/clients/yamls/group-replication.yaml
+++ b/docs/guides/mysql/clients/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/clustering/group-replication/index.md
+++ b/docs/guides/mysql/clustering/group-replication/index.md
@@ -48,7 +48,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -163,7 +163,7 @@ Database Secret:
 AppBinding:
   Metadata:
     Annotations:
-      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"my-group","namespace":"demo"},"spec":{"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"WipeOut","topology":{"group":{"baseServerID":100,"name":"dc002fc3-c412-4d18-b1d4-66c1fbfbbc9b"},"mode":"GroupReplication"},"version":"8.0.23"}}
+      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"my-group","namespace":"demo"},"spec":{"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"WipeOut","topology":{"group":{"baseServerID":100,"name":"dc002fc3-c412-4d18-b1d4-66c1fbfbbc9b"},"mode":"GroupReplication"},"version":"8.0.23-v1"}}
 
     Creation Timestamp:  2020-08-25T10:50:59Z
     Labels:
@@ -171,7 +171,7 @@ AppBinding:
       app.kubernetes.io/instance:    my-group
       app.kubernetes.io/managed-by:  kubedb.com
       app.kubernetes.io/name:        mysql
-      app.kubernetes.io/version:     8.0.23
+      app.kubernetes.io/version:     8.0.23-v1
       app.kubernetes.io/name:        mysqls.kubedb.com
       app.kubernetes.io/instance:               my-group
     Name:                            my-group
@@ -187,7 +187,7 @@ AppBinding:
     Secret:
       Name:   my-group-auth
     Type:     kubedb.com/mysql
-    Version:  8.0.23
+    Version:  8.0.23-v1
 
 Events:
   Type    Reason      Age   From            Message
@@ -281,7 +281,7 @@ spec:
     group:
       name: dc002fc3-c412-4d18-b1d4-66c1fbfbbc9b
     mode: GroupReplication
-  version: 8.0.23
+  version: 8.0.23-v1
 status:
   observedGeneration: 2$4213139756412538772
   phase: Running

--- a/docs/guides/mysql/clustering/group-replication/yamls/group-replication.yaml
+++ b/docs/guides/mysql/clustering/group-replication/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/clustering/overview/images/yamls/group-replication.yaml
+++ b/docs/guides/mysql/clustering/overview/images/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/concepts/appbinding/index.md
+++ b/docs/guides/mysql/concepts/appbinding/index.md
@@ -34,7 +34,7 @@ kind: AppBinding
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"custom-mysql","namespace":"demo"},"spec":{"configSecret":{"name":"my-configuration"},"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"version":"8.0.23"}}
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"custom-mysql","namespace":"demo"},"spec":{"configSecret":{"name":"my-configuration"},"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"version":"8.0.23-v1"}}
   creationTimestamp: "2021-03-11T05:22:43Z"
   generation: 1
   labels:
@@ -72,13 +72,13 @@ spec:
     stash:
       addon:
         backupTask:
-          name: mysql-backup-8.0.21-v1
+          name: mysql-backup-8.0.21-v2
         restoreTask:
-          name: mysql-restore-8.0.21-v1
+          name: mysql-restore-8.0.21-v2
   secret:
     name: custom-mysql-auth
   type: kubedb.com/mysql
-  version: 8.0.23
+  version: 8.0.23-v1
 ```
 
 Here, we are going to describe the sections of an `AppBinding` crd.

--- a/docs/guides/mysql/concepts/catalog/index.md
+++ b/docs/guides/mysql/concepts/catalog/index.md
@@ -39,10 +39,10 @@ metadata:
     app.kubernetes.io/name: kubedb-catalog
     app.kubernetes.io/version: v0.16.2
     helm.sh/chart: kubedb-catalog-v0.16.2
-  name: 8.0.23
+  name: 8.0.23-v1
 spec:
   db:
-    image: suaas21/mysql:8.0.23
+    image: kubedb/mysql:8.0.23-v1
   distribution: Oracle
   exporter:
     image: kubedb/mysqld-exporter:v0.11.0

--- a/docs/guides/mysql/concepts/database/index.md
+++ b/docs/guides/mysql/concepts/database/index.md
@@ -29,7 +29,7 @@ metadata:
   name: m1
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   topology:
     mode: GroupReplication
     group:
@@ -115,8 +115,8 @@ spec:
 
 `spec.version` is a required field specifying the name of the [MySQLVersion](/docs/guides/mysql/concepts/catalog/index.md) crd where the docker images are specified. Currently, when you install KubeDB, it creates the following `MySQLVersion` resources,
 
-- `8.0.23`, `8.0.21-v1`, `8.0.20-v1`, `8.0.14-v2`, `8.0.3-v2`
-- `5.7.33`, `5.7.31-v1`, `5.7.29-v1`, `5.7.25-v2`
+- `8.0.23-v1`, `8.0.21-v2`, `8.0.20-v1`, `8.0.14-v2`, `8.0.3-v2`
+- `5.7.33-v1`, `5.7.31-v2`, `5.7.29-v2`, `5.7.25-v2`
 
 ### spec.topology
 
@@ -195,7 +195,7 @@ metadata:
   name: m1
   namespace: demo
 spec:
-  version: 8.0.23
+  version: 8.0.23-v1
   init:
     script:
       configMap:

--- a/docs/guides/mysql/concepts/opsrequest/index.md
+++ b/docs/guides/mysql/concepts/opsrequest/index.md
@@ -39,7 +39,7 @@ spec:
     name: my-group
   type: Upgrade
   upgrade:
-    targetVersion: 8.0.23
+    targetVersion: 8.0.23-v1
 status:
   conditions:
   - lastTransitionTime: "2020-06-11T09:59:05Z"

--- a/docs/guides/mysql/configuration/config-file/index.md
+++ b/docs/guides/mysql/configuration/config-file/index.md
@@ -115,7 +115,7 @@ metadata:
   name: custom-mysql
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   configSecret:
     name: my-configuration
   storage:

--- a/docs/guides/mysql/configuration/config-file/yamls/mysql-custom.yaml
+++ b/docs/guides/mysql/configuration/config-file/yamls/mysql-custom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-mysql
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   configSecret:
     name: my-configuration
   storage:

--- a/docs/guides/mysql/configuration/podtemplating/index.md
+++ b/docs/guides/mysql/configuration/podtemplating/index.md
@@ -60,7 +60,7 @@ Read about the fields in details in [PodTemplate concept](/docs/guides/mysql/con
 
 Below is the YAML for the MySQL created in this example. Here, [`spec.podTemplate.spec.env`](/docs/guides/mysql/concepts/database/index.md#specpodtemplatespecenv) specifies environment variables and [`spec.podTemplate.spec.args`](/docs/guides/mysql/concepts/database/index.md#specpodtemplatespecargs) provides extra arguments for [MySQL Docker Image](https://hub.docker.com/_/mysql/).
 
-In this tutorial, an initial database `myDB` will be created by providing `env` `MYSQL_DATABASE` while the server character set will be set to `utf8mb4` by adding extra `args`. Note that, `character-set-server` in `MySQL 5.7.33` is `latin1`.
+In this tutorial, an initial database `myDB` will be created by providing `env` `MYSQL_DATABASE` while the server character set will be set to `utf8mb4` by adding extra `args`. Note that, `character-set-server` in `MySQL 5.7.33-v1` is `latin1`.
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -69,7 +69,7 @@ metadata:
   name: mysql-misc-config
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   storageType: "Durable"
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/configuration/podtemplating/yamls/mysql-misc-config.yaml
+++ b/docs/guides/mysql/configuration/podtemplating/yamls/mysql-misc-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-misc-config
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   storageType: "Durable"
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/custom-rbac/index.md
+++ b/docs/guides/mysql/custom-rbac/index.md
@@ -143,7 +143,7 @@ metadata:
   name: quick-mysql
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storageType: Durable
   podTemplate:
     spec:
@@ -209,7 +209,7 @@ metadata:
   name: minute-mysql
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/mysql/custom-rbac/yamls/my-custom-db-two.yaml
+++ b/docs/guides/mysql/custom-rbac/yamls/my-custom-db-two.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minute-mysql
   namespace: demo
 spec:
-  version: "8.0.21-v1"
+  version: "8.0.21-v2"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/mysql/custom-rbac/yamls/my-custom-db.yaml
+++ b/docs/guides/mysql/custom-rbac/yamls/my-custom-db.yaml
@@ -4,7 +4,7 @@ metadata:
   name: quick-mysql
   namespace: demo
 spec:
-  version: "8.0.21-v1"
+  version: "8.0.21-v2"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/mysql/initialization/index.md
+++ b/docs/guides/mysql/initialization/index.md
@@ -89,7 +89,7 @@ metadata:
   name: mysql-init-script
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storage:
     storageClassName: "standard"
     accessModes:
@@ -191,7 +191,7 @@ Init:
 AppBinding:
   Metadata:
     Annotations:
-      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-init-script","namespace":"demo"},"spec":{"init":{"script":{"configMap":{"name":"my-init-script"}}},"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"version":"8.0.21-v1"}}
+      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-init-script","namespace":"demo"},"spec":{"init":{"script":{"configMap":{"name":"my-init-script"}}},"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"version":"8.0.21-v2"}}
 
     Creation Timestamp:  2020-08-27T06:43:15Z
     Labels:
@@ -199,7 +199,7 @@ AppBinding:
       app.kubernetes.io/instance:    mysql-init-script
       app.kubernetes.io/managed-by:  kubedb.com
       app.kubernetes.io/name:        mysql
-      app.kubernetes.io/version:     8.0.21-v1
+      app.kubernetes.io/version:     8.0.21-v2
       app.kubernetes.io/name:        mysqls.kubedb.com
       app.kubernetes.io/instance:               mysql-init-script
     Name:                            mysql-init-script
@@ -215,7 +215,7 @@ AppBinding:
     Secret:
       Name:   mysql-init-script-auth
     Type:     kubedb.com/mysql
-    Version:  8.0.21-v1
+    Version:  8.0.21-v2
 
 Events:
   Type    Reason      Age   From            Message
@@ -253,7 +253,7 @@ kind: MySQL
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-init-script","namespace":"demo"},"spec":{"init":{"script":{"configMap":{"name":"my-init-script"}}},"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"version":"8.0.21-v1"}}
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-init-script","namespace":"demo"},"spec":{"init":{"script":{"configMap":{"name":"my-init-script"}}},"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"version":"8.0.21-v2"}}
   creationTimestamp: "2020-08-27T06:42:04Z"
   finalizers:
   - kubedb.com
@@ -288,7 +288,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   terminationPolicy: Delete
-  version: 8.0.21-v1
+  version: 8.0.21-v2
 status:
   observedGeneration: 2
   phase: Running

--- a/docs/guides/mysql/initialization/yamls/initialize-mysql.yaml
+++ b/docs/guides/mysql/initialization/yamls/initialize-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-init-script
   namespace: demo
 spec:
-  version: "8.0.21-v1"
+  version: "8.0.21-v2"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mysql/monitoring/builtin-prometheus/index.md
+++ b/docs/guides/mysql/monitoring/builtin-prometheus/index.md
@@ -49,7 +49,7 @@ metadata:
   name: builtin-prom-mysql
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"
@@ -80,7 +80,7 @@ $ watch -n 3 kubectl get mysql -n demo builtin-prom-mysql
 Every 3.0s: kubectl get mysql -n demo builtin-prom-mysql        suaas-appscode: Tue Aug 25 16:07:29 2020
 
 NAME                 VERSION      STATUS    AGE
-builtin-prom-mysql   8.0.21-v1    Running   3m33s
+builtin-prom-mysql   8.0.21-v2    Running   3m33s
 ```
 
 KubeDB will create a separate stats service with name `{MySQL crd name}-stats` for monitoring purpose.

--- a/docs/guides/mysql/monitoring/builtin-prometheus/yamls/builtin-prom-mysql.yaml
+++ b/docs/guides/mysql/monitoring/builtin-prometheus/yamls/builtin-prom-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-mysql
   namespace: demo
 spec:
-  version: "8.0.21-v1"
+  version: "8.0.21-v2"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/monitoring/prometheus-operator/index.md
+++ b/docs/guides/mysql/monitoring/prometheus-operator/index.md
@@ -111,7 +111,7 @@ metadata:
   name: coreos-prom-mysql
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"
@@ -151,7 +151,7 @@ $ watch -n 3 kubectl get mysql -n demo coreos-prom-mysql
 Every 3.0s: kubectl get mysql -n demo coreos-prom-mysql         suaas-appscode: Tue Aug 25 11:53:34 2020
 
 NAME                VERSION      STATUS    AGE
-coreos-prom-mysql   8.0.21-v1    Running   2m53s
+coreos-prom-mysql   8.0.21-v2    Running   2m53s
 ```
 
 KubeDB will create a separate stats service with name `{MySQL crd name}-stats` for monitoring purpose.

--- a/docs/guides/mysql/monitoring/prometheus-operator/yamls/prom-operator-mysql.yaml
+++ b/docs/guides/mysql/monitoring/prometheus-operator/yamls/prom-operator-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: prom-operator-mysql
   namespace: demo
 spec:
-  version: "8.0.21-v1"
+  version: "8.0.21-v2"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/private-registry/index.md
+++ b/docs/guides/mysql/private-registry/index.md
@@ -30,13 +30,13 @@ KubeDB operator supports using private Docker registry. This tutorial will show 
   $ kubectl get mysqlversions -n kube-system  -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,DB_IMAGE:.spec.db.image,EXPORTER_IMAGE:.spec.exporter.image,REPLICATION_MODE_DETECTOR_IMAGE:.spec.replicationModeDetector.image,INITCONTAINER_IMAGE:.spec.initContainer.image,DEPRECATED:.spec.deprecated
   NAME        VERSION   DB_IMAGE                  EXPORTER_IMAGE                   REPLICATION_MODE_DETECTOR_IMAGE           INITCONTAINER_IMAGE   DEPRECATED
   5.7.25-v2   5.7.25    kubedb/mysql:5.7.25-v2    kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
-  5.7.29-v1   5.7.29    suaas21/mysql:5.7.29-v1   kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
-  5.7.31-v1   5.7.31    suaas21/mysql:5.7.31-v1   kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
-  5.7.33      5.7.33    suaas21/mysql:5.7.33      kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
+  5.7.29-v2   5.7.29    kubedb/mysql:5.7.29-v2    kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
+  5.7.31-v2   5.7.31    kubedb/mysql:5.7.31-v2    kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
+  5.7.33-v1   5.7.33    kubedb/mysql:5.7.33-v1    kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
   8.0.14-v2   8.0.14    kubedb/mysql:8.0.14-v2    kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
   8.0.20-v1   8.0.20    kubedb/mysql:8.0.20-v1    kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
-  8.0.21-v1   8.0.21    suaas21/mysql:8.0.21-v1   kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
-  8.0.23      8.0.23    suaas21/mysql:8.0.23      kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
+  8.0.21-v2   8.0.21    kubedb/mysql:8.0.21-v2    kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
+  8.0.23-v1   8.0.23    kubedb/mysql:8.0.23-v1    kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
   8.0.3-v2    8.0.3     kubedb/mysql:8.0.3-v2     kubedb/mysqld-exporter:v0.11.0   kubedb/replication-mode-detector:v0.3.2   kubedb/toybox:0.8.4   <none>
   ```
 
@@ -52,10 +52,10 @@ KubeDB operator supports using private Docker registry. This tutorial will show 
   apiVersion: catalog.kubedb.com/v1alpha1
   kind: MySQLVersion
   metadata:
-    name: 8.0.23
+    name: 8.0.23-v1
   spec:
     db:
-      image: PRIVATE_REGISTRY/mysql:8.0.23
+      image: PRIVATE_REGISTRY/mysql:8.0.23-v1
     distribution: Oracle
     exporter:
       image: PRIVATE_REGISTRY/mysqld-exporter:v0.11.0
@@ -122,7 +122,7 @@ metadata:
   name: mysql-pvt-reg
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mysql/private-registry/yamls/quickstart.yaml
+++ b/docs/guides/mysql/private-registry/yamls/quickstart.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/private-registry/yamls/standalone.yaml
+++ b/docs/guides/mysql/private-registry/yamls/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-pvt-reg
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mysql/quickstart/index.md
+++ b/docs/guides/mysql/quickstart/index.md
@@ -84,13 +84,13 @@ When you have installed KubeDB, it has created `MySQLVersion` crd for all suppor
 $ kubectl get mysqlversions
 NAME        VERSION   DB_IMAGE                  DEPRECATED   AGE
 5.7.25-v2   5.7.25    kubedb/mysql:5.7.25-v2                 3h55m
-5.7.29-v1   5.7.29    suaas21/mysql:5.7.29-v1                3h55m
-5.7.31-v1   5.7.31    suaas21/mysql:5.7.31-v1                3h55m
-5.7.33      5.7.33    suaas21/mysql:5.7.33                   3h55m
+5.7.29-v2   5.7.29    kubedb/mysql:5.7.29-v2                 3h55m
+5.7.31-v2   5.7.31    kubedb/mysql:5.7.31-v2                 3h55m
+5.7.33-v1   5.7.33    kubedb/mysql:5.7.33-v1                 3h55m
 8.0.14-v2   8.0.14    kubedb/mysql:8.0.14-v2                 3h55m
 8.0.20-v1   8.0.20    kubedb/mysql:8.0.20-v1                 3h55m
-8.0.21-v1   8.0.21    suaas21/mysql:8.0.21-v1                3h55m
-8.0.23      8.0.23    kubedb/mysql:8.0.23                    3h55m
+8.0.21-v2   8.0.21    kubedb/mysql:8.0.21-v2                 3h55m
+8.0.23-v1      8.0.23-v1    kubedb/mysql:8.0.23-v1                    3h55m
 8.0.3-v2    8.0.3     kubedb/mysql:8.0.3-v2                  3h55m
 ```
 
@@ -105,7 +105,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -124,7 +124,7 @@ mysql.kubedb.com/mysql-quickstart created
 
 Here,
 
-- `spec.version` is the name of the MySQLVersion CRD where the docker images are specified. In this tutorial, a MySQL `8.0.23` database is going to be created.
+- `spec.version` is the name of the MySQLVersion CRD where the docker images are specified. In this tutorial, a MySQL `8.0.23-v1` database is going to be created.
 - `spec.storageType` specifies the type of storage that will be used for MySQL database. It can be `Durable` or `Ephemeral`. Default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create MySQL database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the StatefulSet created by KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests.
 - `spec.terminationPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `MySQL` crd or which resources KubeDB should keep or delete when you delete `MySQL` crd. If admission webhook is enabled, It prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`. Learn details of all `TerminationPolicy` [here](/docs/guides/mysql/concepts/database/index.md#specterminationpolicy)
@@ -203,7 +203,7 @@ Database Secret:
 AppBinding:
   Metadata:
     Annotations:
-      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-quickstart","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"DoNotTerminate","version":"8.0.23"}}
+      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-quickstart","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"DoNotTerminate","version":"8.0.23-v1"}}
 
     Creation Timestamp:  2020-08-31T10:40:53Z
     Labels:
@@ -211,7 +211,7 @@ AppBinding:
       app.kubernetes.io/instance:    mysql-quickstart
       app.kubernetes.io/managed-by:  kubedb.com
       app.kubernetes.io/name:        mysql
-      app.kubernetes.io/version:     8.0.23
+      app.kubernetes.io/version:     8.0.23-v1
       app.kubernetes.io/name:        mysqls.kubedb.com
       app.kubernetes.io/instance:               mysql-quickstart
     Name:                            mysql-quickstart
@@ -227,7 +227,7 @@ AppBinding:
     Secret:
       Name:   mysql-quickstart-auth
     Type:     kubedb.com/mysql
-    Version:  8.0.23
+    Version:  8.0.23-v1
 
 Events:
   Type    Reason      Age   From            Message
@@ -267,7 +267,7 @@ kind: MySQL
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-quickstart","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"DoNotTerminate","version":"8.0.23"}}
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-quickstart","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"DoNotTerminate","version":"8.0.23-v1"}}
   creationTimestamp: "2020-08-27T12:19:42Z"
   finalizers:
   - kubedb.com
@@ -296,7 +296,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   terminationPolicy: DoNotTerminate
-  version: 8.0.23
+  version: 8.0.23-v1
 status:
   observedGeneration: 2
   phase: Running
@@ -436,7 +436,7 @@ Run the following command to get MySQL resources,
 ```bash
 $ kubectl get my,sts,secret,svc,pvc -n demo
 NAME                                VERSION   STATUS   AGE
-mysql.kubedb.com/mysql-quickstart   8.0.23    Halted   22m
+mysql.kubedb.com/mysql-quickstart   8.0.23-v1    Halted   22m
 
 NAME                           TYPE                                  DATA   AGE
 secret/default-token-lgbjm     kubernetes.io/service-account-token   3      27h

--- a/docs/guides/mysql/quickstart/yamls/quickstart.yaml
+++ b/docs/guides/mysql/quickstart/yamls/quickstart.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.0.21-v1"
+  version: "8.0.21-v2"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/scaling/horizontal-scaling/group-replication/index.md
+++ b/docs/guides/mysql/scaling/horizontal-scaling/group-replication/index.md
@@ -54,17 +54,17 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion
 NAME        VERSION   DB_IMAGE                  DEPRECATED   AGE
 5.7.25-v2   5.7.25    kubedb/mysql:5.7.25-v2                 3h55m
-5.7.29-v1   5.7.29    suaas21/mysql:5.7.29-v1                3h55m
-5.7.31-v1   5.7.31    suaas21/mysql:5.7.31-v1                3h55m
-5.7.33      5.7.33    suaas21/mysql:5.7.33                   3h55m
+5.7.29-v2   5.7.29    kubedb/mysql:5.7.29-v2                 3h55m
+5.7.31-v2   5.7.31    kubedb/mysql:5.7.31-v2                 3h55m
+5.7.33-v1   5.7.33    kubedb/mysql:5.7.33-v1                 3h55m
 8.0.14-v2   8.0.14    kubedb/mysql:8.0.14-v2                 3h55m
 8.0.20-v1   8.0.20    kubedb/mysql:8.0.20-v1                 3h55m
-8.0.21-v1   8.0.21    suaas21/mysql:8.0.21-v1                3h55m
-8.0.23      8.0.23    kubedb/mysql:8.0.23                    3h55m
+8.0.21-v2   8.0.21    kubedb/mysql:8.0.21-v2                 3h55m
+8.0.23-v1      8.0.23-v1    kubedb/mysql:8.0.23-v1                    3h55m
 8.0.3-v2    8.0.3     kubedb/mysql:8.0.3-v2                  3h55m
 ```
 
-The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a MySQL Group Replication using `MySQL`  `8.0.23`.
+The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a MySQL Group Replication using `MySQL`  `8.0.23-v1`.
 
 **Deploy MySQL Group Replication:**
 
@@ -77,7 +77,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -111,7 +111,7 @@ $ watch -n 3 kubectl get my -n demo my-group
 Every 3.0s: kubectl get my -n demo my-group                     suaas-appscode: Tue Jun 30 22:43:57 2020
 
 NAME       VERSION   STATUS    AGE
-my-group   8.0.23    Running   16m
+my-group   8.0.23-v1    Running   16m
 
 $ watch -n 3 kubectl get sts -n demo my-group
 Every 3.0s: kubectl get sts -n demo my-group                     Every 3.0s: kubectl get sts -n demo my-group                    suaas-appscode: Tue Jun 30 22:44:35 2020

--- a/docs/guides/mysql/scaling/horizontal-scaling/group-replication/yamls/group-replication.yaml
+++ b/docs/guides/mysql/scaling/horizontal-scaling/group-replication/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/scaling/vertical-scaling/group-replication/imdex.md
+++ b/docs/guides/mysql/scaling/vertical-scaling/group-replication/imdex.md
@@ -54,17 +54,17 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion
 NAME        VERSION   DB_IMAGE                  DEPRECATED   AGE
 5.7.25-v2   5.7.25    kubedb/mysql:5.7.25-v2                 3h55m
-5.7.29-v1   5.7.29    suaas21/mysql:5.7.29-v1                3h55m
-5.7.31-v1   5.7.31    suaas21/mysql:5.7.31-v1                3h55m
-5.7.33      5.7.33    suaas21/mysql:5.7.33                   3h55m
+5.7.29-v2   5.7.29    kubedb/mysql:5.7.29-v2                 3h55m
+5.7.31-v2   5.7.31    kubedb/mysql:5.7.31-v2                 3h55m
+5.7.33-v1   5.7.33    kubedb/mysql:5.7.33-v1                 3h55m
 8.0.14-v2   8.0.14    kubedb/mysql:8.0.14-v2                 3h55m
 8.0.20-v1   8.0.20    kubedb/mysql:8.0.20-v1                 3h55m
-8.0.21-v1   8.0.21    suaas21/mysql:8.0.21-v1                3h55m
-8.0.23      8.0.23    kubedb/mysql:8.0.23                    3h55m
+8.0.21-v2   8.0.21    kubedb/mysql:8.0.21-v2                 3h55m
+8.0.23-v1      8.0.23-v1    kubedb/mysql:8.0.23-v1                    3h55m
 8.0.3-v2    8.0.3     kubedb/mysql:8.0.3-v2                  3h55m
 ```
 
-The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a MySQL Group Replication using non-deprecated `MySQL` version `8.0.23`.
+The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a MySQL Group Replication using non-deprecated `MySQL` version `8.0.23-v1`.
 
 **Deploy MySQL Group Replication:**
 
@@ -77,7 +77,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -111,7 +111,7 @@ $ watch -n 3 kubectl get my -n demo my-group
 Every 3.0s: kubectl get my -n demo my-group                     suaas-appscode: Tue Jun 30 22:43:57 2020
 
 NAME       VERSION   STATUS    AGE
-my-group   8.0.23    Running   16m
+my-group   8.0.23-v1    Running   16m
 
 $ watch -n 3 kubectl get sts -n demo my-group
 Every 3.0s: kubectl get sts -n demo my-group                     Every 3.0s: kubectl get sts -n demo my-group                    suaas-appscode: Tue Jun 30 22:44:35 2020

--- a/docs/guides/mysql/scaling/vertical-scaling/group-replication/yamls/group-replication.yaml
+++ b/docs/guides/mysql/scaling/vertical-scaling/group-replication/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/scaling/vertical-scaling/standalone/index.md
+++ b/docs/guides/mysql/scaling/vertical-scaling/standalone/index.md
@@ -54,17 +54,17 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion
 NAME        VERSION   DB_IMAGE                  DEPRECATED   AGE
 5.7.25-v2   5.7.25    kubedb/mysql:5.7.25-v2                 3h55m
-5.7.29-v1   5.7.29    suaas21/mysql:5.7.29-v1                3h55m
-5.7.31-v1   5.7.31    suaas21/mysql:5.7.31-v1                3h55m
-5.7.33      5.7.33    suaas21/mysql:5.7.33                   3h55m
+5.7.29-v2   5.7.29    kubedb/mysql:5.7.29-v2                 3h55m
+5.7.31-v2   5.7.31    kubedb/mysql:5.7.31-v2                 3h55m
+5.7.33-v1   5.7.33    kubedb/mysql:5.7.33-v1                 3h55m
 8.0.14-v2   8.0.14    kubedb/mysql:8.0.14-v2                 3h55m
 8.0.20-v1   8.0.20    kubedb/mysql:8.0.20-v1                 3h55m
-8.0.21-v1   8.0.21    suaas21/mysql:8.0.21-v1                3h55m
-8.0.23      8.0.23    kubedb/mysql:8.0.23                    3h55m
+8.0.21-v2   8.0.21    kubedb/mysql:8.0.21-v2                 3h55m
+8.0.23-v1      8.0.23-v1    kubedb/mysql:8.0.23-v1                    3h55m
 8.0.3-v2    8.0.3     kubedb/mysql:8.0.3-v2                  3h55m
 ```
 
-The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a standalone using non-deprecated `MySQL`  version `8.0.23`.
+The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a standalone using non-deprecated `MySQL`  version `8.0.23-v1`.
 
 **Deploy MySQL Standalone:**
 
@@ -77,7 +77,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -106,7 +106,7 @@ $ watch -n 3 kubectl get my -n demo my-standalone
 Every 3.0s: kubectl get my -n demo my-standalone                 suaas-appscode: Wed Jul  1 17:48:14 2020
 
 NAME            VERSION      STATUS    AGE
-my-standalone   8.0.23    Running   2m58s
+my-standalone   8.0.23-v1    Running   2m58s
 
 $ watch -n 3 kubectl get sts -n demo my-standalone
 Every 3.0s: kubectl get sts -n demo my-standalone                suaas-appscode: Wed Jul  1 17:48:52 2020

--- a/docs/guides/mysql/scaling/vertical-scaling/standalone/yamls/standalone.yaml
+++ b/docs/guides/mysql/scaling/vertical-scaling/standalone/yamls/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/tls/configure/index.md
+++ b/docs/guides/mysql/tls/configure/index.md
@@ -90,7 +90,7 @@ metadata:
   name: my-standalone-tls
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -144,7 +144,7 @@ $ watch -n 3 kubectl get my -n demo my-standalone-tls
 Every 3.0s: kubectl get my -n demo my-standalone-tls            suaas-appscode: Thu Aug 13 18:12:39 2020
 
 NAME                VERSION   STATUS    AGE
-my-standalone-tls   8.0.23    Running   7m5s
+my-standalone-tls   8.0.23-v1    Running   7m5s
 
 $ watch -n 3 kubectl get sts -n demo my-standalone-tls
 Every 3.0s: kubectl get sts -n demo my-standalone-tls            suaas-appscode: Thu Aug 13 18:12:59 2020
@@ -325,7 +325,7 @@ metadata:
   name: my-group-tls
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -373,7 +373,7 @@ $ watch -n 3 kubectl get my -n demo my-group-tls
 Every 3.0s: kubectl get my -n demo my-group-tls                 suaas-appscode: Thu Aug 13 19:02:15 2020
 
 NAME           VERSION   STATUS    AGE
-my-group-tls   8.0.23    Running   9m41s
+my-group-tls   8.0.23-v1    Running   9m41s
 
 $ watch -n 3 kubectl get sts -n demo my-group-tls
 Every 3.0s: kubectl get sts -n demo my-group-tls                suaas-appscode: Thu Aug 13 19:02:42 2020

--- a/docs/guides/mysql/tls/configure/yamls/tls-group.yaml
+++ b/docs/guides/mysql/tls/configure/yamls/tls-group.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group-tls
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/tls/configure/yamls/tls-standalone.yaml
+++ b/docs/guides/mysql/tls/configure/yamls/tls-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone-tls
   namespace: demo
 spec:
-  version: "8.0.23"
+  version: "8.0.23-v1"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/upgrading/majorversion/group-replication/index.md
+++ b/docs/guides/mysql/upgrading/majorversion/group-replication/index.md
@@ -54,13 +54,13 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion 
 NAME        VERSION   DB_IMAGE                  DEPRECATED   AGE
 5.7.25-v2   5.7.25    kubedb/mysql:5.7.25-v2                 3h55m
-5.7.29-v1   5.7.29    suaas21/mysql:5.7.29-v1                3h55m
-5.7.31-v1   5.7.31    suaas21/mysql:5.7.31-v1                3h55m
-5.7.33      5.7.33    suaas21/mysql:5.7.33                   3h55m
+5.7.29-v2   5.7.29    kubedb/mysql:5.7.29-v2                 3h55m
+5.7.31-v2   5.7.31    kubedb/mysql:5.7.31-v2                 3h55m
+5.7.33-v1   5.7.33    kubedb/mysql:5.7.33-v1                 3h55m
 8.0.14-v2   8.0.14    kubedb/mysql:8.0.14-v2                 3h55m
 8.0.20-v1   8.0.20    kubedb/mysql:8.0.20-v1                 3h55m
-8.0.21-v1   8.0.21    suaas21/mysql:8.0.21-v1                3h55m
-8.0.23      8.0.23    kubedb/mysql:8.0.23                    3h55m
+8.0.21-v2   8.0.21    kubedb/mysql:8.0.21-v2                 3h55m
+8.0.23-v1   8.0.23    kubedb/mysql:8.0.23-v1                 3h55m
 8.0.3-v2    8.0.3     kubedb/mysql:8.0.3-v2                  3h55m
 ```
 
@@ -68,10 +68,10 @@ The version above that does not show `DEPRECATED` true is supported by `KubeDB` 
 
 **Check Upgrade Constraints:**
 
-Database version upgrade constraints is a constraint that shows whether it is possible or not possible to upgrade from one version to another. Let's check the version upgrade constraints of `MySQL` `5.7.31-v1`,
+Database version upgrade constraints is a constraint that shows whether it is possible or not possible to upgrade from one version to another. Let's check the version upgrade constraints of `MySQL` `5.7.31-v2`,
 
 ```bash
-$ kubectl get mysqlversion 5.7.31-v1 -o yaml | kubectl neat
+$ kubectl get mysqlversion 5.7.31-v2 -o yaml | kubectl neat
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion
 metadata:
@@ -84,10 +84,10 @@ metadata:
     app.kubernetes.io/name: kubedb-catalog
     app.kubernetes.io/version: v0.16.2
     helm.sh/chart: kubedb-catalog-v0.16.2
-  name: 5.7.31-v1
+  name: 5.7.31-v2
 spec:
   db:
-    image: suaas21/mysql:5.7.31-v1
+    image: kubedb/mysql:5.7.31-v2
   distribution: Oracle
   exporter:
     image: kubedb/mysqld-exporter:v0.11.0
@@ -112,7 +112,7 @@ spec:
   version: 5.7.31
 ```
 
-The above `spec.upgradeConstraints.denylist` of `5.7.31-v1` is showing that upgrading below version of `5.7.31-v1` is not possible for both group replication and standalone. That means, it is possible to upgrade any version above `5.7.31-v1`. Here, we are going to create a `MySQL` Group Replication using MySQL  `5.7.31-v1`. Then we are going to upgrade this version to `8.0.21-v1`.
+The above `spec.upgradeConstraints.denylist` of `5.7.31-v2` is showing that upgrading below version of `5.7.31-v2` is not possible for both group replication and standalone. That means, it is possible to upgrade any version above `5.7.31-v2`. Here, we are going to create a `MySQL` Group Replication using MySQL  `5.7.31-v2`. Then we are going to upgrade this version to `8.0.21-v2`.
 
 **Deploy MySQL Group Replication:**
 
@@ -125,7 +125,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -159,7 +159,7 @@ $ watch -n 3 kubectl get my -n demo my-group
 Every 3.0s: kubectl get my -n demo my-group                      suaas-appscode: Thu Jun 18 14:30:24 2020
 
 NAME       VERSION      STATUS    AGE
-my-group   5.7.31-v1    Running   5m52s
+my-group   5.7.31-v2    Running   5m52s
 
 $ watch -n 3 kubectl get sts -n demo my-group
 Every 3.0s: kubectl get sts -n demo my-group                     suaas-appscode: Thu Jun 18 14:31:44 2020
@@ -180,15 +180,15 @@ Let's verify the `MySQL`, the `StatefulSet` and its `Pod` image version,
 
 ```bash
 $ kubectl get my -n demo my-group -o=jsonpath='{.spec.version}{"\n"}'
-5.7.31-v1
+5.7.31-v2
 
 $ kubectl get sts -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
-"kubedb/mysql:5.7.31-v1"
+"kubedb/mysql:5.7.31-v2"
 
 $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.containers[1].image'
-"kubedb/mysql:5.7.31-v1"
-"kubedb/mysql:5.7.31-v1"
-"kubedb/mysql:5.7.31-v1"
+"kubedb/mysql:5.7.31-v2"
+"kubedb/mysql:5.7.31-v2"
+"kubedb/mysql:5.7.31-v2"
 ```
 
 Let's also verify that the StatefulSet’s pods have joined into a group replication,
@@ -215,7 +215,7 @@ We are ready to apply upgrading on this `MySQL` group replication.
 
 #### Upgrade
 
-Here, we are going to upgrade the `MySQL` group replication from `5.7.31-v1` to `8.0.21-v1`.
+Here, we are going to upgrade the `MySQL` group replication from `5.7.31-v2` to `8.0.21-v2`.
 
 **Create MySQLOpsRequest:**
 
@@ -232,14 +232,14 @@ spec:
   databaseRef:
     name: my-group
   upgrade:
-    targetVersion: "8.0.21-v1"
+    targetVersion: "8.0.21-v2"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
 - `spec.type` specifies that we are going to perform `Upgrade` on our database.
-- `spec.upgrade.targetVersion` specifies expected version `8.0.21-v1` after upgrading.
+- `spec.upgrade.targetVersion` specifies expected version `8.0.21-v2` after upgrading.
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 
@@ -293,7 +293,7 @@ Spec:
   Stateful Set Ordinal:  1
   Type:                  Upgrade
   Upgrade:
-    Target Version:  8.0.21-v1
+    Target Version:  8.0.21-v2
 Status:
   Conditions:
     Last Transition Time:  2021-03-10T08:50:47Z
@@ -343,15 +343,15 @@ Now, we are going to verify whether the `MySQL` and `StatefulSet` and it's `Pod`
 
 ```bash
 $ kubectl get my -n demo my-group -o=jsonpath='{.spec.version}{"\n"}'
-8.0.21-v1
+8.0.21-v2
 
 $ kubectl get sts -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
-"kubedb/mysql:8.0.21-v1"
+"kubedb/mysql:8.0.21-v2"
 
 $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.containers[1].image'
-"kubedb/mysql:8.0.21-v1"
-"kubedb/mysql:8.0.21-v1"
-"kubedb/mysql:8.0.21-v1"
+"kubedb/mysql:8.0.21-v2"
+"kubedb/mysql:8.0.21-v2"
+"kubedb/mysql:8.0.21-v2"
 ```
 
 Let's also check the StatefulSet pods have joined the `MySQL` group replication,

--- a/docs/guides/mysql/upgrading/majorversion/group-replication/yamls/group_replication.yaml
+++ b/docs/guides/mysql/upgrading/majorversion/group-replication/yamls/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.31-v1"
+  version: "5.7.31-v2"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/upgrading/majorversion/group-replication/yamls/upgrade_major_version_group.yaml
+++ b/docs/guides/mysql/upgrading/majorversion/group-replication/yamls/upgrade_major_version_group.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: my-group
   upgrade:
-    targetVersion: "8.0.21-v1"
+    targetVersion: "8.0.21-v2"

--- a/docs/guides/mysql/upgrading/majorversion/standalone/index.md
+++ b/docs/guides/mysql/upgrading/majorversion/standalone/index.md
@@ -54,13 +54,13 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion
 NAME        VERSION   DB_IMAGE                  DEPRECATED   AGE
 5.7.25-v2   5.7.25    kubedb/mysql:5.7.25-v2                 128m
-5.7.29-v1   5.7.29    suaas21/mysql:5.7.29-v1                128m
-5.7.31-v1   5.7.31    suaas21/mysql:5.7.31-v1                128m
-5.7.33      5.7.33    suaas21/mysql:5.7.33                   128m
+5.7.29-v2   5.7.29    kubedb/mysql:5.7.29-v2                 128m
+5.7.31-v2   5.7.31    kubedb/mysql:5.7.31-v2                 128m
+5.7.33-v1   5.7.33    kubedb/mysql:5.7.33-v1                 128m
 8.0.14-v2   8.0.14    kubedb/mysql:8.0.14-v2                 128m
 8.0.20-v1   8.0.20    kubedb/mysql:8.0.20-v1                 128m
-8.0.21-v1   8.0.21    suaas21/mysql:8.0.21-v1                128m
-8.0.23      8.0.23    kubedb/mysql:8.0.23                    128m
+8.0.21-v2   8.0.21    kubedb/mysql:8.0.21-v2                 128m
+8.0.23-v1   8.0.23    kubedb/mysql:8.0.23-v1                 128m
 8.0.3-v2    8.0.3     kubedb/mysql:8.0.3-v2                  128m
 ```
 
@@ -68,10 +68,10 @@ The version above that does not show `DEPRECATED` `true` is supported by `KubeDB
 
 **Check Upgrade Constraints:**
 
-Database version upgrade constraints is a constraint that shows whether it is possible or not possible to upgrade from one version to another. Let's check the version upgrade constraints of `MySQL` `5.7.31-v1`,
+Database version upgrade constraints is a constraint that shows whether it is possible or not possible to upgrade from one version to another. Let's check the version upgrade constraints of `MySQL` `5.7.31-v2`,
 
 ```bash
-$ kubectl get mysqlversion 5.7.31-v1 -o yaml | kubectl neat
+$ kubectl get mysqlversion 5.7.31-v2 -o yaml | kubectl neat
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion
 metadata:
@@ -84,10 +84,10 @@ metadata:
     app.kubernetes.io/name: kubedb-catalog
     app.kubernetes.io/version: v0.16.2
     helm.sh/chart: kubedb-catalog-v0.16.2
-  name: 5.7.31-v1
+  name: 5.7.31-v2
 spec:
   db:
-    image: suaas21/mysql:5.7.31-v1
+    image: kubedb/mysql:5.7.31-v2
   distribution: Oracle
   exporter:
     image: kubedb/mysqld-exporter:v0.11.0
@@ -112,7 +112,7 @@ spec:
   version: 5.7.31
 ```
 
-The above `spec.upgradeConstraints.denylist` is showing that upgrading below version of `5.7.31-v1` is not possible for both standalone and group replication. That means, it is possible to upgrade any version above `5.7.31-v1`. Here, we are going to create a `MySQL` standalone using MySQL  `5.7.31-v1`. Then we are going to upgrade this version to `8.0.21-v1`.
+The above `spec.upgradeConstraints.denylist` is showing that upgrading below version of `5.7.31-v2` is not possible for both standalone and group replication. That means, it is possible to upgrade any version above `5.7.31-v2`. Here, we are going to create a `MySQL` standalone using MySQL  `5.7.31-v2`. Then we are going to upgrade this version to `8.0.21-v2`.
 
 **Deploy MySQL standalone:**
 
@@ -125,7 +125,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -154,7 +154,7 @@ $ watch -n 3 kubectl get my -n demo my-standalone
 Every 3.0s: kubectl get my -n demo my-standalone                 suaas-appscode: Thu Jun 18 01:28:43 2020
 
 NAME            VERSION      STATUS    AGE
-my-standalone   5.7.31-v1    Running   3m
+my-standalone   5.7.31-v2    Running   3m
 
 $ watch -n 3 kubectl get sts -n demo my-standalone
 Every 3.0s: kubectl get sts -n demo my-standalone                suaas-appscode: Thu Jun 18 12:57:42 2020
@@ -173,20 +173,20 @@ Let's verify the `MySQL`, the `StatefulSet` and its `Pod` image version,
 
 ```bash
 $ kubectl get my -n demo my-standalone -o=jsonpath='{.spec.version}{"\n"}'
-5.7.31-v1
+5.7.31-v2
 
 $ kubectl get sts -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-kubedb/my:5.7.31-v1
+kubedb/my:5.7.31-v2
 
 $ kubectl get pod -n demo my-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-kubedb/my:5.7.31-v1
+kubedb/my:5.7.31-v2
 ```
 
 We are ready to apply upgrading on this `MySQL` standalone.
 
 #### Upgrade
 
-Here, we are going to upgrade `MySQL` standalone from `5.7.31-v1` to `8.0.21-v1`.
+Here, we are going to upgrade `MySQL` standalone from `5.7.31-v2` to `8.0.21-v2`.
 
 **Create MySQLOpsRequest:**
 
@@ -203,14 +203,14 @@ spec:
     name: my-standalone
   type: Upgrade
   upgrade:
-    targetVersion: "8.0.21-v1"
+    targetVersion: "8.0.21-v2"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
 - `spec.type` specifies that we are going to perform `Upgrade` on our database.
-- `spec.upgrade.targetVersion` specifies expected version `8.0.21-v1` after upgrading.
+- `spec.upgrade.targetVersion` specifies expected version `8.0.21-v2` after upgrading.
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 
@@ -261,7 +261,7 @@ Spec:
   Stateful Set Ordinal:  0
   Type:                  Upgrade
   Upgrade:
-    Target Version:  8.0.21-v1
+    Target Version:  8.0.21-v2
 Status:
   Conditions:
     Last Transition Time:  2021-03-10T08:38:48Z
@@ -308,13 +308,13 @@ Now, we are going to verify whether the `MySQL`, `StatefulSet` and it's `Pod` ha
 
 ```bash
 $ kubectl get my -n demo my-standalone -o=jsonpath='{.spec.version}{"\n"}'
-8.0.21-v1
+8.0.21-v2
 
 $ kubectl get sts -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-kubedb/my:8.0.21-v1
+kubedb/my:8.0.21-v2
 
 $ kubectl get pod -n demo my-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-kubedb/my:8.0.21-v1
+kubedb/my:8.0.21-v2
 ```
 
 You can see above that our `MySQL`standalone has been updated with the new version. It verifies that we have successfully upgraded our standalone.

--- a/docs/guides/mysql/upgrading/majorversion/standalone/yamls/standalone.yaml
+++ b/docs/guides/mysql/upgrading/majorversion/standalone/yamls/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "5.7.31-v1"
+  version: "5.7.31-v2"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/upgrading/majorversion/standalone/yamls/upgrade_major_version_standalone.yaml
+++ b/docs/guides/mysql/upgrading/majorversion/standalone/yamls/upgrade_major_version_standalone.yaml
@@ -8,4 +8,4 @@ spec:
     name: my-standalone
   type: Upgrade
   upgrade:
-    targetVersion: "8.0.21-v1"
+    targetVersion: "8.0.21-v2"

--- a/docs/guides/mysql/upgrading/minorversion/group-replication/index.md
+++ b/docs/guides/mysql/upgrading/minorversion/group-replication/index.md
@@ -54,13 +54,13 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion
 NAME        VERSION   DB_IMAGE                  DEPRECATED   AGE
 5.7.25-v2   5.7.25    kubedb/mysql:5.7.25-v2                 98m
-5.7.29-v1   5.7.29    suaas21/mysql:5.7.29-v1                98m
-5.7.31-v1   5.7.31    suaas21/mysql:5.7.31-v1                98m
-5.7.33      5.7.33    suaas21/mysql:5.7.33                   98m
+5.7.29-v2   5.7.29    kubedb/mysql:5.7.29-v2                 98m
+5.7.31-v2   5.7.31    kubedb/mysql:5.7.31-v2                 98m
+5.7.33-v1   5.7.33    kubedb/mysql:5.7.33-v1                 98m
 8.0.14-v2   8.0.14    kubedb/mysql:8.0.14-v2                 98m
 8.0.20-v1   8.0.20    kubedb/mysql:8.0.20-v1                 98m
-8.0.21-v1   8.0.21    suaas21/mysql:8.0.21-v1                98m
-8.0.23      8.0.23    kubedb/mysql:8.0.23                    98m
+8.0.21-v2   8.0.21    kubedb/mysql:8.0.21-v2                 98m
+8.0.23-v1   8.0.23    kubedb/mysql:8.0.23-v1                 98m
 8.0.3-v2    8.0.3     kubedb/mysql:8.0.3-v2                  98m
 ```
 
@@ -68,10 +68,10 @@ The version above that does not show `DEPRECATED` true is supported by `KubeDB` 
 
 **Check Upgrade Constraints:**
 
-Database version upgrade constraints is a constraint that shows whether it is possible or not possible to upgrade from one version to another. Let's check the version upgrade constraints of `MySQL` `5.7.29-v1`,
+Database version upgrade constraints is a constraint that shows whether it is possible or not possible to upgrade from one version to another. Let's check the version upgrade constraints of `MySQL` `5.7.29-v2`,
 
 ```bash
-$ kubectl get mysqlversion 5.7.29-v1 -o yaml
+$ kubectl get mysqlversion 5.7.29-v2 -o yaml
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion
 metadata:
@@ -84,10 +84,10 @@ metadata:
     app.kubernetes.io/name: kubedb-catalog
     app.kubernetes.io/version: v0.16.2
     helm.sh/chart: kubedb-catalog-v0.16.2
-  name: 5.7.29-v1
+  name: 5.7.29-v2
 spec:
   db:
-    image: suaas21/mysql:5.7.29-v1
+    image: kubedb/mysql:5.7.29-v2
   distribution: Oracle
   exporter:
     image: kubedb/mysqld-exporter:v0.11.0
@@ -112,7 +112,7 @@ spec:
   version: 5.7.29
 ```
 
-The above `spec.upgradeConstraints.denylist` of `5.7.29-v1` is showing that upgrading below version of `5.7.29-v1` is not possible for both group replication and standalone. That means, it is possible to upgrade any version above `5.7.29-v1`. Here, we are going to create a `MySQL` Group Replication using MySQL  `5.7.29-v1`. Then we are going to upgrade this version to `5.7.31-v1`.
+The above `spec.upgradeConstraints.denylist` of `5.7.29-v2` is showing that upgrading below version of `5.7.29-v2` is not possible for both group replication and standalone. That means, it is possible to upgrade any version above `5.7.29-v2`. Here, we are going to create a `MySQL` Group Replication using MySQL  `5.7.29-v2`. Then we are going to upgrade this version to `5.7.31-v2`.
 
 **Deploy MySQL Group Replication:**
 
@@ -125,7 +125,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -159,7 +159,7 @@ $ watch -n 3 kubectl get my -n demo my-group
 Every 3.0s: kubectl get my -n demo my-group                      suaas-appscode: Thu Jun 18 14:30:24 2020
 
 NAME       VERSION   STATUS    AGE
-my-group   5.7.29-v1    Running   5m52s
+my-group   5.7.29-v2    Running   5m52s
 
 $ watch -n 3 kubectl get sts -n demo my-group
 Every 3.0s: kubectl get sts -n demo my-group                     suaas-appscode: Thu Jun 18 14:31:44 2020
@@ -180,15 +180,15 @@ Let's verify the `MySQL`, the `StatefulSet` and its `Pod` image version,
 
 ```bash
 $ kubectl get my -n demo my-group -o=jsonpath='{.spec.version}{"\n"}'
-5.7.29-v1
+5.7.29-v2
 
 $ kubectl get sts -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
-"kubedb/my:5.7.29-v1"
+"kubedb/my:5.7.29-v2"
 
 $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.containers[1].image'
-"kubedb/my:5.7.29-v1"
-"kubedb/my:5.7.29-v1"
-"kubedb/my:5.7.29-v1"
+"kubedb/my:5.7.29-v2"
+"kubedb/my:5.7.29-v2"
+"kubedb/my:5.7.29-v2"
 ```
 
 Let's also verify that the StatefulSet’s pods have joined into the group replication,
@@ -215,7 +215,7 @@ We are ready to apply upgrading on this `MySQL` group replication.
 
 #### Upgrade
 
-Here, we are going to upgrade the `MySQL` group replication from `5.7.29-v1` to `5.7.31-v1`.
+Here, we are going to upgrade the `MySQL` group replication from `5.7.29-v2` to `5.7.31-v2`.
 
 **Create MySQLOpsRequest:**
 
@@ -232,7 +232,7 @@ spec:
   databaseRef:
     name: my-group
   upgrade:
-    targetVersion: "5.7.31-v1"
+    targetVersion: "5.7.31-v2"
 ```
 
 Here,
@@ -299,7 +299,7 @@ Spec:
   Stateful Set Ordinal:  0
   Type:                  Upgrade
   Upgrade:
-    Target Version:  5.7.31-v1
+    Target Version:  5.7.31-v2
 Status:
   Conditions:
     Last Transition Time:  2021-03-10T06:42:13Z
@@ -348,15 +348,15 @@ Now, we are going to verify whether the `MySQL` and `StatefulSet` and it's `Pod`
 
 ```bash
 $ kubectl get my -n demo my-group -o=jsonpath='{.spec.version}{"\n"}'
-5.7.31-v1
+5.7.31-v2
 
 $ kubectl get sts -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
-"kubedb/mysql:5.7.31-v1"
+"kubedb/mysql:5.7.31-v2"
 
 $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.containers[1].image'
-"suaas21/mysql:5.7.31-v1"
-"suaas21/mysql:5.7.31-v1"
-"suaas21/mysql:5.7.31-v1"
+"kubedb/mysql:5.7.31-v2"
+"kubedb/mysql:5.7.31-v2"
+"kubedb/mysql:5.7.31-v2"
 ```
 
 Let's also check the StatefulSet pods have joined the `MySQL` group replication,

--- a/docs/guides/mysql/upgrading/minorversion/group-replication/yamls/group_replication.yaml
+++ b/docs/guides/mysql/upgrading/minorversion/group-replication/yamls/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.29-v1"
+  version: "5.7.29-v2"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/upgrading/minorversion/group-replication/yamls/upgrade_minor_version_group.yaml
+++ b/docs/guides/mysql/upgrading/minorversion/group-replication/yamls/upgrade_minor_version_group.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: my-group
   upgrade:
-    targetVersion: "5.7.31-v1"
+    targetVersion: "5.7.31-v2"

--- a/docs/guides/mysql/upgrading/minorversion/standalone/index.md
+++ b/docs/guides/mysql/upgrading/minorversion/standalone/index.md
@@ -54,13 +54,13 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion
 NAME        VERSION   DB_IMAGE                 DEPRECATED   AGE
 5.7.25-v2   5.7.25    kubedb/mysql:5.7.25-v2                8s
-5.7.29-v1   5.7.29    kubedb/mysql:5.7.29-v1                8s
-5.7.31-v1   5.7.31    kubedb/mysql:5.7.31-v1                8s
-5.7.33      5.7.33    kubedb/mysql:5.7.33                   8s
+5.7.29-v2   5.7.29    kubedb/mysql:5.7.29-v2                8s
+5.7.31-v2   5.7.31    kubedb/mysql:5.7.31-v2                8s
+5.7.33-v1   5.7.33    kubedb/mysql:5.7.33-v1                8s
 8.0.14-v2   8.0.14    kubedb/mysql:8.0.14-v2                8s
 8.0.20-v1   8.0.20    kubedb/mysql:8.0.20-v1                8s
-8.0.21-v1   8.0.21    kubedb/mysql:8.0.21-v1                8s
-8.0.23      8.0.23    kubedb/mysql:8.0.23                   8s
+8.0.21-v2   8.0.21    kubedb/mysql:8.0.21-v2                8s
+8.0.23-v1   8.0.23    kubedb/mysql:8.0.23-v1                8s
 8.0.3-v2    8.0.3     kubedb/mysql:8.0.3-v2                 8s
 ```
 
@@ -68,10 +68,10 @@ The version above that does not show `DEPRECATED` `true` is supported by `KubeDB
 
 **Check Upgrade Constraints:**
 
-Database version upgrade constraints is a constraint that shows whether it is possible or not possible to upgrade from one version to another. Let's check the version upgrade constraints of `MySQL` `5.7.29-v1`,
+Database version upgrade constraints is a constraint that shows whether it is possible or not possible to upgrade from one version to another. Let's check the version upgrade constraints of `MySQL` `5.7.29-v2`,
 
 ```bash
-$ kubectl get mysqlversion 5.7.29-v1 -o yaml
+$ kubectl get mysqlversion 5.7.29-v2 -o yaml
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion
 metadata:
@@ -84,10 +84,10 @@ metadata:
     app.kubernetes.io/name: kubedb-catalog
     app.kubernetes.io/version: v0.16.2
     helm.sh/chart: kubedb-catalog-v0.16.2
-  name: 5.7.29-v1
+  name: 5.7.29-v2
 spec:
   db:
-    image: suaas21/mysql:5.7.29-v1
+    image: kubedb/mysql:5.7.29-v2
   exporter:
     image: kubedb/mysqld-exporter:v0.11.0
   initContainer:
@@ -111,7 +111,7 @@ spec:
   version: 5.7.29
 ```
 
-The above `spec.upgradeConstraints.denylist` is showing that upgrading below version of `5.7.29-v1` is not possible for both standalone and group replication. That means, it is possible to upgrade any version above `5.7.29-v1`. Here, we are going to create a `MySQL` standalone using MySQL  `5.7.29-v1`. Then we are going to upgrade this version to `5.7.31-v1`.
+The above `spec.upgradeConstraints.denylist` is showing that upgrading below version of `5.7.29-v2` is not possible for both standalone and group replication. That means, it is possible to upgrade any version above `5.7.29-v2`. Here, we are going to create a `MySQL` standalone using MySQL  `5.7.29-v2`. Then we are going to upgrade this version to `5.7.31-v2`.
 
 **Deploy MySQL standalone:**
 
@@ -124,7 +124,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -153,7 +153,7 @@ $ watch -n 3 kubectl get my -n demo my-standalone
 Every 3.0s: kubectl get my -n demo my-standalone                 suaas-appscode: Thu Jun 18 01:28:43 2020
 
 NAME            VERSION      STATUS    AGE
-my-standalone   5.7.29-v1    Running   3m
+my-standalone   5.7.29-v2    Running   3m
 
 $ watch -n 3 kubectl get sts -n demo my-standalone
 Every 3.0s: kubectl get sts -n demo my-standalone                suaas-appscode: Thu Jun 18 12:57:42 2020
@@ -172,20 +172,20 @@ Let's verify the `MySQL`, the `StatefulSet` and its `Pod` image version,
 
 ```bash
 $ kubectl get my -n demo my-standalone -o=jsonpath='{.spec.version}{"\n"}'
-5.7.29-v1
+5.7.29-v2
 
 $ kubectl get sts -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-kubedb/my:5.7.29-v1
+kubedb/my:5.7.29-v2
 
 $ kubectl get pod -n demo my-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-kubedb/my:5.7.29-v1
+kubedb/my:5.7.29-v2
 ```
 
 We are ready to apply upgrading on this `MySQL` standalone.
 
 #### Upgrade
 
-Here, we are going to upgrade `MySQL` standalone from `5.7.29-v1` to `5.7.31-v1`.
+Here, we are going to upgrade `MySQL` standalone from `5.7.29-v2` to `5.7.31-v2`.
 
 **Create MySQLOpsRequest:**
 
@@ -202,14 +202,14 @@ spec:
     name: my-standalone
   type: Upgrade
   upgrade:
-    targetVersion: "5.7.31-v1"
+    targetVersion: "5.7.31-v2"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
 - `spec.type` specifies that we are going to perform `Upgrade` on our database.
-- `spec.upgrade.targetVersion` specifies expected version `5.7.31-v1` after upgrading.
+- `spec.upgrade.targetVersion` specifies expected version `5.7.31-v2` after upgrading.
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 
@@ -254,7 +254,7 @@ Spec:
   Stateful Set Ordinal:  0
   Type:                  Upgrade
   Upgrade:
-    Target Version:  5.7.31-v1
+    Target Version:  5.7.31-v2
 Status:
   Conditions:
     Last Transition Time:  2021-03-10T06:23:10Z
@@ -301,13 +301,13 @@ Now, we are going to verify whether the `MySQL`, `StatefulSet` and it's `Pod` ha
 
 ```bash
 $ kubectl get my -n demo my-standalone -o=jsonpath='{.spec.version}{"\n"}'
-5.7.31-v1
+5.7.31-v2
 
 $ kubectl get sts -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-kubedb/my:5.7.31-v1
+kubedb/my:5.7.31-v2
 
 $ kubectl get pod -n demo my-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-kubedb/my:5.7.31-v1
+kubedb/my:5.7.31-v2
 ```
 
 You can see above that our `MySQL`standalone has been updated with the new version. It verifies that we have successfully upgraded our standalone.

--- a/docs/guides/mysql/upgrading/minorversion/standalone/yamls/standalone.yaml
+++ b/docs/guides/mysql/upgrading/minorversion/standalone/yamls/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "5.7.29-v1"
+  version: "5.7.29-v2"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/upgrading/minorversion/standalone/yamls/upgrade_minor_version_standalone.yaml
+++ b/docs/guides/mysql/upgrading/minorversion/standalone/yamls/upgrade_minor_version_standalone.yaml
@@ -8,4 +8,4 @@ spec:
     name: my-standalone
   type: Upgrade
   upgrade:
-    targetVersion: "5.7.31-v1"
+    targetVersion: "5.7.31-v2"

--- a/docs/guides/proxysql/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/proxysql/monitoring/using-builtin-prometheus.md
@@ -53,7 +53,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/monitoring/using-prometheus-operator.md
+++ b/docs/guides/proxysql/monitoring/using-prometheus-operator.md
@@ -103,7 +103,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/quickstart/load-balance-mysql-group-replication.md
+++ b/docs/guides/proxysql/quickstart/load-balance-mysql-group-replication.md
@@ -55,7 +55,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.33"
+  version: "5.7.33-v1"
   replicas: 3
   topology:
     mode: GroupReplication


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.06.21-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/38
Signed-off-by: 1gtm <1gtm@appscode.com>