### PR TITLE
Prepare for release v2023.11.2

### DIFF
--- a/docs/CHANGELOG-v2023.11.2.md
+++ b/docs/CHANGELOG-v2023.11.2.md
@@ -1,0 +1,259 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2023.11.2
+    name: Changelog-v2023.11.2
+    parent: welcome
+    weight: 20231102
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.11.2/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.11.2/
+---
+
+# KubeDB v2023.11.2 (2023-11-02)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.37.0](https://github.com/kubedb/apimachinery/releases/tag/v0.37.0)
+
+- [feb7d046](https://github.com/kubedb/apimachinery/commit/feb7d046) Update deps
+- [b69c766e](https://github.com/kubedb/apimachinery/commit/b69c766e) Bring back GetRequestType() (#1064)
+- [f684560c](https://github.com/kubedb/apimachinery/commit/f684560c) Remove spec.upgrade field and Upgrade ops type (#1063)
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.22.0](https://github.com/kubedb/autoscaler/releases/tag/v0.22.0)
+
+- [4d6e524e](https://github.com/kubedb/autoscaler/commit/4d6e524e) Prepare for release v0.22.0 (#157)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.37.0](https://github.com/kubedb/cli/releases/tag/v0.37.0)
+
+- [78ff0505](https://github.com/kubedb/cli/commit/78ff0505) Prepare for release v0.37.0 (#729)
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.13.0](https://github.com/kubedb/dashboard/releases/tag/v0.13.0)
+
+- [746cdbf2](https://github.com/kubedb/dashboard/commit/746cdbf2) Prepare for release v0.13.0 (#83)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.37.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.37.0)
+
+- [9f3dcdd2](https://github.com/kubedb/elasticsearch/commit/9f3dcdd2b) Prepare for release v0.37.0 (#675)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2023.11.2](https://github.com/kubedb/installer/releases/tag/v2023.11.2)
+
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.8.0](https://github.com/kubedb/kafka/releases/tag/v0.8.0)
+
+- [1101f2c](https://github.com/kubedb/kafka/commit/1101f2c) Prepare for release v0.8.0 (#41)
+- [4e3c27e](https://github.com/kubedb/kafka/commit/4e3c27e) Disable stash installation
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.21.0](https://github.com/kubedb/mariadb/releases/tag/v0.21.0)
+
+- [7f583121](https://github.com/kubedb/mariadb/commit/7f583121) Prepare for release v0.21.0 (#231)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.17.0](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.17.0)
+
+- [fc27813c](https://github.com/kubedb/mariadb-coordinator/commit/fc27813c) Prepare for release v0.17.0 (#91)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.30.0](https://github.com/kubedb/memcached/releases/tag/v0.30.0)
+
+- [91294d5d](https://github.com/kubedb/memcached/commit/91294d5d) Prepare for release v0.30.0 (#404)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.30.0](https://github.com/kubedb/mongodb/releases/tag/v0.30.0)
+
+- [b4783ade](https://github.com/kubedb/mongodb/commit/b4783ade) Prepare for release v0.30.0 (#574)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.30.0](https://github.com/kubedb/mysql/releases/tag/v0.30.0)
+
+- [c48c4374](https://github.com/kubedb/mysql/commit/c48c4374) Prepare for release v0.30.0 (#569)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.15.0](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.15.0)
+
+- [8a49d1f](https://github.com/kubedb/mysql-coordinator/commit/8a49d1f) Prepare for release v0.15.0 (#88)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.15.0](https://github.com/kubedb/mysql-router-init/releases/tag/v0.15.0)
+
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.24.0](https://github.com/kubedb/ops-manager/releases/tag/v0.24.0)
+
+- [ecee4464](https://github.com/kubedb/ops-manager/commit/ecee4464) Prepare for release v0.24.0 (#484)
+- [eecc2c17](https://github.com/kubedb/ops-manager/commit/eecc2c17) Remove spec.upgrade field and Upgrade ops type (#482)
+- [54caa66d](https://github.com/kubedb/ops-manager/commit/54caa66d) Reprovision opsReq will progress even if DB is in Provisioning state (#480)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.24.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.24.0)
+
+- [83f333a6](https://github.com/kubedb/percona-xtradb/commit/83f333a6) Prepare for release v0.24.0 (#330)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.10.0](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.10.0)
+
+- [d92be74](https://github.com/kubedb/percona-xtradb-coordinator/commit/d92be74) Prepare for release v0.10.0 (#48)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.21.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.21.0)
+
+- [bc69455b](https://github.com/kubedb/pg-coordinator/commit/bc69455b) Prepare for release v0.21.0 (#135)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.24.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.24.0)
+
+- [2973741d](https://github.com/kubedb/pgbouncer/commit/2973741d) Prepare for release v0.24.0 (#295)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.37.0](https://github.com/kubedb/postgres/releases/tag/v0.37.0)
+
+- [9bf1793e](https://github.com/kubedb/postgres/commit/9bf1793ea) Prepare for release v0.37.0 (#676)
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.37.0](https://github.com/kubedb/provisioner/releases/tag/v0.37.0)
+
+- [aece653d](https://github.com/kubedb/provisioner/commit/aece653d2) Prepare for release v0.37.0 (#58)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.24.0](https://github.com/kubedb/proxysql/releases/tag/v0.24.0)
+
+- [ebcaa7ac](https://github.com/kubedb/proxysql/commit/ebcaa7ac) Prepare for release v0.24.0 (#312)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.30.0](https://github.com/kubedb/redis/releases/tag/v0.30.0)
+
+- [abe2953b](https://github.com/kubedb/redis/commit/abe2953b) Prepare for release v0.30.0 (#493)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.16.0](https://github.com/kubedb/redis-coordinator/releases/tag/v0.16.0)
+
+- [5159461a](https://github.com/kubedb/redis-coordinator/commit/5159461a) Prepare for release v0.16.0 (#79)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.24.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.24.0)
+
+- [16cba321](https://github.com/kubedb/replication-mode-detector/commit/16cba321) Prepare for release v0.24.0 (#243)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.13.0](https://github.com/kubedb/schema-manager/releases/tag/v0.13.0)
+
+- [072d4c70](https://github.com/kubedb/schema-manager/commit/072d4c70) Prepare for release v0.13.0 (#84)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.22.0](https://github.com/kubedb/tests/releases/tag/v0.22.0)
+
+- [7f48fadf](https://github.com/kubedb/tests/commit/7f48fadf) Prepare for release v0.22.0 (#265)
+- [94fcf34b](https://github.com/kubedb/tests/commit/94fcf34b) Minimize mongo test areas; Increase timeout (#264)
+- [0808fc26](https://github.com/kubedb/tests/commit/0808fc26) Add Redis Autoscaler tests (#255)
+- [bbf8b2f3](https://github.com/kubedb/tests/commit/bbf8b2f3) Update mysql remote replica (#263)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.13.0](https://github.com/kubedb/ui-server/releases/tag/v0.13.0)
+
+- [82adcd74](https://github.com/kubedb/ui-server/commit/82adcd74) Prepare for release v0.13.0 (#93)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.13.0](https://github.com/kubedb/webhook-server/releases/tag/v0.13.0)
+
+- [9ffa4b85](https://github.com/kubedb/webhook-server/commit/9ffa4b85) Prepare for release v0.13.0 (#69)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.11.2
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/74
Signed-off-by: 1gtm <1gtm@appscode.com>