### PR TITLE
Set terminationPolicy in Redis quickstart

### DIFF
--- a/docs/guides/redis/quickstart/quickstart.md
+++ b/docs/guides/redis/quickstart/quickstart.md
@@ -82,6 +82,7 @@ spec:
     resources:
       requests:
         storage: 1Gi
+    terminationPolicy: DoNotTerminate
 ```
 
 ```bash


### PR DESCRIPTION
The documentation following the initial creation is based on `terminationPolicy: DoNotTerminate` being set so it gets confusing when this isn't actually the case.