### PR TITLE
Prepare for release v2023.06.13-rc.0

### DIFF
--- a/docs/CHANGELOG-v2023.06.13-rc.0.md
+++ b/docs/CHANGELOG-v2023.06.13-rc.0.md
@@ -1,0 +1,360 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2023.06.13-rc.0
+    name: Changelog-v2023.06.13-rc.0
+    parent: welcome
+    weight: 20230613
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.06.13-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.06.13-rc.0/
+---
+
+# KubeDB v2023.06.13-rc.0 (2023-06-13)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.34.0-rc.0](https://github.com/kubedb/apimachinery/releases/tag/v0.34.0-rc.0)
+
+- [19397df9](https://github.com/kubedb/apimachinery/commit/19397df9) Auto detect mode for ProxySQL (#1043)
+- [892c0d78](https://github.com/kubedb/apimachinery/commit/892c0d78) Move the schema-doubleOptIn helpers to be used as common utility (#1044)
+- [ef5eaff4](https://github.com/kubedb/apimachinery/commit/ef5eaff4) Update license verifier (#1042)
+- [70ebcf52](https://github.com/kubedb/apimachinery/commit/70ebcf52) Add `enableServiceLinks` to PodSpec (#1039)
+- [a92b36c3](https://github.com/kubedb/apimachinery/commit/a92b36c3) Test against K8s 1.27.1 (#1038)
+- [81c3f83c](https://github.com/kubedb/apimachinery/commit/81c3f83c) Test against K8s 1.27.0 (#1037)
+- [bb1d4ff3](https://github.com/kubedb/apimachinery/commit/bb1d4ff3) Fix linter
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.19.0-rc.0](https://github.com/kubedb/autoscaler/releases/tag/v0.19.0-rc.0)
+
+- [d0116a87](https://github.com/kubedb/autoscaler/commit/d0116a87) Prepare for release v0.19.0-rc.0 (#146)
+- [7b5d01a3](https://github.com/kubedb/autoscaler/commit/7b5d01a3) Update license verifier (#145)
+- [1987e74c](https://github.com/kubedb/autoscaler/commit/1987e74c) Update license verifier (#144)
+- [5d3a8fc6](https://github.com/kubedb/autoscaler/commit/5d3a8fc6) Add enableServiceLinks to PodSpec (#143)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.34.0-rc.0](https://github.com/kubedb/cli/releases/tag/v0.34.0-rc.0)
+
+- [166b7b23](https://github.com/kubedb/cli/commit/166b7b23) Prepare for release v0.34.0-rc.0 (#707)
+- [2efbea85](https://github.com/kubedb/cli/commit/2efbea85) Update license verifier (#706)
+- [b0d86409](https://github.com/kubedb/cli/commit/b0d86409) Add enableServiceLinks to PodSpec (#705)
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.10.0-rc.0](https://github.com/kubedb/dashboard/releases/tag/v0.10.0-rc.0)
+
+- [2dd3f01](https://github.com/kubedb/dashboard/commit/2dd3f01) Prepare for release v0.10.0-rc.0 (#74)
+- [7f4dce3](https://github.com/kubedb/dashboard/commit/7f4dce3) Re-Configure pod template fields (#72)
+- [d6780b2](https://github.com/kubedb/dashboard/commit/d6780b2) Update license verifier (#73)
+- [4bc57b5](https://github.com/kubedb/dashboard/commit/4bc57b5) Add enableServiceLinks to PodSpec (#71)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.34.0-rc.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.34.0-rc.0)
+
+- [805c7274](https://github.com/kubedb/elasticsearch/commit/805c72747) Prepare for release v0.34.0-rc.0 (#643)
+- [dfeec431](https://github.com/kubedb/elasticsearch/commit/dfeec4312) Use cached client (#639)
+- [605d3acc](https://github.com/kubedb/elasticsearch/commit/605d3acce) Re-Configure pod template fields (#637)
+- [1d060eff](https://github.com/kubedb/elasticsearch/commit/1d060eff8) Update docker/distribution (#642)
+- [7dcc3a7a](https://github.com/kubedb/elasticsearch/commit/7dcc3a7af) Update license verifier (#641)
+- [fd59f56c](https://github.com/kubedb/elasticsearch/commit/fd59f56c6) Update license verifier (#640)
+- [5a8b386f](https://github.com/kubedb/elasticsearch/commit/5a8b386f9) Add enableServiceLinks to PodSpec (#636)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2023.06.13-rc.0](https://github.com/kubedb/installer/releases/tag/v2023.06.13-rc.0)
+
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.5.0-rc.0](https://github.com/kubedb/kafka/releases/tag/v0.5.0-rc.0)
+
+- [d523a2e](https://github.com/kubedb/kafka/commit/d523a2e) Prepare for release v0.5.0-rc.0 (#29)
+- [640213a](https://github.com/kubedb/kafka/commit/640213a) Re-Configure pod template fields (#24)
+- [a772b4c](https://github.com/kubedb/kafka/commit/a772b4c) Update docker/distribution (#27)
+- [b643c9b](https://github.com/kubedb/kafka/commit/b643c9b) Update license verifier (#26)
+- [f75f877](https://github.com/kubedb/kafka/commit/f75f877) Update license verifier (#25)
+- [4985a5b](https://github.com/kubedb/kafka/commit/4985a5b) Add enableServiceLinks to PodSpec (#23)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.18.0-rc.0](https://github.com/kubedb/mariadb/releases/tag/v0.18.0-rc.0)
+
+- [710e8863](https://github.com/kubedb/mariadb/commit/710e8863) Prepare for release v0.18.0-rc.0 (#214)
+- [013cbda6](https://github.com/kubedb/mariadb/commit/013cbda6) Used cached client (#209)
+- [17475079](https://github.com/kubedb/mariadb/commit/17475079) Configure podtemplate fields (#213)
+- [059ba1e2](https://github.com/kubedb/mariadb/commit/059ba1e2) Update docker/distribution (#212)
+- [5cb60c15](https://github.com/kubedb/mariadb/commit/5cb60c15) Update license verifier (#211)
+- [b04b55ea](https://github.com/kubedb/mariadb/commit/b04b55ea) Update license verifier (#210)
+- [4953dd26](https://github.com/kubedb/mariadb/commit/4953dd26) Add enableServiceLinks to PodSpec (#208)
+- [f953bfb4](https://github.com/kubedb/mariadb/commit/f953bfb4) Test against K8s 1.27.0 (#207)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.14.0-rc.0](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.14.0-rc.0)
+
+- [1ad0eab6](https://github.com/kubedb/mariadb-coordinator/commit/1ad0eab6) Prepare for release v0.14.0-rc.0 (#84)
+- [6e2fcb39](https://github.com/kubedb/mariadb-coordinator/commit/6e2fcb39) Read pass from env (#81)
+- [0b3ae6b8](https://github.com/kubedb/mariadb-coordinator/commit/0b3ae6b8) Update license verifier (#83)
+- [ca4b5b1d](https://github.com/kubedb/mariadb-coordinator/commit/ca4b5b1d) Update license verifier (#82)
+- [5bc15939](https://github.com/kubedb/mariadb-coordinator/commit/5bc15939) Add enableServiceLinks to PodSpec (#80)
+- [e3a4ed91](https://github.com/kubedb/mariadb-coordinator/commit/e3a4ed91) Test against K8s 1.27.0 (#79)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.27.0-rc.0](https://github.com/kubedb/memcached/releases/tag/v0.27.0-rc.0)
+
+- [8584ad5d](https://github.com/kubedb/memcached/commit/8584ad5d) Prepare for release v0.27.0-rc.0 (#395)
+- [d91bd11f](https://github.com/kubedb/memcached/commit/d91bd11f) Update license verifier (#394)
+- [44765061](https://github.com/kubedb/memcached/commit/44765061) Update license verifier (#393)
+- [d4be3ee0](https://github.com/kubedb/memcached/commit/d4be3ee0) Add enableServiceLinks to PodSpec (#392)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.27.0-rc.0](https://github.com/kubedb/mongodb/releases/tag/v0.27.0-rc.0)
+
+- [39f1936f](https://github.com/kubedb/mongodb/commit/39f1936f) Prepare for release v0.27.0-rc.0 (#553)
+- [5f12f078](https://github.com/kubedb/mongodb/commit/5f12f078) Use cached client (#550)
+- [2130dd52](https://github.com/kubedb/mongodb/commit/2130dd52) Update docker/distribution (#552)
+- [0c3ee218](https://github.com/kubedb/mongodb/commit/0c3ee218) Update license verifier (#551)
+- [70367dcd](https://github.com/kubedb/mongodb/commit/70367dcd) Configure pod template fields (#548)
+- [61a4b51a](https://github.com/kubedb/mongodb/commit/61a4b51a) Add enableServiceLinks to PodSpec (#546)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.27.0-rc.0](https://github.com/kubedb/mysql/releases/tag/v0.27.0-rc.0)
+
+- [6b41e393](https://github.com/kubedb/mysql/commit/6b41e393) Prepare for release v0.27.0-rc.0 (#538)
+- [9b3a2cf6](https://github.com/kubedb/mysql/commit/9b3a2cf6) Used cached client (#535)
+- [fefe9865](https://github.com/kubedb/mysql/commit/fefe9865) Configure pod template fields (#534)
+- [d30d0aa9](https://github.com/kubedb/mysql/commit/d30d0aa9) Update docker/distribution (#537)
+- [da13390d](https://github.com/kubedb/mysql/commit/da13390d) Update license verifier (#536)
+- [bb928789](https://github.com/kubedb/mysql/commit/bb928789) Add enableServiceLinks to PodSpec (#532)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.12.0-rc.0](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.12.0-rc.0)
+
+- [0a4ecdf](https://github.com/kubedb/mysql-coordinator/commit/0a4ecdf) Prepare for release v0.12.0-rc.0 (#80)
+- [8a7f31c](https://github.com/kubedb/mysql-coordinator/commit/8a7f31c) Read password form env (#79)
+- [d1d8106](https://github.com/kubedb/mysql-coordinator/commit/d1d8106) Add enableServiceLinks to PodSpec (#78)
+- [3e67a4f](https://github.com/kubedb/mysql-coordinator/commit/3e67a4f) Test against K8s 1.27.0 (#77)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.12.0-rc.0](https://github.com/kubedb/mysql-router-init/releases/tag/v0.12.0-rc.0)
+
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.21.0-rc.0](https://github.com/kubedb/ops-manager/releases/tag/v0.21.0-rc.0)
+
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.21.0-rc.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.21.0-rc.0)
+
+- [cb1c8481](https://github.com/kubedb/percona-xtradb/commit/cb1c8481) Prepare for release v0.21.0-rc.0 (#315)
+- [da3fbc76](https://github.com/kubedb/percona-xtradb/commit/da3fbc76) Used cached client (#311)
+- [39144eb2](https://github.com/kubedb/percona-xtradb/commit/39144eb2) Configure podtemplate fields (#314)
+- [d85284ea](https://github.com/kubedb/percona-xtradb/commit/d85284ea) Update docker/distribution (#313)
+- [b3a5c6f3](https://github.com/kubedb/percona-xtradb/commit/b3a5c6f3) Update license verifier (#312)
+- [445c4787](https://github.com/kubedb/percona-xtradb/commit/445c4787) Add enableServiceLinks to PodSpec (#309)
+- [c2c1451e](https://github.com/kubedb/percona-xtradb/commit/c2c1451e) Test against K8s 1.27.0 (#308)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.7.0-rc.0](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.7.0-rc.0)
+
+- [cfd5919](https://github.com/kubedb/percona-xtradb-coordinator/commit/cfd5919) Prepare for release v0.7.0-rc.0 (#41)
+- [fa25aaa](https://github.com/kubedb/percona-xtradb-coordinator/commit/fa25aaa) Read pass from env (#38)
+- [3322225](https://github.com/kubedb/percona-xtradb-coordinator/commit/3322225) Update license verifier (#40)
+- [f44d3ba](https://github.com/kubedb/percona-xtradb-coordinator/commit/f44d3ba) Update license verifier (#39)
+- [bbbabf7](https://github.com/kubedb/percona-xtradb-coordinator/commit/bbbabf7) Add enableServiceLinks to PodSpec (#37)
+- [052fb88](https://github.com/kubedb/percona-xtradb-coordinator/commit/052fb88) Test against K8s 1.27.0 (#36)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.18.0-rc.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.18.0-rc.0)
+
+- [dbc0ab09](https://github.com/kubedb/pg-coordinator/commit/dbc0ab09) Prepare for release v0.18.0-rc.0 (#123)
+- [8a17dbe1](https://github.com/kubedb/pg-coordinator/commit/8a17dbe1) Update license verifier (#122)
+- [a86af91b](https://github.com/kubedb/pg-coordinator/commit/a86af91b) Update license verifier (#121)
+- [1a538695](https://github.com/kubedb/pg-coordinator/commit/1a538695) Add enableServiceLinks to PodSpec (#120)
+- [f680dc7b](https://github.com/kubedb/pg-coordinator/commit/f680dc7b) Test against K8s 1.27.0 (#119)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.21.0-rc.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.21.0-rc.0)
+
+- [510a0100](https://github.com/kubedb/pgbouncer/commit/510a0100) Prepare for release v0.21.0-rc.0 (#280)
+- [1b5a8f2b](https://github.com/kubedb/pgbouncer/commit/1b5a8f2b) Update docker/distribution (#279)
+- [7da9582c](https://github.com/kubedb/pgbouncer/commit/7da9582c) Update license verifier (#278)
+- [b056ed70](https://github.com/kubedb/pgbouncer/commit/b056ed70) Update license verifier (#277)
+- [e4211b77](https://github.com/kubedb/pgbouncer/commit/e4211b77) Add enableServiceLinks to PodSpec (#275)
+- [32d37f30](https://github.com/kubedb/pgbouncer/commit/32d37f30) Test against K8s 1.27.0 (#274)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.34.0-rc.0](https://github.com/kubedb/postgres/releases/tag/v0.34.0-rc.0)
+
+- [03615529](https://github.com/kubedb/postgres/commit/036155296) Prepare for release v0.34.0-rc.0 (#645)
+- [5b178fe3](https://github.com/kubedb/postgres/commit/5b178fe3c) Used cached client (#641)
+- [5d4f949c](https://github.com/kubedb/postgres/commit/5d4f949cd) Update docker/distribution (#644)
+- [0bd2d452](https://github.com/kubedb/postgres/commit/0bd2d452b) Configure pod template fields (#642)
+- [7e18f135](https://github.com/kubedb/postgres/commit/7e18f1359) Update license verifier (#643)
+- [09607de3](https://github.com/kubedb/postgres/commit/09607de3e) Add enableServiceLinks to PodSpec (#639)
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.34.0-rc.0](https://github.com/kubedb/provisioner/releases/tag/v0.34.0-rc.0)
+
+- [5828a53a](https://github.com/kubedb/provisioner/commit/5828a53aa) Prepare for release v0.34.0-rc.0 (#49)
+- [ddbfc75b](https://github.com/kubedb/provisioner/commit/ddbfc75bd) Update docker/distribution (#48)
+- [1f2d4d5a](https://github.com/kubedb/provisioner/commit/1f2d4d5a6) Update license verifier (#47)
+- [b2b71d00](https://github.com/kubedb/provisioner/commit/b2b71d00c) Add enableServiceLinks to PodSpec (#46)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.21.0-rc.0](https://github.com/kubedb/proxysql/releases/tag/v0.21.0-rc.0)
+
+- [55a2b71f](https://github.com/kubedb/proxysql/commit/55a2b71f) Prepare for release v0.21.0-rc.0 (#297)
+- [3b813223](https://github.com/kubedb/proxysql/commit/3b813223) Used cached client (#291)
+- [e657808c](https://github.com/kubedb/proxysql/commit/e657808c) Fix ProxySQL Backend Mode Issue (#296)
+- [c8540a1a](https://github.com/kubedb/proxysql/commit/c8540a1a) Configure pod template feilds (#295)
+- [8586dcdf](https://github.com/kubedb/proxysql/commit/8586dcdf) Update docker/distribution (#294)
+- [80122c5d](https://github.com/kubedb/proxysql/commit/80122c5d) Update license verifier (#292)
+- [1de70c13](https://github.com/kubedb/proxysql/commit/1de70c13) Add enableServiceLinks to PodSpec (#290)
+- [32525708](https://github.com/kubedb/proxysql/commit/32525708) Test against K8s 1.27.0 (#289)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.27.0-rc.0](https://github.com/kubedb/redis/releases/tag/v0.27.0-rc.0)
+
+- [8411d7d9](https://github.com/kubedb/redis/commit/8411d7d9) Prepare for release v0.27.0-rc.0 (#467)
+- [f1f3e2c9](https://github.com/kubedb/redis/commit/f1f3e2c9) Use cached client (#463)
+- [0884c60c](https://github.com/kubedb/redis/commit/0884c60c) Update docker/distribution (#466)
+- [385691d6](https://github.com/kubedb/redis/commit/385691d6) Update license verifier (#465)
+- [37fa806f](https://github.com/kubedb/redis/commit/37fa806f) Configure pod template fields (#464)
+- [2993d8b7](https://github.com/kubedb/redis/commit/2993d8b7) Add enableServiceLinks to PodSpec (#461)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.13.0-rc.0](https://github.com/kubedb/redis-coordinator/releases/tag/v0.13.0-rc.0)
+
+- [8b0ecaa](https://github.com/kubedb/redis-coordinator/commit/8b0ecaa) Prepare for release v0.13.0-rc.0 (#73)
+- [9d42b96](https://github.com/kubedb/redis-coordinator/commit/9d42b96) Update license verifier (#72)
+- [31a4f43](https://github.com/kubedb/redis-coordinator/commit/31a4f43) Update license verifier (#71)
+- [61bc0cf](https://github.com/kubedb/redis-coordinator/commit/61bc0cf) Add enableServiceLinks to PodSpec (#70)
+- [ca42ade](https://github.com/kubedb/redis-coordinator/commit/ca42ade) Test against K8s 1.27.0 (#69)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.21.0-rc.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.21.0-rc.0)
+
+- [22364949](https://github.com/kubedb/replication-mode-detector/commit/22364949) Prepare for release v0.21.0-rc.0 (#235)
+- [13f4af9f](https://github.com/kubedb/replication-mode-detector/commit/13f4af9f) Update license verifier (#234)
+- [49187c88](https://github.com/kubedb/replication-mode-detector/commit/49187c88) Update license verifier (#233)
+- [cc8e62a7](https://github.com/kubedb/replication-mode-detector/commit/cc8e62a7) Test against K8s 1.27.0 (#231)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.10.0-rc.0](https://github.com/kubedb/schema-manager/releases/tag/v0.10.0-rc.0)
+
+- [3bf16dac](https://github.com/kubedb/schema-manager/commit/3bf16dac) Prepare for release v0.10.0-rc.0 (#75)
+- [a80da62a](https://github.com/kubedb/schema-manager/commit/a80da62a) Update license verifier (#74)
+- [0761e223](https://github.com/kubedb/schema-manager/commit/0761e223) Update license verifier (#73)
+- [83fa3191](https://github.com/kubedb/schema-manager/commit/83fa3191) Add enableServiceLinks to PodSpec (#72)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.19.0-rc.0](https://github.com/kubedb/tests/releases/tag/v0.19.0-rc.0)
+
+- [066c8cf9](https://github.com/kubedb/tests/commit/066c8cf9) Prepare for release v0.19.0-rc.0 (#227)
+- [e49d6470](https://github.com/kubedb/tests/commit/e49d6470) Update license verifier (#226)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.10.0-rc.0](https://github.com/kubedb/ui-server/releases/tag/v0.10.0-rc.0)
+
+- [f3cee800](https://github.com/kubedb/ui-server/commit/f3cee800) Prepare for release v0.10.0-rc.0 (#80)
+- [86d37355](https://github.com/kubedb/ui-server/commit/86d37355) Update docker/distribution (#79)
+- [5f060b7e](https://github.com/kubedb/ui-server/commit/5f060b7e) Update license verifier (#77)
+- [6cf6d5ab](https://github.com/kubedb/ui-server/commit/6cf6d5ab) Close mongo client connection with defer (#76)
+- [312e5210](https://github.com/kubedb/ui-server/commit/312e5210) Add enableServiceLinks to PodSpec (#75)
+- [662808cb](https://github.com/kubedb/ui-server/commit/662808cb) Test against K8s 1.27.0 (#74)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.10.0-rc.0](https://github.com/kubedb/webhook-server/releases/tag/v0.10.0-rc.0)
+
+- [6673b381](https://github.com/kubedb/webhook-server/commit/6673b381) Prepare for release v0.10.0-rc.0 (#60)
+- [c502edd3](https://github.com/kubedb/webhook-server/commit/c502edd3) Add enableServiceLinks to PodSpec (#59)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.06.13-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/70
Signed-off-by: 1gtm <1gtm@appscode.com>