### PR TITLE
Prepare for release v2022.08.02-rc.0

### DIFF
--- a/docs/CHANGELOG-v2022.08.02-rc.0.md
+++ b/docs/CHANGELOG-v2022.08.02-rc.0.md
@@ -1,0 +1,367 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2022.08.02-rc.0
+    name: Changelog-v2022.08.02-rc.0
+    parent: welcome
+    weight: 20220802
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.08.02-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.08.02-rc.0/
+---
+
+# KubeDB v2022.08.02-rc.0 (2022-08-02)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/apimachinery/releases/tag/v0.28.0-rc.0)
+
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.13.0-rc.0](https://github.com/kubedb/autoscaler/releases/tag/v0.13.0-rc.0)
+
+- [896d0bb5](https://github.com/kubedb/autoscaler/commit/896d0bb5) Prepare for release v0.13.0-rc.0 (#95)
+- [a904819e](https://github.com/kubedb/autoscaler/commit/a904819e) Update db-client-go (#94)
+- [049b959a](https://github.com/kubedb/autoscaler/commit/049b959a) Acquire license from license-proxyserver if available (#93)
+- [6f47ba7d](https://github.com/kubedb/autoscaler/commit/6f47ba7d) Use MemoryUsedPercentage as float (#92)
+- [2f41e629](https://github.com/kubedb/autoscaler/commit/2f41e629) Fix mongodb inMemory calculation and changes for updated autoscaler CRD (#91)
+- [a0d00ea2](https://github.com/kubedb/autoscaler/commit/a0d00ea2) Update mongodb inmemory recommendation logic (#90)
+- [7fd346e6](https://github.com/kubedb/autoscaler/commit/7fd346e6) Change some in-memory recommendation logic (#89)
+- [00b9087f](https://github.com/kubedb/autoscaler/commit/00b9087f) Convert to KubeBuilder style (#88)
+- [9a3599ac](https://github.com/kubedb/autoscaler/commit/9a3599ac) Update dependencies
+- [7260dc2f](https://github.com/kubedb/autoscaler/commit/7260dc2f) Add custom recommender for dbs (#85)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/cli/releases/tag/v0.28.0-rc.0)
+
+- [902c36b2](https://github.com/kubedb/cli/commit/902c36b2) Prepare for release v0.28.0-rc.0 (#671)
+- [e0564ec0](https://github.com/kubedb/cli/commit/e0564ec0) Acquire license from license-proxyserver if available (#670)
+- [da3169be](https://github.com/kubedb/cli/commit/da3169be) Update for release Stash@v2022.07.09 (#669)
+- [38b1149c](https://github.com/kubedb/cli/commit/38b1149c) Update for release Stash@v2022.06.21 (#668)
+- [09bb7b93](https://github.com/kubedb/cli/commit/09bb7b93) Update to k8s 1.24 toolchain (#666)
+- [1642a399](https://github.com/kubedb/cli/commit/1642a399) Update to k8s 1.24 toolchain (#665)
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.4.0-rc.0](https://github.com/kubedb/dashboard/releases/tag/v0.4.0-rc.0)
+
+- [26e7432](https://github.com/kubedb/dashboard/commit/26e7432) Prepare for release v0.4.0-rc.0 (#32)
+- [60f3154](https://github.com/kubedb/dashboard/commit/60f3154) Acquire license from license-proxyserver if available (#31)
+- [9b18e46](https://github.com/kubedb/dashboard/commit/9b18e46) Update to k8s 1.24 toolchain (#29)
+- [5ce68d1](https://github.com/kubedb/dashboard/commit/5ce68d1) Update to k8s 1.24 toolchain (#28)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.28.0-rc.0)
+
+- [6991fc7a](https://github.com/kubedb/elasticsearch/commit/6991fc7a3) Prepare for release v0.28.0-rc.0 (#592)
+- [d8df80d1](https://github.com/kubedb/elasticsearch/commit/d8df80d1c) Update db-client-go (#591)
+- [177990ef](https://github.com/kubedb/elasticsearch/commit/177990efa) Make Changes for newKBClient() args removal (#590)
+- [3c704bdc](https://github.com/kubedb/elasticsearch/commit/3c704bdc1) Acquire license from license-proxyserver if available (#589)
+- [46e8fa20](https://github.com/kubedb/elasticsearch/commit/46e8fa201) Add support for volumes and volumeMounts (#588)
+- [51536415](https://github.com/kubedb/elasticsearch/commit/515364158) Re-construct Elasticsearch health checker (#587)
+- [cc1a8224](https://github.com/kubedb/elasticsearch/commit/cc1a8224a) SKIP_IMAGE_DIGEST for dev builds (#586)
+- [c1c84b12](https://github.com/kubedb/elasticsearch/commit/c1c84b124) Use docker image with digest value (#579)
+- [5594ad03](https://github.com/kubedb/elasticsearch/commit/5594ad035) Change credential sync log level to avoid operator log overloading (#584)
+- [6c40c79e](https://github.com/kubedb/elasticsearch/commit/6c40c79ed) Revert es client version
+- [e6621d98](https://github.com/kubedb/elasticsearch/commit/e6621d980) Update to k8s 1.24 toolchain (#580)
+- [93fd95b6](https://github.com/kubedb/elasticsearch/commit/93fd95b65) Test against Kubernetes 1.24.0 (#578)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2022.08.02-rc.0](https://github.com/kubedb/installer/releases/tag/v2022.08.02-rc.0)
+
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.12.0-rc.0](https://github.com/kubedb/mariadb/releases/tag/v0.12.0-rc.0)
+
+- [8ed9b5e8](https://github.com/kubedb/mariadb/commit/8ed9b5e8) Prepare for release v0.12.0-rc.0 (#161)
+- [7eb4d546](https://github.com/kubedb/mariadb/commit/7eb4d546) Acquire license from license-proxyserver if available (#160)
+- [16dc94dd](https://github.com/kubedb/mariadb/commit/16dc94dd) Add custom volume and volume mount support (#159)
+- [d03b7ab3](https://github.com/kubedb/mariadb/commit/d03b7ab3) Update MariaDB Health check (#155)
+- [ac7fc040](https://github.com/kubedb/mariadb/commit/ac7fc040) Add syncAndValidate for secrets | Not delete custom auth secrets (#153)
+- [75a280b3](https://github.com/kubedb/mariadb/commit/75a280b3) SKIP_IMAGE_DIGEST for dev builds (#158)
+- [09e31be1](https://github.com/kubedb/mariadb/commit/09e31be1) Fix MariaDB not ready condition after removing halt (#157)
+- [29934625](https://github.com/kubedb/mariadb/commit/29934625) Add digest value on docker image (#154)
+- [a73717c8](https://github.com/kubedb/mariadb/commit/a73717c8) Update to k8s 1.24 toolchain (#151)
+- [ff6e83e5](https://github.com/kubedb/mariadb/commit/ff6e83e5) Update to k8s 1.24 toolchain (#150)
+- [c1dba654](https://github.com/kubedb/mariadb/commit/c1dba654) Test against Kubernetes 1.24.0 (#148)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.8.0-rc.0](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.8.0-rc.0)
+
+- [82bad04](https://github.com/kubedb/mariadb-coordinator/commit/82bad04) Prepare for release v0.8.0-rc.0 (#50)
+- [487fdbb](https://github.com/kubedb/mariadb-coordinator/commit/487fdbb) Acquire license from license-proxyserver if available (#49)
+- [b2565e4](https://github.com/kubedb/mariadb-coordinator/commit/b2565e4) Add primary component detector (#48)
+- [84810c8](https://github.com/kubedb/mariadb-coordinator/commit/84810c8) Fix custom auth secret failure (#47)
+- [7261a98](https://github.com/kubedb/mariadb-coordinator/commit/7261a98) Update to k8s 1.24 toolchain (#45)
+- [3c23773](https://github.com/kubedb/mariadb-coordinator/commit/3c23773) Update to k8s 1.24 toolchain (#44)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.21.0-rc.0](https://github.com/kubedb/memcached/releases/tag/v0.21.0-rc.0)
+
+- [6fcbc121](https://github.com/kubedb/memcached/commit/6fcbc121) Prepare for release v0.21.0-rc.0 (#360)
+- [8d43bd1e](https://github.com/kubedb/memcached/commit/8d43bd1e) Acquire license from license-proxyserver if available (#359)
+- [cd2fa52b](https://github.com/kubedb/memcached/commit/cd2fa52b) Fix validator webhook api group
+- [71c254a7](https://github.com/kubedb/memcached/commit/71c254a7) Update to k8s 1.24 toolchain (#357)
+- [0545e187](https://github.com/kubedb/memcached/commit/0545e187) Test against Kubernetes 1.24.0 (#356)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.21.0-rc.0](https://github.com/kubedb/mongodb/releases/tag/v0.21.0-rc.0)
+
+- [c0a023d2](https://github.com/kubedb/mongodb/commit/c0a023d2) Prepare for release v0.21.0-rc.0 (#496)
+- [0b56bec3](https://github.com/kubedb/mongodb/commit/0b56bec3) Update db-client-go (#495)
+- [7126f7f1](https://github.com/kubedb/mongodb/commit/7126f7f1) getExporterContainer only if monitoring enabled (#494)
+- [cdd6adbc](https://github.com/kubedb/mongodb/commit/cdd6adbc) Acquire license from license-proxyserver if available (#493)
+- [c598db8e](https://github.com/kubedb/mongodb/commit/c598db8e) Add `--collect-all` exporter container cmd args (#487)
+- [dc2fce0d](https://github.com/kubedb/mongodb/commit/dc2fce0d) Add InMemory validations & some refactoration (#491)
+- [991588ef](https://github.com/kubedb/mongodb/commit/991588ef) Add support for custom volumes (#492)
+- [4fc305c0](https://github.com/kubedb/mongodb/commit/4fc305c0) Update Health Checker (#480)
+- [3be64a6b](https://github.com/kubedb/mongodb/commit/3be64a6b) SKIP_IMAGE_DIGEST for dev builds (#490)
+- [3fd70298](https://github.com/kubedb/mongodb/commit/3fd70298) Use docker images with digest value (#486)
+- [c7325a29](https://github.com/kubedb/mongodb/commit/c7325a29) Fix connection leak when ping fails (#485)
+- [4ff96a0e](https://github.com/kubedb/mongodb/commit/4ff96a0e) Use kubebuilder client for db-client-go (#484)
+- [4094f54a](https://github.com/kubedb/mongodb/commit/4094f54a) Update to k8s 1.24 toolchain (#482)
+- [2e56a4e9](https://github.com/kubedb/mongodb/commit/2e56a4e9) Update to k8s 1.24 toolchain (#481)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.21.0-rc.0](https://github.com/kubedb/mysql/releases/tag/v0.21.0-rc.0)
+
+- [15f1a9dd](https://github.com/kubedb/mysql/commit/15f1a9dd) Prepare for release v0.21.0-rc.0 (#484)
+- [43f733a3](https://github.com/kubedb/mysql/commit/43f733a3) Acquire license from license-proxyserver if available (#483)
+- [0c88f473](https://github.com/kubedb/mysql/commit/0c88f473) Use GetCertSecret instead of MustCertSecretName (#482)
+- [afb1c070](https://github.com/kubedb/mysql/commit/afb1c070) Add support for Custom volume and volume mounts (#481)
+- [4f167ef8](https://github.com/kubedb/mysql/commit/4f167ef8) Update MySQL healthchecker (#480)
+- [05d5179e](https://github.com/kubedb/mysql/commit/05d5179e) Update read replica Auth secret (#477)
+- [d36e09de](https://github.com/kubedb/mysql/commit/d36e09de) upsert volumes with existing volumes. (#476)
+- [e51c7d79](https://github.com/kubedb/mysql/commit/e51c7d79) Use docker image with digest value (#475)
+- [574fc526](https://github.com/kubedb/mysql/commit/574fc526) SKIP_IMAGE_DIGEST for dev builds (#479)
+- [10dd0b78](https://github.com/kubedb/mysql/commit/10dd0b78) Fix not ready condition after removing halt (#478)
+- [3c514bae](https://github.com/kubedb/mysql/commit/3c514bae) Update to k8s 1.24 toolchain (#473)
+- [6a09468a](https://github.com/kubedb/mysql/commit/6a09468a) Update to k8s 1.24 toolchain (#472)
+- [04c925b5](https://github.com/kubedb/mysql/commit/04c925b5) Test against Kubernetes 1.24.0 (#471)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.6.0-rc.0](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.6.0-rc.0)
+
+- [7c79e5f](https://github.com/kubedb/mysql-coordinator/commit/7c79e5f) Prepare for release v0.6.0-rc.0 (#42)
+- [2eb313d](https://github.com/kubedb/mysql-coordinator/commit/2eb313d) Acquire license from license-proxyserver if available (#40)
+- [6116c0e](https://github.com/kubedb/mysql-coordinator/commit/6116c0e) Read replica count from db object If sts not found (#39)
+- [40d1007](https://github.com/kubedb/mysql-coordinator/commit/40d1007) fix custom auth secret issue (#38)
+- [a72d3a9](https://github.com/kubedb/mysql-coordinator/commit/a72d3a9) Update to k8s 1.24 toolchain (#37)
+- [593433a](https://github.com/kubedb/mysql-coordinator/commit/593433a) Update dependencies (#36)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.6.0-rc.0](https://github.com/kubedb/mysql-router-init/releases/tag/v0.6.0-rc.0)
+
+- [445a2ff](https://github.com/kubedb/mysql-router-init/commit/445a2ff) Acquire license from license-proxyserver if available (#23)
+- [28eb2d4](https://github.com/kubedb/mysql-router-init/commit/28eb2d4) Update to k8s 1.24 toolchain (#22)
+- [40d3dd9](https://github.com/kubedb/mysql-router-init/commit/40d3dd9) Update to k8s 1.24 toolchain (#21)
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.15.0-rc.0](https://github.com/kubedb/ops-manager/releases/tag/v0.15.0-rc.0)
+
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.15.0-rc.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.15.0-rc.0)
+
+- [4970d99b](https://github.com/kubedb/percona-xtradb/commit/4970d99b) Prepare for release v0.15.0-rc.0 (#264)
+- [d1896876](https://github.com/kubedb/percona-xtradb/commit/d1896876) Acquire license from license-proxyserver if available (#263)
+- [8e65e97d](https://github.com/kubedb/percona-xtradb/commit/8e65e97d) Add custom volume and volume mount support (#262)
+- [1866eed1](https://github.com/kubedb/percona-xtradb/commit/1866eed1) Add Percona XtraDB Cluster Support (#237)
+- [501c5a18](https://github.com/kubedb/percona-xtradb/commit/501c5a18) Update to k8s 1.24 toolchain (#260)
+- [e632ea56](https://github.com/kubedb/percona-xtradb/commit/e632ea56) Test against Kubernetes 1.24.0 (#259)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.12.0-rc.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.12.0-rc.0)
+
+- [e066e950](https://github.com/kubedb/pg-coordinator/commit/e066e950) Prepare for release v0.12.0-rc.0 (#85)
+- [e3256a32](https://github.com/kubedb/pg-coordinator/commit/e3256a32) Acquire license from license-proxyserver if available (#83)
+- [909c225e](https://github.com/kubedb/pg-coordinator/commit/909c225e) Remove role scripts from the coordinator. (#82)
+- [fdd2a4ad](https://github.com/kubedb/pg-coordinator/commit/fdd2a4ad) Update to k8s 1.24 toolchain (#81)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.15.0-rc.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.15.0-rc.0)
+
+- [09815675](https://github.com/kubedb/pgbouncer/commit/09815675) Prepare for release v0.15.0-rc.0 (#230)
+- [6e18d967](https://github.com/kubedb/pgbouncer/commit/6e18d967) Acquire license from license-proxyserver if available (#229)
+- [4d042db4](https://github.com/kubedb/pgbouncer/commit/4d042db4) Update healthcheck (#228)
+- [22cf136d](https://github.com/kubedb/pgbouncer/commit/22cf136d) Add digest value on docker image (#227)
+- [3e9914c9](https://github.com/kubedb/pgbouncer/commit/3e9914c9) Update test for PgBouncer (#219)
+- [92662071](https://github.com/kubedb/pgbouncer/commit/92662071) SKIP_IMAGE_DIGEST for dev builds (#226)
+- [a62c708f](https://github.com/kubedb/pgbouncer/commit/a62c708f) Update to k8s 1.24 toolchain (#224)
+- [061e53fe](https://github.com/kubedb/pgbouncer/commit/061e53fe) Update to k8s 1.24 toolchain (#223)
+- [a89ce8fd](https://github.com/kubedb/pgbouncer/commit/a89ce8fd) Test against Kubernetes 1.24.0 (#222)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/postgres/releases/tag/v0.28.0-rc.0)
+
+- [e2a4636b](https://github.com/kubedb/postgres/commit/e2a4636b) Prepare for release v0.28.0-rc.0 (#582)
+- [8f861234](https://github.com/kubedb/postgres/commit/8f861234) Acquire license from license-proxyserver if available (#581)
+- [52f6820d](https://github.com/kubedb/postgres/commit/52f6820d) Add Custom Volume and VolumeMount Support (#580)
+- [34f8283f](https://github.com/kubedb/postgres/commit/34f8283f) Update Postgres  health check (#578)
+- [ad40ece7](https://github.com/kubedb/postgres/commit/ad40ece7) Use docker image with digest value (#579)
+- [c51a4716](https://github.com/kubedb/postgres/commit/c51a4716) Update: remove sidecar from standalone. (#576)
+- [514ef2bd](https://github.com/kubedb/postgres/commit/514ef2bd) SKIP_IMAGE_DIGEST for dev builds (#577)
+- [2bc43818](https://github.com/kubedb/postgres/commit/2bc43818) Update to k8s 1.24 toolchain (#575)
+- [8e2a02a3](https://github.com/kubedb/postgres/commit/8e2a02a3) Test against Kubernetes 1.24.0 (#574)
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/provisioner/releases/tag/v0.28.0-rc.0)
+
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.15.0-rc.0](https://github.com/kubedb/proxysql/releases/tag/v0.15.0-rc.0)
+
+- [89e4767d](https://github.com/kubedb/proxysql/commit/89e4767d) Prepare for release v0.15.0-rc.0 (#243)
+- [a4c92b9b](https://github.com/kubedb/proxysql/commit/a4c92b9b) Acquire license from license-proxyserver if available (#242)
+- [fb6f2301](https://github.com/kubedb/proxysql/commit/fb6f2301) Rewrite ProxySQL HealthChecker (#241)
+- [a6c80651](https://github.com/kubedb/proxysql/commit/a6c80651) Add proxysql declarative configuration (#239)
+- [1d9c415c](https://github.com/kubedb/proxysql/commit/1d9c415c) SKIP_IMAGE_DIGEST for dev builds (#240)
+- [23a85c85](https://github.com/kubedb/proxysql/commit/23a85c85) Update to k8s 1.24 toolchain (#237)
+- [a93f8f4e](https://github.com/kubedb/proxysql/commit/a93f8f4e) Test against Kubernetes 1.24.0 (#236)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.21.0-rc.0](https://github.com/kubedb/redis/releases/tag/v0.21.0-rc.0)
+
+- [a5ec2963](https://github.com/kubedb/redis/commit/a5ec2963) Prepare for release v0.21.0-rc.0 (#411)
+- [738a1964](https://github.com/kubedb/redis/commit/738a1964) Acquire license from license-proxyserver if available (#410)
+- [9336d51d](https://github.com/kubedb/redis/commit/9336d51d) Add Custom Volume Support (#409)
+- [8235b201](https://github.com/kubedb/redis/commit/8235b201) Rework Redis and Redis Sentinel Health Checker (#403)
+- [f5c45ae5](https://github.com/kubedb/redis/commit/f5c45ae5) Image Digest For Sentinel Images (#406)
+- [8962659f](https://github.com/kubedb/redis/commit/8962659f) SKIP_IMAGE_DIGEST for dev builds (#405)
+- [efa9e726](https://github.com/kubedb/redis/commit/efa9e726) Use image with digest value (#402)
+- [08388f4a](https://github.com/kubedb/redis/commit/08388f4a) Update to k8s 1.24 toolchain (#400)
+- [82cd6ba2](https://github.com/kubedb/redis/commit/82cd6ba2) Test against Kubernetes 1.24.0 (#398)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.7.0-rc.0](https://github.com/kubedb/redis-coordinator/releases/tag/v0.7.0-rc.0)
+
+- [d9726c9](https://github.com/kubedb/redis-coordinator/commit/d9726c9) Prepare for release v0.7.0-rc.0 (#38)
+- [f672fd6](https://github.com/kubedb/redis-coordinator/commit/f672fd6) Acquire license from license-proxyserver if available (#37)
+- [5bbab2c](https://github.com/kubedb/redis-coordinator/commit/5bbab2c) Update to k8s 1.24 toolchain (#35)
+- [df38bb5](https://github.com/kubedb/redis-coordinator/commit/df38bb5) Update to k8s 1.24 toolchain (#34)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.15.0-rc.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.15.0-rc.0)
+
+- [e06b4771](https://github.com/kubedb/replication-mode-detector/commit/e06b4771) Prepare for release v0.15.0-rc.0 (#200)
+- [e77ff57c](https://github.com/kubedb/replication-mode-detector/commit/e77ff57c) Update db-client-go (#199)
+- [3008bd62](https://github.com/kubedb/replication-mode-detector/commit/3008bd62) Acquire license from license-proxyserver if available (#198)
+- [134d10c7](https://github.com/kubedb/replication-mode-detector/commit/134d10c7) Use mongodb db client (#197)
+- [0a9cf005](https://github.com/kubedb/replication-mode-detector/commit/0a9cf005) Update to k8s 1.24 toolchain (#195)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.4.0-rc.0](https://github.com/kubedb/schema-manager/releases/tag/v0.4.0-rc.0)
+
+- [114d882a](https://github.com/kubedb/schema-manager/commit/114d882a) Prepare for release v0.4.0-rc.0 (#36)
+- [bcb51407](https://github.com/kubedb/schema-manager/commit/bcb51407) Update db-client-go (#35)
+- [e6ffd878](https://github.com/kubedb/schema-manager/commit/e6ffd878) Acquire license from license-proxyserver if available (#34)
+- [5a6ae96d](https://github.com/kubedb/schema-manager/commit/5a6ae96d) Update kutil dependency (#33)
+- [8e9a2732](https://github.com/kubedb/schema-manager/commit/8e9a2732) Update to use KubeVault v2022.06.16 (#32)
+- [5f7e441d](https://github.com/kubedb/schema-manager/commit/5f7e441d) Update to k8s 1.24 toolchain (#31)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.13.0-rc.0](https://github.com/kubedb/tests/releases/tag/v0.13.0-rc.0)
+
+- [c9a1d705](https://github.com/kubedb/tests/commit/c9a1d705) Prepare for release v0.13.0-rc.0 (#183)
+- [7307b213](https://github.com/kubedb/tests/commit/7307b213) Acquire license from license-proxyserver if available (#182)
+- [84bdf708](https://github.com/kubedb/tests/commit/84bdf708) Update to k8s 1.24 toolchain (#180)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.4.0-rc.0](https://github.com/kubedb/ui-server/releases/tag/v0.4.0-rc.0)
+
+- [56b14fd6](https://github.com/kubedb/ui-server/commit/56b14fd6) Prepare for release v0.4.0-rc.0 (#40)
+- [932c6cd7](https://github.com/kubedb/ui-server/commit/932c6cd7) Vendor Elasticsearch changes in db-client-go (#39)
+- [1e8b3cd7](https://github.com/kubedb/ui-server/commit/1e8b3cd7) Acquire license from license-proxyserver if available (#37)
+- [eef867b5](https://github.com/kubedb/ui-server/commit/eef867b5) Fix linter warning regarding selfLink (#36)
+- [15556fc9](https://github.com/kubedb/ui-server/commit/15556fc9) Update to k8s 1.24 toolchain (#35)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.4.0-rc.0](https://github.com/kubedb/webhook-server/releases/tag/v0.4.0-rc.0)
+
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2022.08.02-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/52
Signed-off-by: 1gtm <1gtm@appscode.com>