### PR TITLE
Prepare for release v2022.08.04-rc.1

### DIFF
--- a/docs/CHANGELOG-v2022.08.04-rc.1.md
+++ b/docs/CHANGELOG-v2022.08.04-rc.1.md
@@ -1,0 +1,293 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2022.08.04-rc.1
+    name: Changelog-v2022.08.04-rc.1
+    parent: welcome
+    weight: 20220804
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.08.04-rc.1/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.08.04-rc.1/
+---
+
+# KubeDB v2022.08.04-rc.1 (2022-08-04)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.28.0-rc.1](https://github.com/kubedb/apimachinery/releases/tag/v0.28.0-rc.1)
+
+- [1241b40d](https://github.com/kubedb/apimachinery/commit/1241b40d) Configure health checker default value (#954)
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.13.0-rc.1](https://github.com/kubedb/autoscaler/releases/tag/v0.13.0-rc.1)
+
+- [8d0fadbb](https://github.com/kubedb/autoscaler/commit/8d0fadbb) Prepare for release v0.13.0-rc.1 (#98)
+- [b907af64](https://github.com/kubedb/autoscaler/commit/b907af64) Update db-client-go (#97)
+- [54169b06](https://github.com/kubedb/autoscaler/commit/54169b06) Update .kodiak.toml
+- [50914655](https://github.com/kubedb/autoscaler/commit/50914655) Update health checker (#96)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.28.0-rc.1](https://github.com/kubedb/cli/releases/tag/v0.28.0-rc.1)
+
+- [1f0d46aa](https://github.com/kubedb/cli/commit/1f0d46aa) Prepare for release v0.28.0-rc.1 (#673)
+- [0e65567a](https://github.com/kubedb/cli/commit/0e65567a) Update health checker (#672)
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.4.0-rc.1](https://github.com/kubedb/dashboard/releases/tag/v0.4.0-rc.1)
+
+- [1e0ee6f](https://github.com/kubedb/dashboard/commit/1e0ee6f) Prepare for release v0.4.0-rc.1 (#35)
+- [4844400](https://github.com/kubedb/dashboard/commit/4844400) Update health checker (#33)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.28.0-rc.1](https://github.com/kubedb/elasticsearch/releases/tag/v0.28.0-rc.1)
+
+- [29ab6c81](https://github.com/kubedb/elasticsearch/commit/29ab6c81b) Prepare for release v0.28.0-rc.1 (#596)
+- [bcaa3512](https://github.com/kubedb/elasticsearch/commit/bcaa3512c) Update db-client-go (#595)
+- [5755abf3](https://github.com/kubedb/elasticsearch/commit/5755abf3b) Set default values during reconcile cycle (#594)
+- [af727aab](https://github.com/kubedb/elasticsearch/commit/af727aab7) Update health checker (#593)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2022.08.04-rc.1](https://github.com/kubedb/installer/releases/tag/v2022.08.04-rc.1)
+
+- [16c0c0bd](https://github.com/kubedb/installer/commit/16c0c0bd) Prepare for release v2022.08.04-rc.1 (#524)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.12.0-rc.1](https://github.com/kubedb/mariadb/releases/tag/v0.12.0-rc.1)
+
+- [0cad6134](https://github.com/kubedb/mariadb/commit/0cad6134) Prepare for release v0.12.0-rc.1 (#163)
+- [7cf4c255](https://github.com/kubedb/mariadb/commit/7cf4c255) Update health checker (#162)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.8.0-rc.1)
+
+- [fe8a57e](https://github.com/kubedb/mariadb-coordinator/commit/fe8a57e) Prepare for release v0.8.0-rc.1 (#52)
+- [9c3c47f](https://github.com/kubedb/mariadb-coordinator/commit/9c3c47f) Update health checker (#51)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/memcached/releases/tag/v0.21.0-rc.1)
+
+- [96b98521](https://github.com/kubedb/memcached/commit/96b98521) Prepare for release v0.21.0-rc.1 (#362)
+- [98aeae01](https://github.com/kubedb/memcached/commit/98aeae01) Update health checker (#361)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/mongodb/releases/tag/v0.21.0-rc.1)
+
+- [0640deb7](https://github.com/kubedb/mongodb/commit/0640deb7) Prepare for release v0.21.0-rc.1 (#500)
+- [ff02931d](https://github.com/kubedb/mongodb/commit/ff02931d) Update db-client-go (#499)
+- [3da24ba2](https://github.com/kubedb/mongodb/commit/3da24ba2) SetDefaults when adding the finalizer (#498)
+- [5652fdc8](https://github.com/kubedb/mongodb/commit/5652fdc8) Update health checker (#497)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/mysql/releases/tag/v0.21.0-rc.1)
+
+- [f0f44703](https://github.com/kubedb/mysql/commit/f0f44703) Prepare for release v0.21.0-rc.1 (#487)
+- [77e0b015](https://github.com/kubedb/mysql/commit/77e0b015) refactor mysql health checker (#486)
+- [8c008024](https://github.com/kubedb/mysql/commit/8c008024) Update health checker (#485)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.6.0-rc.1](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.6.0-rc.1)
+
+- [fa7ad1c](https://github.com/kubedb/mysql-coordinator/commit/fa7ad1c) Prepare for release v0.6.0-rc.1 (#46)
+- [2c3615b](https://github.com/kubedb/mysql-coordinator/commit/2c3615b) update labels (#45)
+- [38a4f88](https://github.com/kubedb/mysql-coordinator/commit/38a4f88) Update health checker (#43)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.6.0-rc.1](https://github.com/kubedb/mysql-router-init/releases/tag/v0.6.0-rc.1)
+
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/ops-manager/releases/tag/v0.15.0-rc.1)
+
+- [23ca2d3b](https://github.com/kubedb/ops-manager/commit/23ca2d3b9) Prepare for release v0.15.0-rc.1 (#336)
+- [2d03cc25](https://github.com/kubedb/ops-manager/commit/2d03cc257) Fix Upgrade | Volume Expansion ops request MySQL (#335)
+- [9f4c0acb](https://github.com/kubedb/ops-manager/commit/9f4c0acb1) Update db-client-go (#334)
+- [490d5fce](https://github.com/kubedb/ops-manager/commit/490d5fcec) Update health checker (#332)
+- [0531e84b](https://github.com/kubedb/ops-manager/commit/0531e84b6) Fix multiple recommendation creation for same cause for empty phase (#333)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/percona-xtradb/releases/tag/v0.15.0-rc.1)
+
+- [c512779b](https://github.com/kubedb/percona-xtradb/commit/c512779b) Prepare for release v0.15.0-rc.1 (#266)
+- [a767d382](https://github.com/kubedb/percona-xtradb/commit/a767d382) Update health checker (#265)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.1.0-rc.1)
+
+- [290e281](https://github.com/kubedb/percona-xtradb-coordinator/commit/290e281) Prepare for release v0.1.0-rc.1 (#9)
+- [c57449c](https://github.com/kubedb/percona-xtradb-coordinator/commit/c57449c) Update health checker (#8)
+- [adad8b5](https://github.com/kubedb/percona-xtradb-coordinator/commit/adad8b5) Acquire license from license-proxyserver if available (#7)
+- [14f17f0](https://github.com/kubedb/percona-xtradb-coordinator/commit/14f17f0) Add Percona XtraDB Coordinator (#3)
+- [4434736](https://github.com/kubedb/percona-xtradb-coordinator/commit/4434736) Update to k8s 1.24 toolchain (#5)
+- [e01945d](https://github.com/kubedb/percona-xtradb-coordinator/commit/e01945d) Update to k8s 1.24 toolchain (#4)
+- [ad7dd9c](https://github.com/kubedb/percona-xtradb-coordinator/commit/ad7dd9c) Use Go 1.18 (#2)
+- [5a140bb](https://github.com/kubedb/percona-xtradb-coordinator/commit/5a140bb) make fmt (#1)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.12.0-rc.1](https://github.com/kubedb/pg-coordinator/releases/tag/v0.12.0-rc.1)
+
+- [e555754d](https://github.com/kubedb/pg-coordinator/commit/e555754d) Prepare for release v0.12.0-rc.1 (#88)
+- [28c83e07](https://github.com/kubedb/pg-coordinator/commit/28c83e07) Update health checker (#86)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/pgbouncer/releases/tag/v0.15.0-rc.1)
+
+- [6b3f6715](https://github.com/kubedb/pgbouncer/commit/6b3f6715) Prepare for release v0.15.0-rc.1 (#232)
+- [a88654ad](https://github.com/kubedb/pgbouncer/commit/a88654ad) Update health checker (#231)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.28.0-rc.1](https://github.com/kubedb/postgres/releases/tag/v0.28.0-rc.1)
+
+- [f2b875d4](https://github.com/kubedb/postgres/commit/f2b875d4) Prepare for release v0.28.0-rc.1 (#585)
+- [a15214c9](https://github.com/kubedb/postgres/commit/a15214c9) Set default values during reconcile cycle (#584)
+- [acf99b7f](https://github.com/kubedb/postgres/commit/acf99b7f) Update health checker (#583)
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.28.0-rc.1](https://github.com/kubedb/provisioner/releases/tag/v0.28.0-rc.1)
+
+- [e855a3ff](https://github.com/kubedb/provisioner/commit/e855a3ff6) Prepare for release v0.28.0-rc.1 (#10)
+- [309ada2c](https://github.com/kubedb/provisioner/commit/309ada2c9) Update db-client-go (#9)
+- [e61a83fc](https://github.com/kubedb/provisioner/commit/e61a83fcd) Update health checker (#8)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/proxysql/releases/tag/v0.15.0-rc.1)
+
+- [de17ccb4](https://github.com/kubedb/proxysql/commit/de17ccb4) Prepare for release v0.15.0-rc.1 (#245)
+- [bceb7ff5](https://github.com/kubedb/proxysql/commit/bceb7ff5) Update health checker (#244)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/redis/releases/tag/v0.21.0-rc.1)
+
+- [4be0e311](https://github.com/kubedb/redis/commit/4be0e311) Prepare for release v0.21.0-rc.1 (#415)
+- [c819ea86](https://github.com/kubedb/redis/commit/c819ea86) Update Health Checker (#414)
+- [41079e80](https://github.com/kubedb/redis/commit/41079e80) Update health checker (#413)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.7.0-rc.1](https://github.com/kubedb/redis-coordinator/releases/tag/v0.7.0-rc.1)
+
+- [535162a](https://github.com/kubedb/redis-coordinator/commit/535162a) Prepare for release v0.7.0-rc.1 (#40)
+- [9dc5d3d](https://github.com/kubedb/redis-coordinator/commit/9dc5d3d) Update health checker (#39)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.15.0-rc.1)
+
+- [50cb0ab6](https://github.com/kubedb/replication-mode-detector/commit/50cb0ab6) Prepare for release v0.15.0-rc.1 (#203)
+- [e5c04c52](https://github.com/kubedb/replication-mode-detector/commit/e5c04c52) Update db-client-go (#202)
+- [6409566e](https://github.com/kubedb/replication-mode-detector/commit/6409566e) Update health checker (#201)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.4.0-rc.1](https://github.com/kubedb/schema-manager/releases/tag/v0.4.0-rc.1)
+
+- [d5033ad5](https://github.com/kubedb/schema-manager/commit/d5033ad5) Prepare for release v0.4.0-rc.1 (#39)
+- [0f7e0747](https://github.com/kubedb/schema-manager/commit/0f7e0747) Update db-client-go (#38)
+- [9b44c0dc](https://github.com/kubedb/schema-manager/commit/9b44c0dc) Update health checker (#37)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.13.0-rc.1](https://github.com/kubedb/tests/releases/tag/v0.13.0-rc.1)
+
+- [a8571959](https://github.com/kubedb/tests/commit/a8571959) Prepare for release v0.13.0-rc.1 (#186)
+- [77ce04e4](https://github.com/kubedb/tests/commit/77ce04e4) Update db-client-go (#185)
+- [7924eac1](https://github.com/kubedb/tests/commit/7924eac1) Update health checker (#184)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.4.0-rc.1](https://github.com/kubedb/ui-server/releases/tag/v0.4.0-rc.1)
+
+- [64a798ef](https://github.com/kubedb/ui-server/commit/64a798ef) Prepare for release v0.4.0-rc.1 (#43)
+- [a0475425](https://github.com/kubedb/ui-server/commit/a0475425) Update db-client-go (#42)
+- [82a9bec5](https://github.com/kubedb/ui-server/commit/82a9bec5) Update health checker (#41)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.4.0-rc.1](https://github.com/kubedb/webhook-server/releases/tag/v0.4.0-rc.1)
+
+- [1714ad93](https://github.com/kubedb/webhook-server/commit/1714ad93) Prepare for release v0.4.0-rc.1 (#25)
+- [30558972](https://github.com/kubedb/webhook-server/commit/30558972) Add Clsuter Topology in PerconaXtraDB (#24)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2022.08.04-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/53
Signed-off-by: 1gtm <1gtm@appscode.com>