### PR TITLE
Prepare for release v2022.12.24-rc.1

### DIFF
--- a/docs/CHANGELOG-v2022.12.24-rc.1.md
+++ b/docs/CHANGELOG-v2022.12.24-rc.1.md
@@ -1,0 +1,283 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2022.12.24-rc.1
+    name: Changelog-v2022.12.24-rc.1
+    parent: welcome
+    weight: 20221224
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.12.24-rc.1/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.12.24-rc.1/
+---
+
+# KubeDB v2022.12.24-rc.1 (2022-12-24)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.30.0-rc.1](https://github.com/kubedb/apimachinery/releases/tag/v0.30.0-rc.1)
+
+- [7f6ffca9](https://github.com/kubedb/apimachinery/commit/7f6ffca9) Revise PgBouncer api (#1002)
+- [e539a58e](https://github.com/kubedb/apimachinery/commit/e539a58e) Update Redis Root Username (#1010)
+- [12cda1e0](https://github.com/kubedb/apimachinery/commit/12cda1e0) Remove docker utils (#1008)
+- [125f3bb7](https://github.com/kubedb/apimachinery/commit/125f3bb7) Add API for ProxySQL UI-Server (#1003)
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/autoscaler/releases/tag/v0.15.0-rc.1)
+
+- [c941fab2](https://github.com/kubedb/autoscaler/commit/c941fab2) Prepare for release v0.15.0-rc.1 (#127)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.30.0-rc.1](https://github.com/kubedb/cli/releases/tag/v0.30.0-rc.1)
+
+- [f91038aa](https://github.com/kubedb/cli/commit/f91038aa) Prepare for release v0.30.0-rc.1 (#690)
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.6.0-rc.1](https://github.com/kubedb/dashboard/releases/tag/v0.6.0-rc.1)
+
+- [0c9d9a4](https://github.com/kubedb/dashboard/commit/0c9d9a4) Prepare for release v0.6.0-rc.1 (#53)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.30.0-rc.1](https://github.com/kubedb/elasticsearch/releases/tag/v0.30.0-rc.1)
+
+- [0812edfe](https://github.com/kubedb/elasticsearch/commit/0812edfee) Prepare for release v0.30.0-rc.1 (#619)
+- [2bd59db3](https://github.com/kubedb/elasticsearch/commit/2bd59db3b) Use go-containerregistry for image digest (#618)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2022.12.24-rc.1](https://github.com/kubedb/installer/releases/tag/v2022.12.24-rc.1)
+
+- [d80dae40](https://github.com/kubedb/installer/commit/d80dae40) Prepare for release v2022.12.24-rc.1 (#580)
+- [c6588fe5](https://github.com/kubedb/installer/commit/c6588fe5) Add MariaDB Version 10.10.2 (#579)
+- [3045cc42](https://github.com/kubedb/installer/commit/3045cc42) Update crds for kubedb/apimachinery@7f6ffca9 (#578)
+- [950b0ae5](https://github.com/kubedb/installer/commit/950b0ae5) Add support for PgBouncer 1.18.0 (#577)
+- [401de79f](https://github.com/kubedb/installer/commit/401de79f) Add Redis Version 6.2.8 and 7.0.6 (#576)
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/kafka/releases/tag/v0.1.0-rc.1)
+
+- [649dbf5](https://github.com/kubedb/kafka/commit/649dbf5) Prepare for release v0.1.0-rc.1 (#8)
+- [ac4dc3d](https://github.com/kubedb/kafka/commit/ac4dc3d) Use go-containerregistry for image digest (#7)
+- [8d8b5bc](https://github.com/kubedb/kafka/commit/8d8b5bc) Use kauth.NoServiceAccount when no sa is specified
+- [16ee315](https://github.com/kubedb/kafka/commit/16ee315) Fix Image digest detection (#6)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/mariadb/releases/tag/v0.14.0-rc.1)
+
+- [50d9424e](https://github.com/kubedb/mariadb/commit/50d9424e) Prepare for release v0.14.0-rc.1 (#190)
+- [ca141bfa](https://github.com/kubedb/mariadb/commit/ca141bfa) Use go-containerregistry for image digest (#189)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.10.0-rc.1](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.10.0-rc.1)
+
+- [378ac91](https://github.com/kubedb/mariadb-coordinator/commit/378ac91) Prepare for release v0.10.0-rc.1 (#67)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.23.0-rc.1](https://github.com/kubedb/memcached/releases/tag/v0.23.0-rc.1)
+
+- [0bdafbd7](https://github.com/kubedb/memcached/commit/0bdafbd7) Prepare for release v0.23.0-rc.1 (#379)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.23.0-rc.1](https://github.com/kubedb/mongodb/releases/tag/v0.23.0-rc.1)
+
+- [d94c3301](https://github.com/kubedb/mongodb/commit/d94c3301) Prepare for release v0.23.0-rc.1 (#526)
+- [7ee6de66](https://github.com/kubedb/mongodb/commit/7ee6de66) Use go-containerregistry for image digest (#525)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.23.0-rc.1](https://github.com/kubedb/mysql/releases/tag/v0.23.0-rc.1)
+
+- [b2fcc9fa](https://github.com/kubedb/mysql/commit/b2fcc9fa) Prepare for release v0.23.0-rc.1 (#514)
+- [814b64b8](https://github.com/kubedb/mysql/commit/814b64b8) Use go-containerregistry for image digest (#513)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.8.0-rc.1)
+
+- [24c35fc](https://github.com/kubedb/mysql-coordinator/commit/24c35fc) Prepare for release v0.8.0-rc.1 (#65)
+- [e0bebc6](https://github.com/kubedb/mysql-coordinator/commit/e0bebc6) remove appeding singnal cluster_status_ok (#64)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/mysql-router-init/releases/tag/v0.8.0-rc.1)
+
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.17.0-rc.1](https://github.com/kubedb/ops-manager/releases/tag/v0.17.0-rc.1)
+
+- [eab904d7](https://github.com/kubedb/ops-manager/commit/eab904d7) Prepare for release v0.17.0-rc.1 (#399)
+- [7258d256](https://github.com/kubedb/ops-manager/commit/7258d256) Use kmodules image library for parsing image (#398)
+- [b47b86e7](https://github.com/kubedb/ops-manager/commit/b47b86e7) Add adminUserName as CommonName for PgBouncer (#394)
+- [1f3799b7](https://github.com/kubedb/ops-manager/commit/1f3799b7) Update deps
+- [def279a1](https://github.com/kubedb/ops-manager/commit/def279a1) Use go-containerregistry for image digest (#397)
+- [90bbf6f3](https://github.com/kubedb/ops-manager/commit/90bbf6f3) Fix evict api usage for k8s < 1.22 (#396)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.17.0-rc.1](https://github.com/kubedb/percona-xtradb/releases/tag/v0.17.0-rc.1)
+
+- [e374cf7e](https://github.com/kubedb/percona-xtradb/commit/e374cf7e) Prepare for release v0.17.0-rc.1 (#292)
+- [d6a2ffa6](https://github.com/kubedb/percona-xtradb/commit/d6a2ffa6) Use go-containerregistry for image digest (#291)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.3.0-rc.1](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.3.0-rc.1)
+
+- [d6df29d](https://github.com/kubedb/percona-xtradb-coordinator/commit/d6df29d) Prepare for release v0.3.0-rc.1 (#24)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/pg-coordinator/releases/tag/v0.14.0-rc.1)
+
+- [8e83f433](https://github.com/kubedb/pg-coordinator/commit/8e83f433) Prepare for release v0.14.0-rc.1 (#106)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.17.0-rc.1](https://github.com/kubedb/pgbouncer/releases/tag/v0.17.0-rc.1)
+
+- [89675d58](https://github.com/kubedb/pgbouncer/commit/89675d58) Prepare for release v0.17.0-rc.1 (#253)
+- [e84285e2](https://github.com/kubedb/pgbouncer/commit/e84285e2) Add authSecret & configSecret (#249)
+- [a7064c4f](https://github.com/kubedb/pgbouncer/commit/a7064c4f) Use go-containerregistry for image digest (#252)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.30.0-rc.1](https://github.com/kubedb/postgres/releases/tag/v0.30.0-rc.1)
+
+- [1769f0ba](https://github.com/kubedb/postgres/commit/1769f0ba) Prepare for release v0.30.0-rc.1 (#617)
+- [3bd63349](https://github.com/kubedb/postgres/commit/3bd63349) Revert to k8s 1.25 client libraries
+- [42f3f740](https://github.com/kubedb/postgres/commit/42f3f740) Use go-containerregistry for image digest (#616)
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.30.0-rc.1](https://github.com/kubedb/provisioner/releases/tag/v0.30.0-rc.1)
+
+- [57e5c33a](https://github.com/kubedb/provisioner/commit/57e5c33a2) Prepare for release v0.30.0-rc.1 (#30)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.17.0-rc.1](https://github.com/kubedb/proxysql/releases/tag/v0.17.0-rc.1)
+
+- [df3d1df1](https://github.com/kubedb/proxysql/commit/df3d1df1) Prepare for release v0.17.0-rc.1 (#272)
+- [bb0df62a](https://github.com/kubedb/proxysql/commit/bb0df62a) Fix Monitoring Port Issue (#271)
+- [68ad2f54](https://github.com/kubedb/proxysql/commit/68ad2f54) Fix Validator Issue (#270)
+- [350e74af](https://github.com/kubedb/proxysql/commit/350e74af) Use go-containerregistry for image digest (#268)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.23.0-rc.1](https://github.com/kubedb/redis/releases/tag/v0.23.0-rc.1)
+
+- [532ed03f](https://github.com/kubedb/redis/commit/532ed03f) Prepare for release v0.23.0-rc.1 (#441)
+- [a231c6f2](https://github.com/kubedb/redis/commit/a231c6f2) Update Redis Root UserName (#440)
+- [902f036b](https://github.com/kubedb/redis/commit/902f036b) Use go-containerregistry for image digest (#439)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.9.0-rc.1](https://github.com/kubedb/redis-coordinator/releases/tag/v0.9.0-rc.1)
+
+- [384700f](https://github.com/kubedb/redis-coordinator/commit/384700f) Prepare for release v0.9.0-rc.1 (#57)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.17.0-rc.1](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.17.0-rc.1)
+
+- [30f4ff3f](https://github.com/kubedb/replication-mode-detector/commit/30f4ff3f) Prepare for release v0.17.0-rc.1 (#219)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.6.0-rc.1](https://github.com/kubedb/schema-manager/releases/tag/v0.6.0-rc.1)
+
+- [5734ca5e](https://github.com/kubedb/schema-manager/commit/5734ca5e) Prepare for release v0.6.0-rc.1 (#57)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/tests/releases/tag/v0.15.0-rc.1)
+
+- [436f15a7](https://github.com/kubedb/tests/commit/436f15a7) Prepare for release v0.15.0-rc.1 (#209)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.6.0-rc.1](https://github.com/kubedb/ui-server/releases/tag/v0.6.0-rc.1)
+
+- [8254bf93](https://github.com/kubedb/ui-server/commit/8254bf93) Update deps
+- [27c1daf5](https://github.com/kubedb/ui-server/commit/27c1daf5) Proxysql UI server (#57)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.6.0-rc.1](https://github.com/kubedb/webhook-server/releases/tag/v0.6.0-rc.1)
+
+- [b9eabfda](https://github.com/kubedb/webhook-server/commit/b9eabfda) Prepare for release v0.6.0-rc.1 (#42)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2022.12.24-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/61
Signed-off-by: 1gtm <1gtm@appscode.com>