### PR TITLE
PgAdmin does not start from scratch

### DIFF
--- a/docs/examples/postgres/quickstart/pgadmin.yaml
+++ b/docs/examples/postgres/quickstart/pgadmin.yaml
@@ -21,7 +21,7 @@ spec:
         name: pgadmin
         env:
         - name: PGADMIN_DEFAULT_EMAIL
-          value: "admin"
+          value: "admin@cluster.local"
         - name: PGADMIN_DEFAULT_PASSWORD
           value: "admin"
         - name: PGADMIN_PORT


### PR DESCRIPTION
Using 
```
kubectl create -f https://github.com/kubedb/docs/raw/v2023.06.19/docs/examples/postgres/quickstart/pgadmin.yaml
```

My pgadmin instance can't start. Because of

```
❯ docker run -e PGADMIN_DEFAULT_EMAIL=admin -e PGADMIN_DEFAULT_PASSWORD=admin -e PGADMIN_PORT=80 --rm -it dpage/pgadmin4:latest
'admin' does not appear to be a valid email address. Please reset the PGADMIN_DEFAULT_EMAIL environment variable and try again.
```