### PR TITLE
Prepare for release v2023.01.31

### DIFF
--- a/docs/CHANGELOG-v2023.01.31.md
+++ b/docs/CHANGELOG-v2023.01.31.md
@@ -1,0 +1,299 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2023.01.31
+    name: Changelog-v2023.01.31
+    parent: welcome
+    weight: 20230131
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.01.31/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.01.31/
+---
+
+# KubeDB v2023.01.31 (2023-01-30)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.31.0](https://github.com/kubedb/apimachinery/releases/tag/v0.31.0)
+
+- [f2cc1db7](https://github.com/kubedb/apimachinery/commit/f2cc1db7) Add PgBouncer apis for UI Server (#1011)
+- [424a2960](https://github.com/kubedb/apimachinery/commit/424a2960) Fix postgres `transferLeadershipTimeout` (#1013)
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.16.0](https://github.com/kubedb/autoscaler/releases/tag/v0.16.0)
+
+- [1ffa653b](https://github.com/kubedb/autoscaler/commit/1ffa653b) Update sidekick dependency (#135)
+- [e9b84b31](https://github.com/kubedb/autoscaler/commit/e9b84b31) Update sidekick dependency (#133)
+- [02affdc3](https://github.com/kubedb/autoscaler/commit/02affdc3) Read imge pull secret from operator flags (#132)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.31.0](https://github.com/kubedb/cli/releases/tag/v0.31.0)
+
+- [a821a2ce](https://github.com/kubedb/cli/commit/a821a2ce) Update sidekick dependency (#697)
+- [6fdf6747](https://github.com/kubedb/cli/commit/6fdf6747) Read imge pull secret from operator flags (#696)
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.7.0](https://github.com/kubedb/dashboard/releases/tag/v0.7.0)
+
+- [c40c888](https://github.com/kubedb/dashboard/commit/c40c888) Prepare for release v0.7.0 (#62)
+- [205133c](https://github.com/kubedb/dashboard/commit/205133c) Update sidekick dependency (#61)
+- [f6fe542](https://github.com/kubedb/dashboard/commit/f6fe542) Update sidekick dependency (#60)
+- [1ec3b80](https://github.com/kubedb/dashboard/commit/1ec3b80) Read imge pull secret from operator flags (#59)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.31.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.31.0)
+
+- [b91d6a98](https://github.com/kubedb/elasticsearch/commit/b91d6a98e) Update sidekick dependency (#626)
+- [5c36b694](https://github.com/kubedb/elasticsearch/commit/5c36b6944) Read imge pull secret from operator flags (#625)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2023.01.31](https://github.com/kubedb/installer/releases/tag/v2023.01.31)
+
+- [6e84d9a3](https://github.com/kubedb/installer/commit/6e84d9a3) Prepare for release v2023.01.31 (#590)
+- [97109145](https://github.com/kubedb/installer/commit/97109145) Add Sidekick on Cluster Role (POC) (#575)
+- [29c471ed](https://github.com/kubedb/installer/commit/29c471ed) Update Dashboard init container images (#589)
+- [935a7e75](https://github.com/kubedb/installer/commit/935a7e75) Read image pull secret from operator flags (#588)
+- [e58f09ae](https://github.com/kubedb/installer/commit/e58f09ae) Add `pod/eviction` rbac for provisioner (#586)
+- [692d5929](https://github.com/kubedb/installer/commit/692d5929) Update crds for kubedb/apimachinery@424a2960 (#587)
+- [55c4da09](https://github.com/kubedb/installer/commit/55c4da09) Fix grafana dashboard variable Name
+- [9e9b92ee](https://github.com/kubedb/installer/commit/9e9b92ee) Update supervisor crd
+- [63645074](https://github.com/kubedb/installer/commit/63645074) Make service monitor required in global values
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.2.0](https://github.com/kubedb/kafka/releases/tag/v0.2.0)
+
+- [fa669ea](https://github.com/kubedb/kafka/commit/fa669ea) Prepare for release v0.2.0 (#14)
+- [f50c714](https://github.com/kubedb/kafka/commit/f50c714) Read imge pull secret from operator flags (#13)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.15.0](https://github.com/kubedb/mariadb/releases/tag/v0.15.0)
+
+- [6d769a0a](https://github.com/kubedb/mariadb/commit/6d769a0a) Prepare for release v0.15.0 (#198)
+- [56fbf1e4](https://github.com/kubedb/mariadb/commit/56fbf1e4) Read imge pull secret from operator flags (#197)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.11.0](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.11.0)
+
+- [78aaeab](https://github.com/kubedb/mariadb-coordinator/commit/78aaeab) Update sidekick dependency (#72)
+- [5d7a579](https://github.com/kubedb/mariadb-coordinator/commit/5d7a579) Read imge pull secret from operator flags (#71)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.24.0](https://github.com/kubedb/memcached/releases/tag/v0.24.0)
+
+- [67c3dad8](https://github.com/kubedb/memcached/commit/67c3dad8) Update sidekick dependency (#384)
+- [147b0ae0](https://github.com/kubedb/memcached/commit/147b0ae0) Read imge pull secret from operator flags (#383)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.24.0](https://github.com/kubedb/mongodb/releases/tag/v0.24.0)
+
+- [58a098f0](https://github.com/kubedb/mongodb/commit/58a098f0) Update sidekick dependency (#533)
+- [2b4876a0](https://github.com/kubedb/mongodb/commit/2b4876a0) Read imge pull secret from operator flags (#532)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.24.0](https://github.com/kubedb/mysql/releases/tag/v0.24.0)
+
+- [2ce7a185](https://github.com/kubedb/mysql/commit/2ce7a185) Update sidekick dependency (#521)
+- [9e9133db](https://github.com/kubedb/mysql/commit/9e9133db) Read imge pull secret from operator flags (#520)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.9.0](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.9.0)
+
+- [727ce38](https://github.com/kubedb/mysql-coordinator/commit/727ce38) Update sidekick dependency (#70)
+- [4d55c9d](https://github.com/kubedb/mysql-coordinator/commit/4d55c9d) Read imge pull secret from operator flags (#69)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.9.0](https://github.com/kubedb/mysql-router-init/releases/tag/v0.9.0)
+
+- [63ef29f](https://github.com/kubedb/mysql-router-init/commit/63ef29f) Update sidekick dependency (#30)
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.18.0](https://github.com/kubedb/ops-manager/releases/tag/v0.18.0)
+
+- [049b0428](https://github.com/kubedb/ops-manager/commit/049b0428) Prepare for release v0.18.0 (#413)
+- [9dc43bfa](https://github.com/kubedb/ops-manager/commit/9dc43bfa) Update sidekick dependency (#412)
+- [010a65c7](https://github.com/kubedb/ops-manager/commit/010a65c7) Read image pull secret from operator flags (#411)
+- [0b3fcf4a](https://github.com/kubedb/ops-manager/commit/0b3fcf4a) Read imge pull secret from operator flags (#410)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.18.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.18.0)
+
+- [6da94951](https://github.com/kubedb/percona-xtradb/commit/6da94951) Update sidekick dependency (#299)
+- [7f36f57a](https://github.com/kubedb/percona-xtradb/commit/7f36f57a) Read imge pull secret from operator flags (#298)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.4.0](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.4.0)
+
+- [562d7df](https://github.com/kubedb/percona-xtradb-coordinator/commit/562d7df) Update sidekick dependency (#29)
+- [0e823ff](https://github.com/kubedb/percona-xtradb-coordinator/commit/0e823ff) Read imge pull secret from operator flags (#28)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.15.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.15.0)
+
+- [8fdc0143](https://github.com/kubedb/pg-coordinator/commit/8fdc0143) Update sidekick dependency (#112)
+- [b686ba76](https://github.com/kubedb/pg-coordinator/commit/b686ba76) Read imge pull secret from operator flags (#111)
+- [49cd4a67](https://github.com/kubedb/pg-coordinator/commit/49cd4a67) Fix `waiting for the target to be leader` issue (#110)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.18.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.18.0)
+
+- [45753006](https://github.com/kubedb/pgbouncer/commit/45753006) Prepare for release v0.18.0 (#261)
+- [b56e096a](https://github.com/kubedb/pgbouncer/commit/b56e096a) Update sidekick dependency (#260)
+- [aa59fc2c](https://github.com/kubedb/pgbouncer/commit/aa59fc2c) Read imge pull secret from operator flags (#259)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.31.0](https://github.com/kubedb/postgres/releases/tag/v0.31.0)
+
+- [710e4282](https://github.com/kubedb/postgres/commit/710e4282) Update sidekick dependency (#627)
+- [30ffd035](https://github.com/kubedb/postgres/commit/30ffd035) Read imge pull secret from operator flags (#626)
+- [f9dc7194](https://github.com/kubedb/postgres/commit/f9dc7194) Fixed scaling up and down for standalone with `halted=true` and Add eviction RBAC (#624)
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.31.0](https://github.com/kubedb/provisioner/releases/tag/v0.31.0)
+
+- [8d8fe8f5](https://github.com/kubedb/provisioner/commit/8d8fe8f5b) Prepare for release v0.31.0 (#38)
+- [ccd6c545](https://github.com/kubedb/provisioner/commit/ccd6c545f) Update sidekick dependency (#37)
+- [e0214013](https://github.com/kubedb/provisioner/commit/e0214013b) Read imge pull secret from operator flags (#36)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.18.0](https://github.com/kubedb/proxysql/releases/tag/v0.18.0)
+
+- [1c38abc8](https://github.com/kubedb/proxysql/commit/1c38abc8) Prepare for release v0.18.0 (#280)
+- [c19af3c5](https://github.com/kubedb/proxysql/commit/c19af3c5) Update sidekick dependency (#279)
+- [0478dff1](https://github.com/kubedb/proxysql/commit/0478dff1) Read imge pull secret from operator flags (#278)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.24.0](https://github.com/kubedb/redis/releases/tag/v0.24.0)
+
+- [20a616fa](https://github.com/kubedb/redis/commit/20a616fa) Update sidekick dependency (#449)
+- [eebeb0b9](https://github.com/kubedb/redis/commit/eebeb0b9) Read imge pull secret from operator flags (#448)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.10.0](https://github.com/kubedb/redis-coordinator/releases/tag/v0.10.0)
+
+- [d8f8d72](https://github.com/kubedb/redis-coordinator/commit/d8f8d72) Update sidekick dependency (#62)
+- [55e1996](https://github.com/kubedb/redis-coordinator/commit/55e1996) Read imge pull secret from operator flags (#61)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.18.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.18.0)
+
+- [08bd3050](https://github.com/kubedb/replication-mode-detector/commit/08bd3050) Update sidekick dependency (#224)
+- [b65a3b7f](https://github.com/kubedb/replication-mode-detector/commit/b65a3b7f) Read imge pull secret from operator flags (#223)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.7.0](https://github.com/kubedb/schema-manager/releases/tag/v0.7.0)
+
+- [6ce17e7e](https://github.com/kubedb/schema-manager/commit/6ce17e7e) Update sidekick dependency (#64)
+- [9b75ed17](https://github.com/kubedb/schema-manager/commit/9b75ed17) Read imge pull secret from operator flags (#63)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.16.0](https://github.com/kubedb/tests/releases/tag/v0.16.0)
+
+- [73dc61fa](https://github.com/kubedb/tests/commit/73dc61fa) Update sidekick dependency (#216)
+- [53b4a2e2](https://github.com/kubedb/tests/commit/53b4a2e2) Read imge pull secret from operator flags (#215)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.7.0](https://github.com/kubedb/ui-server/releases/tag/v0.7.0)
+
+- [3fd9a734](https://github.com/kubedb/ui-server/commit/3fd9a734) Update sidekick dependency (#66)
+- [f5a40c64](https://github.com/kubedb/ui-server/commit/f5a40c64) Add PgBouncer Support (#62)
+- [fbcb7537](https://github.com/kubedb/ui-server/commit/fbcb7537) Read imge pull secret from operator flags (#65)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.7.0](https://github.com/kubedb/webhook-server/releases/tag/v0.7.0)
+
+- [a01a3928](https://github.com/kubedb/webhook-server/commit/a01a3928) Prepare for release v0.7.0 (#50)
+- [5677176e](https://github.com/kubedb/webhook-server/commit/5677176e) Update sidekick dependency (#49)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.01.31
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/64
Signed-off-by: 1gtm <1gtm@appscode.com>