### PR TITLE
Prepare for release v2023.10.9

### DIFF
--- a/docs/CHANGELOG-v2023.10.9.md
+++ b/docs/CHANGELOG-v2023.10.9.md
@@ -1,0 +1,282 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2023.10.9
+    name: Changelog-v2023.10.9
+    parent: welcome
+    weight: 20231009
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.10.9/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.10.9/
+---
+
+# KubeDB v2023.10.9 (2023-10-10)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.36.0](https://github.com/kubedb/apimachinery/releases/tag/v0.36.0)
+
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.21.0](https://github.com/kubedb/autoscaler/releases/tag/v0.21.0)
+
+- [2a8f602d](https://github.com/kubedb/autoscaler/commit/2a8f602d) Prepare for release v0.21.0 (#156)
+- [e5d14b17](https://github.com/kubedb/autoscaler/commit/e5d14b17) Merge pull request #155 from kubedb/sc
+- [170f72b4](https://github.com/kubedb/autoscaler/commit/170f72b4) Set seccompProfile to RuntimeDefault
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.36.0](https://github.com/kubedb/cli/releases/tag/v0.36.0)
+
+- [54f42c6a](https://github.com/kubedb/cli/commit/54f42c6a) Prepare for release v0.36.0 (#726)
+- [73976008](https://github.com/kubedb/cli/commit/73976008) add support for remote-config (#723)
+- [ceb2bda4](https://github.com/kubedb/cli/commit/ceb2bda4) Use apply: Always for restart command (#725)
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.12.0](https://github.com/kubedb/dashboard/releases/tag/v0.12.0)
+
+- [b1d6bf2e](https://github.com/kubedb/dashboard/commit/b1d6bf2e) Prepare for release v0.12.0 (#82)
+- [57aa22a2](https://github.com/kubedb/dashboard/commit/57aa22a2) Add seccomp profile to installer securityContext
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.36.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.36.0)
+
+- [3519e493](https://github.com/kubedb/elasticsearch/commit/3519e4933) Prepare for release v0.36.0 (#670)
+- [9766b3cd](https://github.com/kubedb/elasticsearch/commit/9766b3cd5) Update daily-opensearch.yml
+- [875eff12](https://github.com/kubedb/elasticsearch/commit/875eff129) Fix support for OS hot-warm-cold nodes (#669)
+- [b51b628e](https://github.com/kubedb/elasticsearch/commit/b51b628ee) Install Kibana Dashboard controller before running opensearch e2e
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2023.10.9](https://github.com/kubedb/installer/releases/tag/v2023.10.9)
+
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.7.0](https://github.com/kubedb/kafka/releases/tag/v0.7.0)
+
+- [0119452](https://github.com/kubedb/kafka/commit/0119452) Prepare for release v0.7.0 (#40)
+- [e26604d](https://github.com/kubedb/kafka/commit/e26604d) Add primary-service address to advertised.listeners (#39)
+- [c3bcf55](https://github.com/kubedb/kafka/commit/c3bcf55) Patch service ports with spec.serviceTemplate (#38)
+- [a11bfd6](https://github.com/kubedb/kafka/commit/a11bfd6) Add external advertised listener and Redesign reconcile (#37)
+- [727f414](https://github.com/kubedb/kafka/commit/727f414) Add seccomp profile to makefile (#36)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.20.0](https://github.com/kubedb/mariadb/releases/tag/v0.20.0)
+
+- [949c14e3](https://github.com/kubedb/mariadb/commit/949c14e3) Prepare for release v0.20.0 (#230)
+- [24de9c01](https://github.com/kubedb/mariadb/commit/24de9c01) Set seccompProfile to RuntimeDefault (#229)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.16.0](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.16.0)
+
+- [4ab95aeb](https://github.com/kubedb/mariadb-coordinator/commit/4ab95aeb) Prepare for release v0.16.0 (#90)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.29.0](https://github.com/kubedb/memcached/releases/tag/v0.29.0)
+
+- [cd5ddf0c](https://github.com/kubedb/memcached/commit/cd5ddf0c) Prepare for release v0.29.0 (#403)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.29.0](https://github.com/kubedb/mongodb/releases/tag/v0.29.0)
+
+- [56c9cecd](https://github.com/kubedb/mongodb/commit/56c9cecd) Prepare for release v0.29.0 (#570)
+- [4ceb44cb](https://github.com/kubedb/mongodb/commit/4ceb44cb) Health check for unusual secondary lock (#569)
+- [10a4fd76](https://github.com/kubedb/mongodb/commit/10a4fd76) Set seccompProfile to RuntimeDefault (#561)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.14.0](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.14.0)
+
+- [bc3b65c](https://github.com/kubedb/mysql-coordinator/commit/bc3b65c) Prepare for release v0.14.0 (#86)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.14.0](https://github.com/kubedb/mysql-router-init/releases/tag/v0.14.0)
+
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.23.0](https://github.com/kubedb/ops-manager/releases/tag/v0.23.0)
+
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.23.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.23.0)
+
+- [21b46846](https://github.com/kubedb/percona-xtradb/commit/21b46846) Prepare for release v0.23.0 (#329)
+- [f1c04f03](https://github.com/kubedb/percona-xtradb/commit/f1c04f03) Set seccompProfile to RuntimeDefault (#328)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.9.0](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.9.0)
+
+- [94433e4](https://github.com/kubedb/percona-xtradb-coordinator/commit/94433e4) Prepare for release v0.9.0 (#47)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.20.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.20.0)
+
+- [e3aa0fe7](https://github.com/kubedb/pg-coordinator/commit/e3aa0fe7) Prepare for release v0.20.0 (#133)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.23.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.23.0)
+
+- [2b2636f5](https://github.com/kubedb/pgbouncer/commit/2b2636f5) Prepare for release v0.23.0 (#290)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.36.0](https://github.com/kubedb/postgres/releases/tag/v0.36.0)
+
+- [3085d92c](https://github.com/kubedb/postgres/commit/3085d92c1) Prepare for release v0.36.0 (#671)
+- [2c16dc52](https://github.com/kubedb/postgres/commit/2c16dc52a) Run release workflows on high priority workers (#670)
+- [57309782](https://github.com/kubedb/postgres/commit/573097827) Set seccompProfile to RuntimeDefault (#667)
+- [90fe6045](https://github.com/kubedb/postgres/commit/90fe60458) update apimacinery (#666)
+- [c95eb6a7](https://github.com/kubedb/postgres/commit/c95eb6a70) add support for remote replica (#665)
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.36.0](https://github.com/kubedb/provisioner/releases/tag/v0.36.0)
+
+- [bcf6db2d](https://github.com/kubedb/provisioner/commit/bcf6db2d9) Prepare for release v0.36.0 (#56)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.23.0](https://github.com/kubedb/proxysql/releases/tag/v0.23.0)
+
+- [7688d9df](https://github.com/kubedb/proxysql/commit/7688d9df) Prepare for release v0.23.0 (#311)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.29.0](https://github.com/kubedb/redis/releases/tag/v0.29.0)
+
+- [2941778b](https://github.com/kubedb/redis/commit/2941778b) Prepare for release v0.29.0 (#486)
+- [c0292f61](https://github.com/kubedb/redis/commit/c0292f61) Set seccompProfile to RuntimeDefault (#485)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.15.0](https://github.com/kubedb/redis-coordinator/releases/tag/v0.15.0)
+
+- [2410719](https://github.com/kubedb/redis-coordinator/commit/2410719) Prepare for release v0.15.0 (#78)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.23.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.23.0)
+
+- [e1bcb02e](https://github.com/kubedb/replication-mode-detector/commit/e1bcb02e) Prepare for release v0.23.0 (#242)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.12.0](https://github.com/kubedb/schema-manager/releases/tag/v0.12.0)
+
+- [c57b7709](https://github.com/kubedb/schema-manager/commit/c57b7709) Prepare for release v0.12.0 (#83)
+- [5a624bde](https://github.com/kubedb/schema-manager/commit/5a624bde) Merge pull request #82 from kubedb/sc
+- [26d04829](https://github.com/kubedb/schema-manager/commit/26d04829) Set seccompProfile to RuntimeDefault
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.21.0](https://github.com/kubedb/tests/releases/tag/v0.21.0)
+
+- [841fe9e9](https://github.com/kubedb/tests/commit/841fe9e9) Prepare for release v0.21.0 (#262)
+- [eed6ebcb](https://github.com/kubedb/tests/commit/eed6ebcb) Fix autoscaler test profiles (#261)
+- [a2df0e09](https://github.com/kubedb/tests/commit/a2df0e09) MySQL autoscale test fix (#260)
+- [b7cc5aaf](https://github.com/kubedb/tests/commit/b7cc5aaf) Fix Mysql Test Issue for Elasticsearchversion. (#259)
+- [b9da67f3](https://github.com/kubedb/tests/commit/b9da67f3) Use storageclass flag for autoscaling, if set (#258)
+- [0cd78c0b](https://github.com/kubedb/tests/commit/0cd78c0b) Unfocus tests
+- [30fd08c8](https://github.com/kubedb/tests/commit/30fd08c8) Fix hot-warm-cold clustering tests for OpenSearch (#257)
+- [b43235f9](https://github.com/kubedb/tests/commit/b43235f9) Fix Test for Downscaling ES data nodes (#256)
+- [8206ec72](https://github.com/kubedb/tests/commit/8206ec72) Add missing provisioner tests for Elasticsearch (#247)
+- [6f289856](https://github.com/kubedb/tests/commit/6f289856) Add Stash Auto-backup tests for Redis (#252)
+- [70db31e5](https://github.com/kubedb/tests/commit/70db31e5) Add AutoScaler for MySQL and Fixed in MariaDB (#246)
+- [816804c6](https://github.com/kubedb/tests/commit/816804c6) Add redis restore tests (#249)
+- [e73c3465](https://github.com/kubedb/tests/commit/e73c3465) Add missing provisioner e2e test - custom auth secret tests (#244)
+- [5adcf205](https://github.com/kubedb/tests/commit/5adcf205) Add stash backup tests (#245)
+- [bedb2081](https://github.com/kubedb/tests/commit/bedb2081) Exclude volume expansion test (#248)
+- [fddc0a69](https://github.com/kubedb/tests/commit/fddc0a69) Fix existing tests for ES & OS (#236)
+- [0089ac1d](https://github.com/kubedb/tests/commit/0089ac1d) Ensure minio-server for stash-related tests (#243)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.12.0](https://github.com/kubedb/ui-server/releases/tag/v0.12.0)
+
+- [e1e491ca](https://github.com/kubedb/ui-server/commit/e1e491ca) Prepare for release v0.12.0 (#91)
+- [119250af](https://github.com/kubedb/ui-server/commit/119250af) Set seccompProfile to RuntimeDefault (#90)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.12.0](https://github.com/kubedb/webhook-server/releases/tag/v0.12.0)
+
+- [24369a19](https://github.com/kubedb/webhook-server/commit/24369a19) Prepare for release v0.12.0 (#68)
+- [0e9ffedc](https://github.com/kubedb/webhook-server/commit/0e9ffedc) Set seccompProfile to RuntimeDefault (#67)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.10.9
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/73
Signed-off-by: 1gtm <1gtm@appscode.com>