### PR TITLE
Prepare for release v2023.01.17

### DIFF
--- a/docs/CHANGELOG-v2023.01.17.md
+++ b/docs/CHANGELOG-v2023.01.17.md
@@ -1,0 +1,290 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2023.01.17
+    name: Changelog-v2023.01.17
+    parent: welcome
+    weight: 20230117
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.01.17/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.01.17/
+---
+
+# KubeDB v2023.01.17 (2023-01-17)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.30.1](https://github.com/kubedb/apimachinery/releases/tag/v0.30.1)
+
+- [d93fabe5](https://github.com/kubedb/apimachinery/commit/d93fabe5) Update deps
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.15.1](https://github.com/kubedb/autoscaler/releases/tag/v0.15.1)
+
+- [4a31539f](https://github.com/kubedb/autoscaler/commit/4a31539f) Prepare for release v0.15.1 (#131)
+- [c6f2ba46](https://github.com/kubedb/autoscaler/commit/c6f2ba46) Set registryFQDN to use docker for local development (#130)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.30.1](https://github.com/kubedb/cli/releases/tag/v0.30.1)
+
+- [264d4323](https://github.com/kubedb/cli/commit/264d4323) Prepare for release v0.30.1 (#695)
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.6.1](https://github.com/kubedb/dashboard/releases/tag/v0.6.1)
+
+- [3d59229](https://github.com/kubedb/dashboard/commit/3d59229) Prepare for release v0.6.1 (#58)
+- [da17eac](https://github.com/kubedb/dashboard/commit/da17eac) Set registryFQDN to use docker for local development (#57)
+- [7b8d07c](https://github.com/kubedb/dashboard/commit/7b8d07c) Disable usage collection from ES (#56)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.30.1](https://github.com/kubedb/elasticsearch/releases/tag/v0.30.1)
+
+- [35c62fa5](https://github.com/kubedb/elasticsearch/commit/35c62fa5b) Prepare for release v0.30.1 (#624)
+- [207904e7](https://github.com/kubedb/elasticsearch/commit/207904e72) Add --insecure-registries flag (#623)
+- [72b402a6](https://github.com/kubedb/elasticsearch/commit/72b402a66) Set registryFQDN to use docker for local development (#622)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2023.01.17](https://github.com/kubedb/installer/releases/tag/v2023.01.17)
+
+- [2414928a](https://github.com/kubedb/installer/commit/2414928a) Prepare for release v2023.01.17 (#584)
+- [a070531c](https://github.com/kubedb/installer/commit/a070531c) Add --insecure-registries flag (#583)
+- [321c3729](https://github.com/kubedb/installer/commit/321c3729) Fix Grafana dashboard crd url
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.1.1](https://github.com/kubedb/kafka/releases/tag/v0.1.1)
+
+- [6b49e97](https://github.com/kubedb/kafka/commit/6b49e97) Prepare for release v0.1.1 (#12)
+- [a3098fa](https://github.com/kubedb/kafka/commit/a3098fa) Add --insecure-registries flag (#11)
+- [edea46b](https://github.com/kubedb/kafka/commit/edea46b) Set registryFQDN to use docker for local development (#10)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.14.1](https://github.com/kubedb/mariadb/releases/tag/v0.14.1)
+
+- [f8c90127](https://github.com/kubedb/mariadb/commit/f8c90127) Prepare for release v0.14.1 (#196)
+- [87d3c9c9](https://github.com/kubedb/mariadb/commit/87d3c9c9) Add --insecure-registries flag (#195)
+- [3d32a203](https://github.com/kubedb/mariadb/commit/3d32a203) Set registryFQDN to use docker for local development (#194)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.10.1](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.10.1)
+
+- [62eec8e](https://github.com/kubedb/mariadb-coordinator/commit/62eec8e) Prepare for release v0.10.1 (#70)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.23.1](https://github.com/kubedb/memcached/releases/tag/v0.23.1)
+
+- [96587959](https://github.com/kubedb/memcached/commit/96587959) Prepare for release v0.23.1 (#382)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.23.1](https://github.com/kubedb/mongodb/releases/tag/v0.23.1)
+
+- [e165db2e](https://github.com/kubedb/mongodb/commit/e165db2e) Prepare for release v0.23.1 (#531)
+- [d24ed694](https://github.com/kubedb/mongodb/commit/d24ed694) Add --insecure-registries flag (#530)
+- [b15c3833](https://github.com/kubedb/mongodb/commit/b15c3833) Set registryFQDN to use docker for local development (#529)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.23.1](https://github.com/kubedb/mysql/releases/tag/v0.23.1)
+
+- [2700e88d](https://github.com/kubedb/mysql/commit/2700e88d) Prepare for release v0.23.1 (#519)
+- [ce7127b1](https://github.com/kubedb/mysql/commit/ce7127b1) Add --insecure-registries flag (#518)
+- [944883c9](https://github.com/kubedb/mysql/commit/944883c9) Set registryFQDN to use docker for local development (#517)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.8.1](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.8.1)
+
+- [4a182b7](https://github.com/kubedb/mysql-coordinator/commit/4a182b7) Prepare for release v0.8.1 (#68)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.8.1](https://github.com/kubedb/mysql-router-init/releases/tag/v0.8.1)
+
+- [960c85b](https://github.com/kubedb/mysql-router-init/commit/960c85b) Remove slack link
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.17.1](https://github.com/kubedb/ops-manager/releases/tag/v0.17.1)
+
+- [57e4e442](https://github.com/kubedb/ops-manager/commit/57e4e442) Prepare for release v0.17.1 (#407)
+- [b8be3433](https://github.com/kubedb/ops-manager/commit/b8be3433) Add --insecure-registries flag (#406)
+- [63ff77f7](https://github.com/kubedb/ops-manager/commit/63ff77f7) Set registryFQDN to use docker for local development (#405)
+- [94110406](https://github.com/kubedb/ops-manager/commit/94110406) Refactor Redis Ops Requests (#404)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.17.1](https://github.com/kubedb/percona-xtradb/releases/tag/v0.17.1)
+
+- [7b0b63f4](https://github.com/kubedb/percona-xtradb/commit/7b0b63f4) Prepare for release v0.17.1 (#297)
+- [84aeef58](https://github.com/kubedb/percona-xtradb/commit/84aeef58) Add --insecure-registries flag (#296)
+- [15386fb7](https://github.com/kubedb/percona-xtradb/commit/15386fb7) Set registryFQDN to use docker for local development (#295)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.3.1](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.3.1)
+
+- [d5d1f97](https://github.com/kubedb/percona-xtradb-coordinator/commit/d5d1f97) Prepare for release v0.3.1 (#27)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.14.1](https://github.com/kubedb/pg-coordinator/releases/tag/v0.14.1)
+
+- [084ba8e0](https://github.com/kubedb/pg-coordinator/commit/084ba8e0) Prepare for release v0.14.1 (#109)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.17.1](https://github.com/kubedb/pgbouncer/releases/tag/v0.17.1)
+
+- [6ea07cb6](https://github.com/kubedb/pgbouncer/commit/6ea07cb6) Prepare for release v0.17.1 (#258)
+- [5d8608e4](https://github.com/kubedb/pgbouncer/commit/5d8608e4) Add --insecure-registries flag (#257)
+- [11c42ab3](https://github.com/kubedb/pgbouncer/commit/11c42ab3) Set registryFQDN to use docker for local development (#256)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.30.1](https://github.com/kubedb/postgres/releases/tag/v0.30.1)
+
+- [d3ded3bd](https://github.com/kubedb/postgres/commit/d3ded3bd) Prepare for release v0.30.1 (#623)
+- [21b81e75](https://github.com/kubedb/postgres/commit/21b81e75) Add --insecure-registries flag (#622)
+- [050c4e61](https://github.com/kubedb/postgres/commit/050c4e61) Set registryFQDN to use docker for local development (#621)
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.30.1](https://github.com/kubedb/provisioner/releases/tag/v0.30.1)
+
+- [02cd0453](https://github.com/kubedb/provisioner/commit/02cd0453b) Prepare for release v0.30.1 (#35)
+- [24d6aa18](https://github.com/kubedb/provisioner/commit/24d6aa18e) Add --insecure-registries flag (#34)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.17.1](https://github.com/kubedb/proxysql/releases/tag/v0.17.1)
+
+- [67500f61](https://github.com/kubedb/proxysql/commit/67500f61) Prepare for release v0.17.1 (#277)
+- [5088aa2e](https://github.com/kubedb/proxysql/commit/5088aa2e) Add --insecure-registries flag (#276)
+- [83c14966](https://github.com/kubedb/proxysql/commit/83c14966) Set registryFQDN to use docker for local development (#275)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.23.1](https://github.com/kubedb/redis/releases/tag/v0.23.1)
+
+- [d4b63271](https://github.com/kubedb/redis/commit/d4b63271) Prepare for release v0.23.1 (#447)
+- [2a829766](https://github.com/kubedb/redis/commit/2a829766) Add --insecure-registries flag (#446)
+- [73260d12](https://github.com/kubedb/redis/commit/73260d12) Set registryFQDN to use docker for local development (#445)
+- [9cabe22e](https://github.com/kubedb/redis/commit/9cabe22e) Add redis client-go (#444)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.9.1](https://github.com/kubedb/redis-coordinator/releases/tag/v0.9.1)
+
+- [a66421c](https://github.com/kubedb/redis-coordinator/commit/a66421c) Prepare for release v0.9.1 (#60)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.17.1](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.17.1)
+
+- [94eeb8d5](https://github.com/kubedb/replication-mode-detector/commit/94eeb8d5) Prepare for release v0.17.1 (#222)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.6.1](https://github.com/kubedb/schema-manager/releases/tag/v0.6.1)
+
+- [94bf0859](https://github.com/kubedb/schema-manager/commit/94bf0859) Prepare for release v0.6.1 (#62)
+- [195a9199](https://github.com/kubedb/schema-manager/commit/195a9199) Update KubeVault crds (#61)
+- [eadf5f6e](https://github.com/kubedb/schema-manager/commit/eadf5f6e) Set registryFQDN to use docker for local development (#60)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.15.1](https://github.com/kubedb/tests/releases/tag/v0.15.1)
+
+- [ad9578bf](https://github.com/kubedb/tests/commit/ad9578bf) Prepare for release v0.15.1 (#214)
+- [ead800d4](https://github.com/kubedb/tests/commit/ead800d4) Add Percona XtraDB Tests (Provisioner, OpsManager, Autoscaler) (#181)
+- [0af9c9b7](https://github.com/kubedb/tests/commit/0af9c9b7) Add MariaDB OpsReq and Autoscaler Tests (#160)
+- [7e18e981](https://github.com/kubedb/tests/commit/7e18e981) Update Redis Sentinel Tests (#211)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.6.1](https://github.com/kubedb/ui-server/releases/tag/v0.6.1)
+
+- [6cfc4469](https://github.com/kubedb/ui-server/commit/6cfc4469) Prepare for release v0.6.1 (#64)
+- [d3c21e61](https://github.com/kubedb/ui-server/commit/d3c21e61) Remove slack link
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.6.1](https://github.com/kubedb/webhook-server/releases/tag/v0.6.1)
+
+- [7b3eff57](https://github.com/kubedb/webhook-server/commit/7b3eff57) Prepare for release v0.6.1 (#47)
+- [c2fffb87](https://github.com/kubedb/webhook-server/commit/c2fffb87) Set registryFQDN to use docker for local development (#45)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.01.17
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/63
Signed-off-by: 1gtm <1gtm@appscode.com>