### PR TITLE
Prepare for release v2023.11.29-rc.0

### DIFF
--- a/docs/CHANGELOG-v2023.11.29-rc.0.md
+++ b/docs/CHANGELOG-v2023.11.29-rc.0.md
@@ -1,0 +1,520 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2023.11.29-rc.0
+    name: Changelog-v2023.11.29-rc.0
+    parent: welcome
+    weight: 20231129
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.11.29-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.11.29-rc.0/
+---
+
+# KubeDB v2023.11.29-rc.0 (2023-11-30)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.38.0-rc.0](https://github.com/kubedb/apimachinery/releases/tag/v0.38.0-rc.0)
+
+- [e070a3ae](https://github.com/kubedb/apimachinery/commit/e070a3ae) Do not default the seccompProfile (#1079)
+- [29c96031](https://github.com/kubedb/apimachinery/commit/29c96031) Set Default Security Context for MariaDB (#1077)
+- [fc35d376](https://github.com/kubedb/apimachinery/commit/fc35d376) Set default SecurityContext for mysql (#1070)
+- [ee71aca0](https://github.com/kubedb/apimachinery/commit/ee71aca0) Update dependencies
+- [93b5ba51](https://github.com/kubedb/apimachinery/commit/93b5ba51) add encriptSecret to postgresAchiver (#1078)
+- [2b06b6e5](https://github.com/kubedb/apimachinery/commit/2b06b6e5) Add mongodb & postgres archiver (#1016)
+- [47793c9a](https://github.com/kubedb/apimachinery/commit/47793c9a) Set default  SecurityContext for Elasticsearch. (#1072)
+- [90567b46](https://github.com/kubedb/apimachinery/commit/90567b46) Set default SecurityContext for Kafka (#1068)
+- [449a4e00](https://github.com/kubedb/apimachinery/commit/449a4e00) Remove redundant helper functions for Kafka and Update constants (#1074)
+- [b28463f4](https://github.com/kubedb/apimachinery/commit/b28463f4) Set fsGroup to 999 to avoid mountedPath's files permission issue in different storageClass (#1075)
+- [8e497b92](https://github.com/kubedb/apimachinery/commit/8e497b92) Set Default Security Context for Redis (#1073)
+- [88ab93c7](https://github.com/kubedb/apimachinery/commit/88ab93c7) Set default SecurityContext for mongodb (#1067)
+- [e7ac5d2e](https://github.com/kubedb/apimachinery/commit/e7ac5d2e) Set default for security Context for postgres (#1069)
+- [f5de4a28](https://github.com/kubedb/apimachinery/commit/f5de4a28) Add support for init with git-sync; Add const (#1065)
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.23.0-rc.0](https://github.com/kubedb/autoscaler/releases/tag/v0.23.0-rc.0)
+
+- [a406fbda](https://github.com/kubedb/autoscaler/commit/a406fbda) Prepare for release v0.23.0-rc.0 (#158)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.38.0-rc.0](https://github.com/kubedb/cli/releases/tag/v0.38.0-rc.0)
+
+- [3a4dcc47](https://github.com/kubedb/cli/commit/3a4dcc47) Prepare for release v0.38.0-rc.0 (#737)
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.14.0-rc.0](https://github.com/kubedb/dashboard/releases/tag/v0.14.0-rc.0)
+
+- [c2982e93](https://github.com/kubedb/dashboard/commit/c2982e93) Prepare for release v0.14.0-rc.0 (#85)
+- [9a9e6cd9](https://github.com/kubedb/dashboard/commit/9a9e6cd9) Add container security context for elasticsearch dashboard. (#84)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.38.0-rc.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.38.0-rc.0)
+
+- [6b2943f1](https://github.com/kubedb/elasticsearch/commit/6b2943f19) Prepare for release v0.38.0-rc.0 (#678)
+- [7f1a37e1](https://github.com/kubedb/elasticsearch/commit/7f1a37e1a) Add prepare cluster installer before test runner (#677)
+- [1d49f16d](https://github.com/kubedb/elasticsearch/commit/1d49f16d2) Remove `init-sysctl` container and add default containerSecurityContext (#676)
+- [4bb15e48](https://github.com/kubedb/elasticsearch/commit/4bb15e48b) Update daily-opensearch workflow to provision v1.3.13
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.1.0-rc.0](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.1.0-rc.0)
+
+- [eb95c84](https://github.com/kubedb/elasticsearch-restic-plugin/commit/eb95c84) Prepare for release v0.1.0-rc.0 (#8)
+- [fe82e1b](https://github.com/kubedb/elasticsearch-restic-plugin/commit/fe82e1b) Update component name (#7)
+- [c155643](https://github.com/kubedb/elasticsearch-restic-plugin/commit/c155643) Update snapshot time (#6)
+- [7093d5a](https://github.com/kubedb/elasticsearch-restic-plugin/commit/7093d5a) Move to kubedb org
+- [a3a079e](https://github.com/kubedb/elasticsearch-restic-plugin/commit/a3a079e) Update deps (#5)
+- [7a0fd38](https://github.com/kubedb/elasticsearch-restic-plugin/commit/7a0fd38) Refactor (#4)
+- [b262635](https://github.com/kubedb/elasticsearch-restic-plugin/commit/b262635) Add support for backup and restore (#1)
+- [50bde7e](https://github.com/kubedb/elasticsearch-restic-plugin/commit/50bde7e) Fix build
+- [b9686b7](https://github.com/kubedb/elasticsearch-restic-plugin/commit/b9686b7) Prepare for release v0.1.0-rc.0 (#3)
+- [ba0c0ed](https://github.com/kubedb/elasticsearch-restic-plugin/commit/ba0c0ed) Fix binary name
+- [b0aa991](https://github.com/kubedb/elasticsearch-restic-plugin/commit/b0aa991) Use firecracker runner
+- [a621400](https://github.com/kubedb/elasticsearch-restic-plugin/commit/a621400) Use Go 1.21 and restic 0.16.0
+- [f08e4e8](https://github.com/kubedb/elasticsearch-restic-plugin/commit/f08e4e8) Use github runner to push docker image
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2023.11.29-rc.0](https://github.com/kubedb/installer/releases/tag/v2023.11.29-rc.0)
+
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.9.0-rc.0](https://github.com/kubedb/kafka/releases/tag/v0.9.0-rc.0)
+
+- [0770fff](https://github.com/kubedb/kafka/commit/0770fff) Prepare for release v0.9.0-rc.0 (#48)
+- [ee3dcf5](https://github.com/kubedb/kafka/commit/ee3dcf5) Add condition for ssl.properties file (#47)
+- [4bd632b](https://github.com/kubedb/kafka/commit/4bd632b) Reconfigure kafka for updated config properties (#45)
+- [cc9795b](https://github.com/kubedb/kafka/commit/cc9795b) Upsert Init Containers with Kafka podtemplate.spec and update default test-profile (#43)
+- [76e743c](https://github.com/kubedb/kafka/commit/76e743c) Update daily e2e tests yml (#42)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.1.0-rc.0](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.1.0-rc.0)
+
+- [bef777c](https://github.com/kubedb/kubedb-manifest-plugin/commit/bef777c) Prepare for release v0.1.0-rc.0 (#28)
+- [46ad967](https://github.com/kubedb/kubedb-manifest-plugin/commit/46ad967) Remove redundancy (#27)
+- [4eaf765](https://github.com/kubedb/kubedb-manifest-plugin/commit/4eaf765) Update snapshot time (#26)
+- [e8ace42](https://github.com/kubedb/kubedb-manifest-plugin/commit/e8ace42) Fix plugin binary name
+- [d4e3c34](https://github.com/kubedb/kubedb-manifest-plugin/commit/d4e3c34) Move to kubedb org
+- [15770b2](https://github.com/kubedb/kubedb-manifest-plugin/commit/15770b2) Update deps (#25)
+- [f50a3af](https://github.com/kubedb/kubedb-manifest-plugin/commit/f50a3af) Fix directory cleanup (#24)
+- [d41eba7](https://github.com/kubedb/kubedb-manifest-plugin/commit/d41eba7) Refactor
+- [0e154e7](https://github.com/kubedb/kubedb-manifest-plugin/commit/0e154e7) Fix release workflow
+- [35c6b95](https://github.com/kubedb/kubedb-manifest-plugin/commit/35c6b95) Prepare for release v0.2.0-rc.0 (#22)
+- [da97d9a](https://github.com/kubedb/kubedb-manifest-plugin/commit/da97d9a) Use gh runner token to publish image
+- [592c51f](https://github.com/kubedb/kubedb-manifest-plugin/commit/592c51f) Use firecracker runner
+- [008042d](https://github.com/kubedb/kubedb-manifest-plugin/commit/008042d) Use Go 1.21
+- [985bcab](https://github.com/kubedb/kubedb-manifest-plugin/commit/985bcab) Set snapshot time after snapshot completed (#21)
+- [6a8c682](https://github.com/kubedb/kubedb-manifest-plugin/commit/6a8c682) Refactor code (#20)
+- [bcb944d](https://github.com/kubedb/kubedb-manifest-plugin/commit/bcb944d) Remove manifest option flags (#19)
+- [5a47722](https://github.com/kubedb/kubedb-manifest-plugin/commit/5a47722) Fix secret restore issue (#18)
+- [3ced8b7](https://github.com/kubedb/kubedb-manifest-plugin/commit/3ced8b7) Update `kmodules.xyz/client-go` version to `v0.25.27` (#17)
+- [2ee1314](https://github.com/kubedb/kubedb-manifest-plugin/commit/2ee1314) Update Readme (#16)
+- [42d0e52](https://github.com/kubedb/kubedb-manifest-plugin/commit/42d0e52) Set initial component status prior to backup and restore (#15)
+- [31a64d6](https://github.com/kubedb/kubedb-manifest-plugin/commit/31a64d6) Remove redundant flags (#14)
+- [a804ba8](https://github.com/kubedb/kubedb-manifest-plugin/commit/a804ba8) Pass Snapshot name for restore
+- [99ca49f](https://github.com/kubedb/kubedb-manifest-plugin/commit/99ca49f) Set snapshot time, integrity and size (#12)
+- [384bbb6](https://github.com/kubedb/kubedb-manifest-plugin/commit/384bbb6) Set backup error in component status + Refactor codebase (#11)
+- [513eef5](https://github.com/kubedb/kubedb-manifest-plugin/commit/513eef5) Update for snapshot and restoresession API changes (#10)
+- [4fb8f52](https://github.com/kubedb/kubedb-manifest-plugin/commit/4fb8f52) Add options for issuerref (#9)
+- [2931d9e](https://github.com/kubedb/kubedb-manifest-plugin/commit/2931d9e) Update restic modules (#7)
+- [3422ddf](https://github.com/kubedb/kubedb-manifest-plugin/commit/3422ddf) Fix bugs + Sync with updated snapshot api (#6)
+- [b1a69b5](https://github.com/kubedb/kubedb-manifest-plugin/commit/b1a69b5) Prepare for release v0.1.0 (#5)
+- [5344e9f](https://github.com/kubedb/kubedb-manifest-plugin/commit/5344e9f) Update modules (#4)
+- [14b2797](https://github.com/kubedb/kubedb-manifest-plugin/commit/14b2797) Add CI badge
+- [969eeda](https://github.com/kubedb/kubedb-manifest-plugin/commit/969eeda) Organize code structure (#3)
+- [9fc3cbe](https://github.com/kubedb/kubedb-manifest-plugin/commit/9fc3cbe) Postgres manifest (#2)
+- [8e2a56f](https://github.com/kubedb/kubedb-manifest-plugin/commit/8e2a56f) Merge pull request #1 from kubestash/mongodb-manifest
+- [e80c1d0](https://github.com/kubedb/kubedb-manifest-plugin/commit/e80c1d0) update flag names.
+- [80d3908](https://github.com/kubedb/kubedb-manifest-plugin/commit/80d3908) Add options for changing name in the restored files.
+- [e7da42d](https://github.com/kubedb/kubedb-manifest-plugin/commit/e7da42d) Fix error.
+- [70a0267](https://github.com/kubedb/kubedb-manifest-plugin/commit/70a0267) Sync with updated snapshot api
+- [9d747d8](https://github.com/kubedb/kubedb-manifest-plugin/commit/9d747d8) Merge branch 'mongodb-manifest' of github.com:stashed/kubedb-manifest into mongodb-manifest
+- [90e00e3](https://github.com/kubedb/kubedb-manifest-plugin/commit/90e00e3) Fix bugs.
+- [9c3fc1e](https://github.com/kubedb/kubedb-manifest-plugin/commit/9c3fc1e) Sync with updated snapshot api
+- [c321013](https://github.com/kubedb/kubedb-manifest-plugin/commit/c321013) update component path.
+- [7f4bd17](https://github.com/kubedb/kubedb-manifest-plugin/commit/7f4bd17) Refactor.
+- [2b61ff0](https://github.com/kubedb/kubedb-manifest-plugin/commit/2b61ff0) Specify component directory
+- [6264cdf](https://github.com/kubedb/kubedb-manifest-plugin/commit/6264cdf) Support restoring particular mongo component.
+- [0008570](https://github.com/kubedb/kubedb-manifest-plugin/commit/0008570) Fix restore component phase updating.
+- [8bd4c95](https://github.com/kubedb/kubedb-manifest-plugin/commit/8bd4c95) Fix restore manifests.
+- [7eda9f9](https://github.com/kubedb/kubedb-manifest-plugin/commit/7eda9f9) Update Snapshot phase calculation.
+- [a2b52d2](https://github.com/kubedb/kubedb-manifest-plugin/commit/a2b52d2) Add core to runtime scheme.
+- [9bd6bd5](https://github.com/kubedb/kubedb-manifest-plugin/commit/9bd6bd5) Fix bugs.
+- [9e08774](https://github.com/kubedb/kubedb-manifest-plugin/commit/9e08774) Fix build
+- [01225c6](https://github.com/kubedb/kubedb-manifest-plugin/commit/01225c6) Update module path
+- [45d0e45](https://github.com/kubedb/kubedb-manifest-plugin/commit/45d0e45) updated flags.
+- [fb0282f](https://github.com/kubedb/kubedb-manifest-plugin/commit/fb0282f) update docker file.
+- [ad4c004](https://github.com/kubedb/kubedb-manifest-plugin/commit/ad4c004) refactor.
+- [8f71d3a](https://github.com/kubedb/kubedb-manifest-plugin/commit/8f71d3a) Fix build
+- [115ef23](https://github.com/kubedb/kubedb-manifest-plugin/commit/115ef23) update makefile.
+- [a274690](https://github.com/kubedb/kubedb-manifest-plugin/commit/a274690) update backup and restore.
+- [cff449f](https://github.com/kubedb/kubedb-manifest-plugin/commit/cff449f) Use yaml pkg from k8s.io.
+- [dcbb399](https://github.com/kubedb/kubedb-manifest-plugin/commit/dcbb399) Use restic package from KubeStash.
+- [596a498](https://github.com/kubedb/kubedb-manifest-plugin/commit/596a498) fix restore implementation.
+- [6ebc19b](https://github.com/kubedb/kubedb-manifest-plugin/commit/6ebc19b) Implement restore.
+- [3e8a869](https://github.com/kubedb/kubedb-manifest-plugin/commit/3e8a869) Start implementing restore.
+- [e841113](https://github.com/kubedb/kubedb-manifest-plugin/commit/e841113) Add backup methods for mongodb.
+- [b5961f7](https://github.com/kubedb/kubedb-manifest-plugin/commit/b5961f7) Continue implementing backup.
+- [d943f6a](https://github.com/kubedb/kubedb-manifest-plugin/commit/d943f6a) Implement manifest backup for MongoDB.
+- [e644c67](https://github.com/kubedb/kubedb-manifest-plugin/commit/e644c67) Implement kubedb-manifest plugin to MongoDB manifests.
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/mariadb/releases/tag/v0.22.0-rc.0)
+
+- [e360fd82](https://github.com/kubedb/mariadb/commit/e360fd82) Prepare for release v0.22.0-rc.0 (#233)
+- [3956f18c](https://github.com/kubedb/mariadb/commit/3956f18c) Set Default Security Context for MariaDB (#232)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.1.0-rc.0](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.1.0-rc.0)
+
+- [65fd6bf](https://github.com/kubedb/mariadb-archiver/commit/65fd6bf) Prepare for release v0.1.0-rc.0 (#3)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.18.0-rc.0](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.18.0-rc.0)
+
+- [bf515bfa](https://github.com/kubedb/mariadb-coordinator/commit/bf515bfa) Prepare for release v0.18.0-rc.0 (#92)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.31.0-rc.0](https://github.com/kubedb/memcached/releases/tag/v0.31.0-rc.0)
+
+- [e44be0a6](https://github.com/kubedb/memcached/commit/e44be0a6) Prepare for release v0.31.0-rc.0 (#405)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.31.0-rc.0](https://github.com/kubedb/mongodb/releases/tag/v0.31.0-rc.0)
+
+- [c368ec94](https://github.com/kubedb/mongodb/commit/c368ec94) Prepare for release v0.31.0-rc.0 (#581)
+- [020d5599](https://github.com/kubedb/mongodb/commit/020d5599) Set manifest component in restoreSession (#579)
+- [95103a47](https://github.com/kubedb/mongodb/commit/95103a47) Implement mongodb archiver (#534)
+- [fb01b593](https://github.com/kubedb/mongodb/commit/fb01b593) Update apimachinery deps for fsgroup defaulting (#578)
+- [22a5bb29](https://github.com/kubedb/mongodb/commit/22a5bb29) Make changes to run containers as non-root user (#576)
+- [8667f411](https://github.com/kubedb/mongodb/commit/8667f411) Rearrange the daily CI (#577)
+- [7024a3ca](https://github.com/kubedb/mongodb/commit/7024a3ca) Add support for initialization with git-sync (#575)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.1.0-rc.0](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.1.0-rc.0)
+
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.1.0-rc.0](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.1.0-rc.0)
+
+- [745f5cb](https://github.com/kubedb/mongodb-restic-plugin/commit/745f5cb) Prepare for release v0.1.0-rc.0 (#13)
+- [2c381ee](https://github.com/kubedb/mongodb-restic-plugin/commit/2c381ee) Rename `max-Concurrency` flag name to `max-concurrency` (#12)
+- [769bb27](https://github.com/kubedb/mongodb-restic-plugin/commit/769bb27) Set DB version from env if empty (#11)
+- [7f51333](https://github.com/kubedb/mongodb-restic-plugin/commit/7f51333) Update snapshot time (#10)
+- [e5972d1](https://github.com/kubedb/mongodb-restic-plugin/commit/e5972d1) Move to kubedb org
+- [004ef7e](https://github.com/kubedb/mongodb-restic-plugin/commit/004ef7e) Update deps (#9)
+- [e54bc9b](https://github.com/kubedb/mongodb-restic-plugin/commit/e54bc9b) Remove version prefix from files (#8)
+- [2ab94f7](https://github.com/kubedb/mongodb-restic-plugin/commit/2ab94f7) Add db version flag (#6)
+- [d3e752d](https://github.com/kubedb/mongodb-restic-plugin/commit/d3e752d) Prepare for release v0.1.0-rc.0 (#7)
+- [e0872f9](https://github.com/kubedb/mongodb-restic-plugin/commit/e0872f9) Use firecracker runners
+- [a2e18e9](https://github.com/kubedb/mongodb-restic-plugin/commit/a2e18e9) Use github runner to push docker image
+- [b32ebb2](https://github.com/kubedb/mongodb-restic-plugin/commit/b32ebb2) Build docker images for each db version (#5)
+- [bc3219d](https://github.com/kubedb/mongodb-restic-plugin/commit/bc3219d) Update deps
+- [8040cc0](https://github.com/kubedb/mongodb-restic-plugin/commit/8040cc0) MongoDB backup and restore addon (#2)
+- [d9cd315](https://github.com/kubedb/mongodb-restic-plugin/commit/d9cd315) Update Readme and license (#1)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.31.0-rc.0](https://github.com/kubedb/mysql/releases/tag/v0.31.0-rc.0)
+
+- [3c005b51](https://github.com/kubedb/mysql/commit/3c005b51) Prepare for release v0.31.0-rc.0 (#572)
+- [bcdfaf4a](https://github.com/kubedb/mysql/commit/bcdfaf4a) Set Default Security Context for MySQL (#571)
+- [9009bcac](https://github.com/kubedb/mysql/commit/9009bcac) Add git sync constants from apimachinery (#570)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.1.0-rc.0](https://github.com/kubedb/mysql-archiver/releases/tag/v0.1.0-rc.0)
+
+- [f79286a](https://github.com/kubedb/mysql-archiver/commit/f79286a) Prepare for release v0.1.0-rc.0 (#2)
+- [dcd2e30](https://github.com/kubedb/mysql-archiver/commit/dcd2e30) Fix wal-g binary
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.16.0-rc.0](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.16.0-rc.0)
+
+- [b5e481fc](https://github.com/kubedb/mysql-coordinator/commit/b5e481fc) Prepare for release v0.16.0-rc.0 (#89)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.1.0-rc.0](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.1.0-rc.0)
+
+- [b255e47](https://github.com/kubedb/mysql-restic-plugin/commit/b255e47) Prepare for release v0.1.0-rc.0 (#11)
+- [9a17360](https://github.com/kubedb/mysql-restic-plugin/commit/9a17360) Set DB version from env if empty (#10)
+- [c67ba7c](https://github.com/kubedb/mysql-restic-plugin/commit/c67ba7c) Update snapshot time (#9)
+- [abef89e](https://github.com/kubedb/mysql-restic-plugin/commit/abef89e) Fix binary name
+- [db1bbbf](https://github.com/kubedb/mysql-restic-plugin/commit/db1bbbf) Move to kubedb org
+- [746d13e](https://github.com/kubedb/mysql-restic-plugin/commit/746d13e) Update deps (#8)
+- [569533a](https://github.com/kubedb/mysql-restic-plugin/commit/569533a) Add version flag + Refactor (#6)
+- [f0abd94](https://github.com/kubedb/mysql-restic-plugin/commit/f0abd94) Prepare for release v0.1.0-rc.0 (#7)
+- [01bff62](https://github.com/kubedb/mysql-restic-plugin/commit/01bff62) Remove arm64 image support
+- [277fda8](https://github.com/kubedb/mysql-restic-plugin/commit/277fda8) Build docker images for each db version (#5)
+- [94f000d](https://github.com/kubedb/mysql-restic-plugin/commit/94f000d) Use Go 1.21
+- [2e4f30d](https://github.com/kubedb/mysql-restic-plugin/commit/2e4f30d) Update Readme (#4)
+- [272c8f9](https://github.com/kubedb/mysql-restic-plugin/commit/272c8f9) Add support for mysql backup and restore (#1)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.16.0-rc.0](https://github.com/kubedb/mysql-router-init/releases/tag/v0.16.0-rc.0)
+
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.25.0-rc.0](https://github.com/kubedb/ops-manager/releases/tag/v0.25.0-rc.0)
+
+- [640fe280](https://github.com/kubedb/ops-manager/commit/640fe280) Prepare for release v0.25.0-rc.0 (#492)
+- [9714e841](https://github.com/kubedb/ops-manager/commit/9714e841) Add kafka version 3.6.0 to daily test (#491)
+- [dd18b17c](https://github.com/kubedb/ops-manager/commit/dd18b17c) postgres arbiter related changes and bug fixes (#483)
+- [de52bda7](https://github.com/kubedb/ops-manager/commit/de52bda7) Remove default configuration and restart kafka with new config (#490)
+- [f7850172](https://github.com/kubedb/ops-manager/commit/f7850172) Add prepare cluster installer before test runners (#489)
+- [79e646ef](https://github.com/kubedb/ops-manager/commit/79e646ef) Update ServiceDNS for kafka (#488)
+- [18851802](https://github.com/kubedb/ops-manager/commit/18851802) added daily postgres (#487)
+- [0c2bdda1](https://github.com/kubedb/ops-manager/commit/0c2bdda1) added daily-postgres.yml (#486)
+- [5cb75965](https://github.com/kubedb/ops-manager/commit/5cb75965) Fixed BUG in postgres reconfigureTLS opsreq (#485)
+- [145e08d5](https://github.com/kubedb/ops-manager/commit/145e08d5) Failover before restarting primary on restart ops (#481)
+- [e53a72ce](https://github.com/kubedb/ops-manager/commit/e53a72ce) Add Kafka daily yml (#475)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.25.0-rc.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.25.0-rc.0)
+
+- [d374a542](https://github.com/kubedb/percona-xtradb/commit/d374a542) Prepare for release v0.25.0-rc.0 (#331)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.11.0-rc.0](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.11.0-rc.0)
+
+- [69e7d1e](https://github.com/kubedb/percona-xtradb-coordinator/commit/69e7d1e) Prepare for release v0.11.0-rc.0 (#49)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.22.0-rc.0)
+
+- [e4efa4db](https://github.com/kubedb/pg-coordinator/commit/e4efa4db) Prepare for release v0.22.0-rc.0 (#139)
+- [7c862bcd](https://github.com/kubedb/pg-coordinator/commit/7c862bcd) Add support for arbiter (#136)
+- [53ba32a9](https://github.com/kubedb/pg-coordinator/commit/53ba32a9) added postgres 16.0 support (#137)
+- [24445f9b](https://github.com/kubedb/pg-coordinator/commit/24445f9b) Added & modified logs (#134)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.25.0-rc.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.25.0-rc.0)
+
+- [21ba9f0f](https://github.com/kubedb/pgbouncer/commit/21ba9f0f) Prepare for release v0.25.0-rc.0 (#296)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.38.0-rc.0](https://github.com/kubedb/postgres/releases/tag/v0.38.0-rc.0)
+
+- [8738ad73](https://github.com/kubedb/postgres/commit/8738ad73e) Prepare for release v0.38.0-rc.0 (#684)
+- [adb69b02](https://github.com/kubedb/postgres/commit/adb69b02e) Implement PostgreSQL archiver (#628)
+- [668e15dd](https://github.com/kubedb/postgres/commit/668e15dd4) Remove test directory (#683)
+- [d857c354](https://github.com/kubedb/postgres/commit/d857c354a) added postgres arbiter support (#677)
+- [8fc98e8e](https://github.com/kubedb/postgres/commit/8fc98e8ed) Fixed a bug for init container (#681)
+- [a2b408ff](https://github.com/kubedb/postgres/commit/a2b408ffb) Bugfix for security context (#680)
+- [fb14015e](https://github.com/kubedb/postgres/commit/fb14015e9) added nightly yml for postgres (#679)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.1.0-rc.0](https://github.com/kubedb/postgres-archiver/releases/tag/v0.1.0-rc.0)
+
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.1.0-rc.0](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.1.0-rc.0)
+
+- [02a45da](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/02a45da) Prepare for release v0.1.0-rc.0 (#6)
+- [1a6457c](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/1a6457c) Update flags and deps + Refactor (#5)
+- [f32b56b](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/f32b56b) Delete .idea folder
+- [e7f8135](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/e7f8135) clean up (#4)
+- [06e7e70](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/06e7e70) clean up (#3)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.1.0-rc.0](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.1.0-rc.0)
+
+- [8208814](https://github.com/kubedb/postgres-restic-plugin/commit/8208814) Prepare for release v0.1.0-rc.0 (#4)
+- [a56fcfa](https://github.com/kubedb/postgres-restic-plugin/commit/a56fcfa) Move to kubedb org (#3)
+- [e8928c7](https://github.com/kubedb/postgres-restic-plugin/commit/e8928c7) Added postgres addon for kubestash (#2)
+- [7c55105](https://github.com/kubedb/postgres-restic-plugin/commit/7c55105) Prepare for release v0.1.0-rc.0 (#1)
+- [19eff67](https://github.com/kubedb/postgres-restic-plugin/commit/19eff67) Use gh runner token to publish docker image
+- [6a71410](https://github.com/kubedb/postgres-restic-plugin/commit/6a71410) Use firecracker runner
+- [e278d71](https://github.com/kubedb/postgres-restic-plugin/commit/e278d71) Use Go 1.21
+- [4899879](https://github.com/kubedb/postgres-restic-plugin/commit/4899879) Update readme + cleanup
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.38.0-rc.0](https://github.com/kubedb/provisioner/releases/tag/v0.38.0-rc.0)
+
+- [7e6099e0](https://github.com/kubedb/provisioner/commit/7e6099e0e) Prepare for release v0.38.0-rc.0 (#59)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.25.0-rc.0](https://github.com/kubedb/proxysql/releases/tag/v0.25.0-rc.0)
+
+- [c4775bf7](https://github.com/kubedb/proxysql/commit/c4775bf7) Prepare for release v0.25.0-rc.0 (#313)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.31.0-rc.0](https://github.com/kubedb/redis/releases/tag/v0.31.0-rc.0)
+
+- [966f14ca](https://github.com/kubedb/redis/commit/966f14ca) Prepare for release v0.31.0-rc.0 (#495)
+- [b72d8319](https://github.com/kubedb/redis/commit/b72d8319) Run Redis and RedisSentinel as non root (#494)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.17.0-rc.0](https://github.com/kubedb/redis-coordinator/releases/tag/v0.17.0-rc.0)
+
+- [9f724e43](https://github.com/kubedb/redis-coordinator/commit/9f724e43) Prepare for release v0.17.0-rc.0 (#80)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.1.0-rc.0](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.1.0-rc.0)
+
+- [f8de18b](https://github.com/kubedb/redis-restic-plugin/commit/f8de18b) Prepare for release v0.1.0-rc.0 (#9)
+- [a4c03d9](https://github.com/kubedb/redis-restic-plugin/commit/a4c03d9) Update snapshot time (#8)
+- [404447d](https://github.com/kubedb/redis-restic-plugin/commit/404447d) Fix binary name
+- [4dbc58b](https://github.com/kubedb/redis-restic-plugin/commit/4dbc58b) Move to kubedb org
+- [e4a6fb2](https://github.com/kubedb/redis-restic-plugin/commit/e4a6fb2) Update deps (#7)
+- [1b28954](https://github.com/kubedb/redis-restic-plugin/commit/1b28954) Remove maxConcurrency variable (#6)
+- [4d13ee5](https://github.com/kubedb/redis-restic-plugin/commit/4d13ee5) Remove addon implementer + Refactor (#5)
+- [44ac2c7](https://github.com/kubedb/redis-restic-plugin/commit/44ac2c7) Prepare for release v0.1.0-rc.0 (#4)
+- [ce275bd](https://github.com/kubedb/redis-restic-plugin/commit/ce275bd) Use firecracker runner
+- [bf39971](https://github.com/kubedb/redis-restic-plugin/commit/bf39971) Update deps
+- [ef24891](https://github.com/kubedb/redis-restic-plugin/commit/ef24891) Use github runner to push docker image
+- [6a6f6d6](https://github.com/kubedb/redis-restic-plugin/commit/6a6f6d6) Add support for redis backup and restore (#1)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.25.0-rc.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.25.0-rc.0)
+
+- [77886a28](https://github.com/kubedb/replication-mode-detector/commit/77886a28) Prepare for release v0.25.0-rc.0 (#244)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.14.0-rc.0](https://github.com/kubedb/schema-manager/releases/tag/v0.14.0-rc.0)
+
+- [893fe8d9](https://github.com/kubedb/schema-manager/commit/893fe8d9) Prepare for release v0.14.0-rc.0 (#85)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.23.0-rc.0](https://github.com/kubedb/tests/releases/tag/v0.23.0-rc.0)
+
+- [bfd1ec79](https://github.com/kubedb/tests/commit/bfd1ec79) Prepare for release v0.23.0-rc.0 (#270)
+- [fab75dd1](https://github.com/kubedb/tests/commit/fab75dd1) Add disableDefault while deploying elasticsearch. (#269)
+- [009399c7](https://github.com/kubedb/tests/commit/009399c7) Run tests in restriced PodSecurityStandard (#266)
+- [4be89382](https://github.com/kubedb/tests/commit/4be89382) Fixed stash test and Innodb issues in MySQL (#250)
+- [f007f5f5](https://github.com/kubedb/tests/commit/f007f5f5) Added test for Standalone to HA scalin (#267)
+- [017546ec](https://github.com/kubedb/tests/commit/017546ec) Add Postgres e2e tests (#233)
+- [fbd16c88](https://github.com/kubedb/tests/commit/fbd16c88) Add kafka e2e tests (#254)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.14.0-rc.0](https://github.com/kubedb/ui-server/releases/tag/v0.14.0-rc.0)
+
+- [b59415fd](https://github.com/kubedb/ui-server/commit/b59415fd) Prepare for release v0.14.0-rc.0 (#94)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.14.0-rc.0](https://github.com/kubedb/webhook-server/releases/tag/v0.14.0-rc.0)
+
+- [c36d61e5](https://github.com/kubedb/webhook-server/commit/c36d61e5) Prepare for release v0.14.0-rc.0 (#70)
+
+
+
+

--- a/docs/examples/mysql/Initialization/demo-1.yaml
+++ b/docs/examples/mysql/Initialization/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-init-script
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/mysql/cli/mysql-demo.yaml
+++ b/docs/examples/mysql/cli/mysql-demo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-demo
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/mysql/clustering/demo-1.yaml
+++ b/docs/examples/mysql/clustering/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/configuration/mysql-custom.yaml
+++ b/docs/examples/mysql/configuration/mysql-custom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-mysql
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   configSecret:
     name: my-custom-config
   storage:

--- a/docs/examples/mysql/configuration/mysql-misc-config.yaml
+++ b/docs/examples/mysql/configuration/mysql-misc-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-misc-config
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   storageType: "Durable"
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/custom-rbac/my-custom-db-two.yaml
+++ b/docs/examples/mysql/custom-rbac/my-custom-db-two.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minute-mysql
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/examples/mysql/custom-rbac/my-custom-db.yaml
+++ b/docs/examples/mysql/custom-rbac/my-custom-db.yaml
@@ -4,7 +4,7 @@ metadata:
   name: quick-mysql
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/examples/mysql/horizontalscaling/group_replication.yaml
+++ b/docs/examples/mysql/horizontalscaling/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/monitoring/builtin-prom-mysql.yaml
+++ b/docs/examples/mysql/monitoring/builtin-prom-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-mysql
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/monitoring/coreos-prom-mysql.yaml
+++ b/docs/examples/mysql/monitoring/coreos-prom-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coreos-prom-mysql
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/private-registry/demo-2.yaml
+++ b/docs/examples/mysql/private-registry/demo-2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-pvt-reg
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/mysql/quickstart/demo-2.yaml
+++ b/docs/examples/mysql/quickstart/demo-2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/tls/tls-group.yaml
+++ b/docs/examples/mysql/tls/tls-group.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group-tls
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/tls/tls-standalone.yaml
+++ b/docs/examples/mysql/tls/tls-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone-tls
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/update-version/majorversion/group_replication.yaml
+++ b/docs/examples/mysql/update-version/majorversion/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/update-version/majorversion/standalone.yaml
+++ b/docs/examples/mysql/update-version/majorversion/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/update-version/majorversion/update_major_version_group.yaml
+++ b/docs/examples/mysql/update-version/majorversion/update_major_version_group.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: my-group
   updateVersion:
-    targetVersion: "8.0.27"
+    targetVersion: "8.0.32"

--- a/docs/examples/mysql/update-version/majorversion/update_major_version_standalone.yaml
+++ b/docs/examples/mysql/update-version/majorversion/update_major_version_standalone.yaml
@@ -8,4 +8,4 @@ spec:
     name: my-standalone
   type: UpdateVersion
   updateVersion:
-    targetVersion: "8.0.27"
+    targetVersion: "8.0.32"

--- a/docs/examples/mysql/update-version/minorversion/group_replication.yaml
+++ b/docs/examples/mysql/update-version/minorversion/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/update-version/minorversion/standalone.yaml
+++ b/docs/examples/mysql/update-version/minorversion/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/update-version/minorversion/update_minor_version_group.yaml
+++ b/docs/examples/mysql/update-version/minorversion/update_minor_version_group.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: my-group
   updateVersion:
-    targetVersion: "5.7.36"
+    targetVersion: "5.7.41"

--- a/docs/examples/mysql/update-version/minorversion/update_minor_version_standalone.yaml
+++ b/docs/examples/mysql/update-version/minorversion/update_minor_version_standalone.yaml
@@ -8,4 +8,4 @@ spec:
     name: my-standalone
   type: UpdateVersion
   updateVersion:
-    targetVersion: "5.7.36"
+    targetVersion: "5.7.41"

--- a/docs/examples/mysql/verticalscaling/group_replication.yaml
+++ b/docs/examples/mysql/verticalscaling/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/verticalscaling/standalone.yaml
+++ b/docs/examples/mysql/verticalscaling/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/proxysql/demo-my-group.yaml
+++ b/docs/examples/proxysql/demo-my-group.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mariadb/autoscaler/compute/cluster/index.md
+++ b/docs/guides/mariadb/autoscaler/compute/cluster/index.md
@@ -88,7 +88,7 @@ Now, wait until `sample-mariadb` has status `Ready`. i.e,
 ```bash
 $ kubectl get mariadb -n demo
 NAME             VERSION   STATUS   AGE
-sample-mariadb   10.5.8    Ready    14m
+sample-mariadb   10.5.23    Ready    14m
 ```
 
 Let's check the Pod containers resources,

--- a/docs/guides/mariadb/autoscaler/storage/cluster/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/autoscaler/storage/cluster/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mariadb/autoscaler/storage/cluster/index.md
@@ -60,7 +60,7 @@ Now, we are going to deploy a `MariaDB` replicaset using a supported version by 
 
 #### Deploy MariaDB Cluster
 
-In this section, we are going to deploy a MariaDB replicaset database with version `10.5.8`.  Then, in the next section we will set up autoscaling for this database using `MariaDBAutoscaler` CRD. Below is the YAML of the `MariaDB` CR that we are going to create,
+In this section, we are going to deploy a MariaDB replicaset database with version `10.5.23`.  Then, in the next section we will set up autoscaling for this database using `MariaDBAutoscaler` CRD. Below is the YAML of the `MariaDB` CR that we are going to create,
 
 > If you want to autoscale MariaDB `Standalone`, Just remove the `spec.Replicas` from the below yaml and rest of the steps are same.
 
@@ -71,7 +71,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:
@@ -96,7 +96,7 @@ Now, wait until `sample-mariadb` has status `Ready`. i.e,
 ```bash
 $ kubectl get mariadb -n demo
 NAME             VERSION   STATUS   AGE
-sample-mariadb   10.5.8    Ready    3m46s
+sample-mariadb   10.5.23    Ready    3m46s
 ```
 
 Let's check volume size from statefulset, and from the persistent volume,

--- a/docs/guides/mariadb/backup/auto-backup/examples/sample-mariadb-2.yaml
+++ b/docs/guides/mariadb/backup/auto-backup/examples/sample-mariadb-2.yaml
@@ -7,7 +7,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mariadb-backup-template
     stash.appscode.com/schedule: "*/3 * * * *"
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/auto-backup/examples/sample-mariadb-3.yaml
+++ b/docs/guides/mariadb/backup/auto-backup/examples/sample-mariadb-3.yaml
@@ -7,7 +7,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mariadb-backup-template
     params.stash.appscode.com/args: --databases mysql
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/auto-backup/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/backup/auto-backup/examples/sample-mariadb.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     stash.appscode.com/backup-blueprint: mariadb-backup-template
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/auto-backup/index.md
+++ b/docs/guides/mariadb/backup/auto-backup/index.md
@@ -52,8 +52,8 @@ When you install the Stash Enterprise edition, it automatically installs all the
 
 ```bash
 ❯ kubectl get tasks.stash.appscode.com | grep mariadb
-mariadb-backup-10.5.8    62m
-mariadb-restore-10.5.8   62m
+mariadb-backup-10.5.23    62m
+mariadb-restore-10.5.23   62m
 ```
 
 ## Prepare Backup Blueprint
@@ -129,7 +129,7 @@ metadata:
   annotations:
     stash.appscode.com/backup-blueprint: mariadb-backup-template
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 1
   storageType: Durable
   storage:
@@ -192,7 +192,7 @@ If everything goes well, Stash should create a `BackupConfiguration` for our Mar
 ```bash
 ❯ kubectl get backupconfiguration -n demo
 NAME                 TASK                    SCHEDULE      PAUSED   PHASE   AGE
-app-sample-mariadb   mariadb-backup-10.5.8   */5 * * * *            Ready   7m28s
+app-sample-mariadb   mariadb-backup-10.5.23   */5 * * * *            Ready   7m28s
 ```
 
 Now, let's check the YAML of the `BackupConfiguration`.
@@ -298,7 +298,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mariadb-backup-template
     stash.appscode.com/schedule: "*/3 * * * *"
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 1
   storageType: Durable
   storage:
@@ -361,7 +361,7 @@ If everything goes well, Stash should create a `BackupConfiguration` for our Mar
 ```bash
 ❯ kubectl get backupconfiguration -n demo-2
 NAME                   TASK                    SCHEDULE      PAUSED   PHASE   AGE
-app-sample-mariadb-2   mariadb-backup-10.5.8   */3 * * * *            Ready   3m24s
+app-sample-mariadb-2   mariadb-backup-10.5.23   */3 * * * *            Ready   3m24s
 ```
 
 Now, let's check the YAML of the `BackupConfiguration`.
@@ -479,7 +479,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mariadb-backup-template
     params.stash.appscode.com/args: --databases mysql
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 1
   storageType: Durable
   storage:
@@ -543,7 +543,7 @@ If everything goes well, Stash should create a `BackupConfiguration` for our Mar
 ```bash
 ❯ kubectl get backupconfiguration -n demo-3
 NAME                   TASK                    SCHEDULE      PAUSED   PHASE   AGE
-app-sample-mariadb-3   mariadb-backup-10.5.8   */5 * * * *            Ready   106s
+app-sample-mariadb-3   mariadb-backup-10.5.23   */5 * * * *            Ready   106s
 ```
 
 Now, let's check the YAML of the `BackupConfiguration`.

--- a/docs/guides/mariadb/backup/customization/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/backup/customization/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/logical/cluster/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/backup/logical/cluster/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/logical/cluster/index.md
+++ b/docs/guides/mariadb/backup/logical/cluster/index.md
@@ -54,7 +54,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:
@@ -110,7 +110,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 26
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -141,7 +141,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 341
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -210,8 +210,8 @@ When you install the Stash Enterprise edition, it automatically installs all the
 
 ```bash
 $ kubectl get tasks.stash.appscode.com | grep mariadb
-mariadb-backup-10.5.8    35s
-mariadb-restore-10.5.8   35s
+mariadb-backup-10.5.23    35s
+mariadb-restore-10.5.23   35s
 ```
 
 ### Ensure AppBinding
@@ -225,7 +225,7 @@ You don't need to worry about appbindings if you are using KubeDB. It creates an
 ```bash
 $ kubectl get appbinding -n demo 
 NAME             TYPE                 VERSION   AGE
-sample-mariadb   kubedb.com/mariadb   10.5.8      62m
+sample-mariadb   kubedb.com/mariadb   10.5.23      62m
 ```
 
 We have a appbinding named same as database name `sample-mariadb`. We will use this later for connecting into this database.
@@ -324,7 +324,7 @@ If everything goes well, the phase of the `BackupConfiguration` should be `Ready
 ```bash
 $ kubectl get backupconfiguration -n demo
 NAME                    TASK                    SCHEDULE      PAUSED   PHASE      AGE
-sample-mariadb-backup   mariadb-backup-10.5.8   */5 * * * *            Ready      11s
+sample-mariadb-backup   mariadb-backup-10.5.23   */5 * * * *            Ready      11s
 ```
 
 #### Verify CronJob
@@ -401,7 +401,7 @@ Verify that the `BackupConfiguration` has been paused,
 ```bash
 $ kubectl get backupconfiguration -n demo sample-mariadb-backup
 NAME                   TASK                    SCHEDULE      PAUSED   PHASE   AGE
-sample-mariadb-backup  mariadb-backup-10.5.8   */5 * * * *   true     Ready   26m
+sample-mariadb-backup  mariadb-backup-10.5.23   */5 * * * *   true     Ready   26m
 ```
 
 Notice the `PAUSED` column. Value `true` for this field means that the `BackupConfiguration` has been paused.
@@ -423,7 +423,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 341
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -517,7 +517,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 341
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -578,7 +578,7 @@ Verify that the `BackupConfiguration` has been resumed,
 ```bash
 $ kubectl get backupconfiguration -n demo sample-mariadb-backup
 NAME                    TASK                    SCHEDULE      PAUSED   PHASE   AGE
-sample-mariadb-backup   mariadb-backup-10.5.8   */5 * * * *   false    Ready   29m
+sample-mariadb-backup   mariadb-backup-10.5.23   */5 * * * *   false    Ready   29m
 ```
 
 Here,  `false` in the `PAUSED` column means the backup has been resume successfully. The CronJob also should be resumed now.

--- a/docs/guides/mariadb/backup/logical/standalone/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/backup/logical/standalone/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/logical/standalone/index.md
+++ b/docs/guides/mariadb/backup/logical/standalone/index.md
@@ -54,7 +54,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 1
   storageType: Durable
   storage:
@@ -108,7 +108,7 @@ $ kubectl logs -n demo sample-mariadb-0
 2021-02-22  9:41:37 0 [Note] Reading of all Master_info entries succeeded
 2021-02-22  9:41:37 0 [Note] Added new Master_info '' to hash table
 2021-02-22  9:41:37 0 [Note] mysqld: ready for connections.
-Version: '10.5.8-MariaDB-1:10.5.8+maria~focal'  socket: '/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
+Version: '10.5.23-MariaDB-1:10.5.23+maria~focal'  socket: '/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
 ```
 
 From the above log, we can see the database is ready to accept connections.
@@ -124,7 +124,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 341
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -193,7 +193,7 @@ When you install the Stash Enterprise edition, it automatically installs all the
 
 ```bash
 $ kubectl get tasks.stash.appscode.com | grep mariadb
-mariadb-backup-10.5.8    35s
+mariadb-backup-10.5.23    35s
 mariadb-restore-10.5.8   35s
 ```
 
@@ -208,7 +208,7 @@ You don't need to worry about appbindings if you are using KubeDB. It creates an
 ```bash
 $ kubectl get appbinding -n demo 
 NAME             TYPE                 VERSION   AGE
-sample-mariadb   kubedb.com/mariadb   10.5.8      62m
+sample-mariadb   kubedb.com/mariadb   10.5.23      62m
 ```
 
 We have a appbinding named same as database name `sample-mariadb`. We will use this later for connecting into this database.
@@ -307,7 +307,7 @@ If everything goes well, the phase of the `BackupConfiguration` should be `Ready
 ```bash
 $ kubectl get backupconfiguration -n demo
 NAME                    TASK                    SCHEDULE      PAUSED   PHASE      AGE
-sample-mariadb-backup   mariadb-backup-10.5.8   */5 * * * *            Ready      11s
+sample-mariadb-backup   mariadb-backup-10.5.23   */5 * * * *            Ready      11s
 ```
 
 #### Verify CronJob
@@ -386,7 +386,7 @@ Verify that the `BackupConfiguration` has been paused,
 ```bash
 $ kubectl get backupconfiguration -n demo sample-mariadb-backup
 NAME                   TASK                    SCHEDULE      PAUSED   PHASE   AGE
-sample-mariadb-backup  mariadb-backup-10.5.8   */5 * * * *   true     Ready   26m
+sample-mariadb-backup  mariadb-backup-10.5.23   */5 * * * *   true     Ready   26m
 ```
 
 Notice the `PAUSED` column. Value `true` for this field means that the `BackupConfiguration` has been paused.
@@ -408,7 +408,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 341
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -505,7 +505,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 341
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -566,7 +566,7 @@ Verify that the `BackupConfiguration` has been resumed,
 ```bash
 $ kubectl get backupconfiguration -n demo sample-mariadb-backup
 NAME                    TASK                    SCHEDULE      PAUSED   PHASE   AGE
-sample-mariadb-backup   mariadb-backup-10.5.8   */5 * * * *   false    Ready   29m
+sample-mariadb-backup   mariadb-backup-10.5.23   */5 * * * *   false    Ready   29m
 ```
 
 Here,  `false` in the `PAUSED` column means the backup has been resume successfully. The CronJob also should be resumed now.

--- a/docs/guides/mariadb/clustering/galera-cluster/examples/demo-1.yaml
+++ b/docs/guides/mariadb/clustering/galera-cluster/examples/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/clustering/galera-cluster/index.md
+++ b/docs/guides/mariadb/clustering/galera-cluster/index.md
@@ -46,7 +46,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:
@@ -78,7 +78,7 @@ kind: MariaDB
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1alpha2","kind":"MariaDB","metadata":{"annotations":{},"name":"sample-mariadb","namespace":"demo"},"spec":{"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"WipeOut","version":"10.5.8"}}
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"MariaDB","metadata":{"annotations":{},"name":"sample-mariadb","namespace":"demo"},"spec":{"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"WipeOut","version":"10.5.23"}}
   creationTimestamp: "2021-03-16T09:39:01Z"
   finalizers:
   - kubedb.com
@@ -102,7 +102,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   terminationPolicy: WipeOut
-  version: 10.5.8
+  version: 10.5.23
 status:
   conditions:
   - lastTransitionTime: "2021-03-16T09:39:01Z"
@@ -176,7 +176,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 26
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -199,7 +199,7 @@ $ kubectl exec -it -n demo sample-mariadb-1 -- bash
 root@sample-mariadb-1:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 94
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -222,7 +222,7 @@ $ kubectl exec -it -n demo sample-mariadb-2 -- bash
 root@sample-mariadb-2:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 78
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -249,7 +249,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 137
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -275,7 +275,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 202
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -309,7 +309,7 @@ exit
 root@sample-mariadb-1:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 209
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -346,7 +346,7 @@ exit
 root@sample-mariadb-2:/  mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 209
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -384,7 +384,7 @@ kubectl exec -it -n demo sample-mariadb-0 -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 11
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -415,7 +415,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 10
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 

--- a/docs/guides/mariadb/concepts/appbinding/index.md
+++ b/docs/guides/mariadb/concepts/appbinding/index.md
@@ -49,7 +49,7 @@ spec:
   secret:
     name: sample-mariadb-auth
   type: kubedb.com/mariadb
-  version: 10.5.8
+  version: 10.5.23
 ```
 
 Here, we are going to describe the sections of an `AppBinding` crd.

--- a/docs/guides/mariadb/concepts/mariadb-version/index.md
+++ b/docs/guides/mariadb/concepts/mariadb-version/index.md
@@ -42,10 +42,10 @@ metadata:
     app.kubernetes.io/version: v0.16.2
     helm.sh/chart: kubedb-catalog-v0.16.2
   ...
-  name: 10.5.8
+  name: 10.5.23
 spec:
   db:
-    image: kubedb/mariadb:10.5.8
+    image: kubedb/mariadb:10.5.23
   exporter:
     image: kubedb/mysqld-exporter:v0.11.0
   initContainer:
@@ -55,10 +55,10 @@ spec:
   stash:
     addon:
       backupTask:
-        name: mariadb-backup-10.5.8
+        name: mariadb-backup-10.5.23
       restoreTask:
-        name: mariadb-restore-10.5.8
-  version: 10.5.8
+        name: mariadb-restore-10.5.23
+  version: 10.5.23
 ```
 
 ### metadata.name

--- a/docs/guides/mariadb/concepts/mariadb/index.md
+++ b/docs/guides/mariadb/concepts/mariadb/index.md
@@ -106,14 +106,14 @@ spec:
       apiGroup: cert-manager.io
       kind: Issuer
       name: md-issuer
-  version: 10.5.8
+  version: 10.5.23
 ```
 
 ### spec.version
 
 `spec.version` is a required field specifying the name of the [MariaDBVersion](/docs/guides/mariadb/concepts/mariadb-version) crd where the docker images are specified. Currently, when you install KubeDB, it creates the following `MariaDBVersion` resources,
 
-- `10.5.8`, `10.4.17`
+- `10.5.23`, `10.4.32`
 
 ### spec.authSecret
 
@@ -182,7 +182,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: 10.5.8
+  version: 10.5.23
   init:
     script:
       configMap:

--- a/docs/guides/mariadb/concepts/opsrequest/index.md
+++ b/docs/guides/mariadb/concepts/opsrequest/index.md
@@ -39,7 +39,7 @@ spec:
   databaseRef:
     name: sample-mariadb
   updateVersion:
-    targetVersion: 10.5.8
+    targetVersion: 10.5.23
 status:
   conditions:
     - lastTransitionTime: "2020-08-25T18:22:38Z"

--- a/docs/guides/mariadb/configuration/using-config-file/examples/md-custom.yaml
+++ b/docs/guides/mariadb/configuration/using-config-file/examples/md-custom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   configSecret:
     name: md-configuration
   storageType: Durable

--- a/docs/guides/mariadb/configuration/using-config-file/index.md
+++ b/docs/guides/mariadb/configuration/using-config-file/index.md
@@ -102,7 +102,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   configSecret:
     name: md-configuration
   storageType: Durable
@@ -128,7 +128,7 @@ sample-mariadb-0   1/1     Running   0          21s
 
 $ kubectl get mariadb -n demo 
 NAME             VERSION   STATUS   AGE
-sample-mariadb   10.5.8    Ready    71s
+sample-mariadb   10.5.23    Ready    71s
 ```
 
 We can see the database is in ready phase so it can accept conncetion.
@@ -143,7 +143,7 @@ Now, we will check if the database has started with the custom configuration we 
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 23
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 

--- a/docs/guides/mariadb/configuration/using-pod-template/examples/md-misc-config.yaml
+++ b/docs/guides/mariadb/configuration/using-pod-template/examples/md-misc-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mariadb/configuration/using-pod-template/index.md
+++ b/docs/guides/mariadb/configuration/using-pod-template/index.md
@@ -69,7 +69,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -112,13 +112,13 @@ Check the pod's log to see if the database is ready
 
 ```bash
 $ kubectl logs -f -n demo sample-mariadb-0
-2021-03-18 06:06:17+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.5.8+maria~focal started.
+2021-03-18 06:06:17+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.5.23+maria~focal started.
 2021-03-18 06:06:18+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
-2021-03-18 06:06:18+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.5.8+maria~focal started.
+2021-03-18 06:06:18+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.5.23+maria~focal started.
 2021-03-18 06:06:19+00:00 [Note] [Entrypoint]: Initializing database files
 ...
 2021-03-18  6:06:33 0 [Note] mysqld: ready for connections.
-Version: '10.5.8-MariaDB-1:10.5.8+maria~focal'  socket: '/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
+Version: '10.5.23-MariaDB-1:10.5.23+maria~focal'  socket: '/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
 ```
 
 Once we see `Note] mysqld: ready for connections.` in the log, the database is ready.
@@ -130,7 +130,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 22
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 

--- a/docs/guides/mariadb/custom-rbac/using-custom-rbac/examples/md-custom-db-2.yaml
+++ b/docs/guides/mariadb/custom-rbac/using-custom-rbac/examples/md-custom-db-2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: another-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/mariadb/custom-rbac/using-custom-rbac/examples/md-custom-db.yaml
+++ b/docs/guides/mariadb/custom-rbac/using-custom-rbac/examples/md-custom-db.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/mariadb/custom-rbac/using-custom-rbac/index.md
+++ b/docs/guides/mariadb/custom-rbac/using-custom-rbac/index.md
@@ -135,7 +135,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storageType: Durable
   podTemplate:
     spec:
@@ -164,15 +164,15 @@ Check the pod's log to see if the database is ready
 
 ```bash
 $ kubectl logs -f -n demo sample-mariadb-0
-2021-03-18 05:35:13+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.5.8+maria~focal started.
+2021-03-18 05:35:13+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.5.23+maria~focal started.
 2021-03-18 05:35:13+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
-2021-03-18 05:35:13+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.5.8+maria~focal started.
+2021-03-18 05:35:13+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.5.23+maria~focal started.
 2021-03-18 05:35:14+00:00 [Note] [Entrypoint]: Initializing database files
 ...
 2021-03-18  5:35:22 0 [Note] Reading of all Master_info entries succeeded
 2021-03-18  5:35:22 0 [Note] Added new Master_info '' to hash table
 2021-03-18  5:35:22 0 [Note] mysqld: ready for connections.
-Version: '10.5.8-MariaDB-1:10.5.8+maria~focal'  socket: '/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
+Version: '10.5.23-MariaDB-1:10.5.23+maria~focal'  socket: '/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
 ```
 
 Once we see `mysqld: ready for connections.` in the log, the database is ready.
@@ -197,7 +197,7 @@ metadata:
   name: another-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storageType: Durable
   podTemplate:
     spec:
@@ -227,13 +227,13 @@ Check the pod's log to see if the database is ready
 ```bash
 ...
 $ kubectl logs -f -n demo another-mariadb-0
-2021-03-18 05:39:50+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.5.8+maria~focal started.
+2021-03-18 05:39:50+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.5.23+maria~focal started.
 2021-03-18 05:39:50+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
-2021-03-18 05:39:50+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.5.8+maria~focal started.
+2021-03-18 05:39:50+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 1:10.5.23+maria~focal started.
 2021-03-18 05:39:50+00:00 [Note] [Entrypoint]: Initializing database files
 ...
 2021-03-18  5:39:59 0 [Note] mysqld: ready for connections.
-Version: '10.5.8-MariaDB-1:10.5.8+maria~focal'  socket: '/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
+Version: '10.5.23-MariaDB-1:10.5.23+maria~focal'  socket: '/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
 ```
 
 `mysqld: ready for connections.` in the log signifies that the database is running successfully.

--- a/docs/guides/mariadb/initialization/using-script/example/demo-1.yaml
+++ b/docs/guides/mariadb/initialization/using-script/example/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mariadb/initialization/using-script/index.md
+++ b/docs/guides/mariadb/initialization/using-script/index.md
@@ -59,7 +59,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storage:
     storageClassName: "standard"
     accessModes:
@@ -113,7 +113,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   terminationPolicy: WipeOut
-  version: 10.5.8
+  version: 10.5.23
 status:
   ...
   phase: Ready
@@ -129,7 +129,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -- bash
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 40
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 

--- a/docs/guides/mariadb/monitoring/builtin-prometheus/examples/builtin-prom-md.yaml
+++ b/docs/guides/mariadb/monitoring/builtin-prometheus/examples/builtin-prom-md.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-md
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mariadb/monitoring/builtin-prometheus/index.md
+++ b/docs/guides/mariadb/monitoring/builtin-prometheus/index.md
@@ -49,7 +49,7 @@ metadata:
   name: builtin-prom-md
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"
@@ -78,7 +78,7 @@ Now, wait for the database to go into `Running` state.
 ```bash
 $ kubectl get mariadb -n demo builtin-prom-md
 NAME              VERSION   STATUS   AGE
-builtin-prom-md   10.5.8    Ready    76s
+builtin-prom-md   10.5.23    Ready    76s
 ```
 
 KubeDB will create a separate stats service with name `{MariaDB crd name}-stats` for monitoring purpose.

--- a/docs/guides/mariadb/monitoring/prometheus-operator/examples/prom-operator-md.yaml
+++ b/docs/guides/mariadb/monitoring/prometheus-operator/examples/prom-operator-md.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coreos-prom-md
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mariadb/monitoring/prometheus-operator/index.md
+++ b/docs/guides/mariadb/monitoring/prometheus-operator/index.md
@@ -111,7 +111,7 @@ metadata:
   name: coreos-prom-md
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"
@@ -149,7 +149,7 @@ Now, wait for the database to go into `Ready` state.
 ```bash
 $ kubectl get mariadb -n demo coreos-prom-md
 NAME             VERSION   STATUS   AGE
-coreos-prom-md   10.5.8    Ready    59s
+coreos-prom-md   10.5.23    Ready    59s
 ```
 
 KubeDB will create a separate stats service with name `{MariaDB crd name}-stats` for monitoring purpose.

--- a/docs/guides/mariadb/private-registry/quickstart/examples/demo.yaml
+++ b/docs/guides/mariadb/private-registry/quickstart/examples/demo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: md-pvt-reg
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mariadb/private-registry/quickstart/index.md
+++ b/docs/guides/mariadb/private-registry/quickstart/index.md
@@ -29,8 +29,8 @@ KubeDB operator supports using private Docker registry. This tutorial will show 
 ```bash
 $ kubectl get mariadbversions -n kube-system  -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,DB_IMAGE:.spec.db.image,EXPORTER_IMAGE:.spec.exporter.image,INITCONTAINER_IMAGE:.spec.initContainer.image,DEPRECATED:.spec.deprecated
 NAME      VERSION   DB_IMAGE                 EXPORTER_IMAGE                   INITCONTAINER_IMAGE   DEPRECATED
-10.4.17   10.4.17   kubedb/mariadb:10.4.17   kubedb/mysqld-exporter:v0.11.0   kubedb/busybox        <none>
-10.5.8    10.5.8    kubedb/mariadb:10.5.8    kubedb/mysqld-exporter:v0.11.0   kubedb/busybox        <none>
+10.4.32   10.4.32   kubedb/mariadb:10.4.32   kubedb/mysqld-exporter:v0.11.0   kubedb/busybox        <none>
+10.5.23    10.5.23    kubedb/mariadb:10.5.23    kubedb/mysqld-exporter:v0.11.0   kubedb/busybox        <none>
 ```
 
 Docker hub repositories:
@@ -45,17 +45,17 @@ Docker hub repositories:
   apiVersion: catalog.kubedb.com/v1alpha1
   kind: MariaDBVersion
   metadata:
-    name: 10.5.8
+    name: 10.5.23
   spec:
     db:
-      image: PRIVATE_REGISTRY/mysql:10.5.8
+      image: PRIVATE_REGISTRY/mysql:10.5.23
     exporter:
       image: PRIVATE_REGISTRY/mysqld-exporter:v0.11.0
     initContainer:
       image: PRIVATE_REGISTRY/busybox
     podSecurityPolicies:
       databasePolicyName: maria-db
-    version: 10.5.8
+    version: 10.5.23
   ```
 
 - To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial. Run the following command to prepare your cluster for this tutorial:
@@ -100,7 +100,7 @@ metadata:
   name: md-pvt-reg
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mariadb/quickstart/overview/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/quickstart/overview/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mariadb/quickstart/overview/index.md
+++ b/docs/guides/mariadb/quickstart/overview/index.md
@@ -50,8 +50,8 @@ When you have installed KubeDB, it has created `MariaDBVersion` crd for all supp
 ```bash
 $ kubectl get mariadbversions
 NAME      VERSION   DB_IMAGE          DEPRECATED   AGE
-10.4.17   10.4.17   mariadb:10.4.17                9s
-10.5.8    10.5.8    mariadb:10.5.8                 9s
+10.4.32   10.4.32   mariadb:10.4.32                9s
+10.5.23    10.5.23    mariadb:10.5.23                 9s
 10.6.4    10.6.4    mariadb:10.6.4                 9s
 ```
 
@@ -66,7 +66,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -85,7 +85,7 @@ mariadb.kubedb.com/sample-mariadb created
 
 Here,
 
-- `spec.version` is the name of the MariaDBVersion CRD where the docker images are specified. In this tutorial, a MariaDB `10.5.8` database is going to create.
+- `spec.version` is the name of the MariaDBVersion CRD where the docker images are specified. In this tutorial, a MariaDB `10.5.23` database is going to create.
 - `spec.storageType` specifies the type of storage that will be used for MariaDB database. It can be `Durable` or `Ephemeral`. Default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create MariaDB database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the StatefulSet created by KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests.
 - `spec.terminationPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `MariaDB` crd or which resources KubeDB should keep or delete when you delete `MariaDB` crd. If admission webhook is enabled, It prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`.
@@ -130,7 +130,7 @@ Spec:
     Storage Class Name:  standard
   Storage Type:          Durable
   Termination Policy:    WipeOut
-  Version:               10.5.8
+  Version:               10.5.23
 Status:
   Conditions:
     Last Transition Time:  2022-06-06T04:42:27Z
@@ -199,7 +199,7 @@ kind: MariaDB
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1alpha2","kind":"MariaDB","metadata":{"annotations":{},"name":"sample-mariadb","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"WipeOut","version":"10.5.8"}}
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"MariaDB","metadata":{"annotations":{},"name":"sample-mariadb","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"WipeOut","version":"10.5.23"}}
   creationTimestamp: "2021-03-10T04:31:09Z"
   finalizers:
   - kubedb.com
@@ -224,7 +224,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   terminationPolicy: Delete
-  version: 10.5.8
+  version: 10.5.23
 status:
   observedGeneration: 2
   phase: Ready
@@ -252,7 +252,7 @@ We will exec into the pod `sample-mariadb-0` and conncet to the database using `
 $ kubectl exec -it -n demo sample-mariadb-0 -- mariadb -u root --password='w*yOU$b53dTbjsjJ'
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 335
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -372,7 +372,7 @@ Run the following command to get MariaDB resources,
 ```bash
 $ kubectl get mariadb,sts,secret,svc,pvc -n demo
 NAME                                VERSION   STATUS   AGE
-mariadb.kubedb.com/mariadb-quickstart   10.5.8    Halted   22m
+mariadb.kubedb.com/mariadb-quickstart   10.5.23    Halted   22m
 
 NAME                           TYPE                                  DATA   AGE
 secret/default-token-lgbjm     kubernetes.io/service-account-token   3      27h

--- a/docs/guides/mariadb/reconfigure-tls/cluster/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/reconfigure-tls/cluster/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/reconfigure-tls/cluster/index.md
+++ b/docs/guides/mariadb/reconfigure-tls/cluster/index.md
@@ -49,7 +49,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:
@@ -74,7 +74,7 @@ Now, wait until `sample-mariadb` has status `Ready`. i.e,
 ```bash
 $ kubectl get mariadb -n demo
 NAME             VERSION   STATUS   AGE
-sample-mariadb   10.5.8    Ready    9m17s
+sample-mariadb   10.5.23    Ready    9m17s
 ```
 
 ```bash
@@ -88,7 +88,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb  -- bash
 root@sample-mariadb-0:/  mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 108
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -230,7 +230,7 @@ ca.crt  tls.crt  tls.key
 root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 58
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -535,7 +535,7 @@ $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb  -- bash
 root@sample-mariadb-0:/  mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 108
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 

--- a/docs/guides/mariadb/scaling/horizontal-scaling/cluster/example/sample-mariadb.yaml
+++ b/docs/guides/mariadb/scaling/horizontal-scaling/cluster/example/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/scaling/horizontal-scaling/cluster/index.md
+++ b/docs/guides/mariadb/scaling/horizontal-scaling/cluster/index.md
@@ -43,7 +43,7 @@ Here, we are going to deploy a  `MariaDB` cluster using a supported version by `
 
 ### Prepare MariaDB Cluster Database
 
-Now, we are going to deploy a `MariaDB` cluster with version `10.5.8`.
+Now, we are going to deploy a `MariaDB` cluster with version `10.5.23`.
 
 ### Deploy MariaDB Cluster
 
@@ -56,7 +56,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:
@@ -81,7 +81,7 @@ Now, wait until `sample-mariadb` has status `Ready`. i.e,
 ```bash
 $ kubectl get mariadb -n demo
 NAME             VERSION   STATUS   AGE
-sample-mariadb   10.5.8    Ready    2m36s
+sample-mariadb   10.5.23    Ready    2m36s
 ```
 
 Let's check the number of replicas this database has from the MariaDB object, number of pods the statefulset have,

--- a/docs/guides/mariadb/scaling/vertical-scaling/cluster/example/sample-mariadb.yaml
+++ b/docs/guides/mariadb/scaling/vertical-scaling/cluster/example/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/scaling/vertical-scaling/cluster/index.md
+++ b/docs/guides/mariadb/scaling/vertical-scaling/cluster/index.md
@@ -43,7 +43,7 @@ Here, we are going to deploy a  `MariaDB` cluster using a supported version by `
 
 ### Prepare MariaDB Cluster
 
-Now, we are going to deploy a `MariaDB` cluster database with version `10.5.8`.
+Now, we are going to deploy a `MariaDB` cluster database with version `10.5.23`.
 > Vertical Scaling for `MariaDB Standalone` can be performed in the same way as `MariaDB Cluster`. Only remove the `spec.replicas` field from the below yaml to deploy a MariaDB Standalone.
 
 ### Deploy MariaDB Cluster 
@@ -57,7 +57,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:
@@ -82,7 +82,7 @@ Now, wait until `sample-mariadb` has status `Ready`. i.e,
 ```bash
 $ kubectl get mariadb -n demo
 NAME             VERSION    STATUS     AGE
-sample-mariadb    10.5.8     Ready     3m46s
+sample-mariadb    10.5.23     Ready     3m46s
 ```
 
 Let's check the Pod containers resources,

--- a/docs/guides/mariadb/tls/configure/examples/tls-cluster.yaml
+++ b/docs/guides/mariadb/tls/configure/examples/tls-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: md-cluster-tls
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/tls/configure/examples/tls-standalone.yaml
+++ b/docs/guides/mariadb/tls/configure/examples/tls-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: md-standalone-tls
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mariadb/tls/configure/index.md
+++ b/docs/guides/mariadb/tls/configure/index.md
@@ -94,7 +94,7 @@ metadata:
   name: md-standalone-tls
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -146,7 +146,7 @@ Now, wait for `MariaDB` going on `Running` state and also wait for `StatefulSet`
 ```bash
 $ kubectl get mariadb -n demo md-standalone-tls
 NAME             VERSION   STATUS   AGE
-md-standalone-tls   10.5.8    Ready    5m48s
+md-standalone-tls   10.5.23    Ready    5m48s
 
 $ kubectl get sts -n demo md-standalone-tls
 NAME             READY   AGE
@@ -188,7 +188,7 @@ ca.crt  tls.crt  tls.key
 root@md-standalone-tls-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 64
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -236,7 +236,7 @@ $ kubectl exec -it -n demo md-standalone-tls-0 -- bash
 root@md-standalone-tls-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 92
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -259,7 +259,7 @@ ERROR 1045 (28000): Access denied for user 'new_user'@'localhost' (using passwor
 root@md-standalone-tls-0:/ mysql -unew_user -p1234 --ssl-ca=/etc/mysql/certs/server/ca.crt  --ssl-cert=/etc/mysql/certs/server/tls.crt --ssl-key=/etc/mysql/certs/server/tls.key
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 116
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -282,7 +282,7 @@ metadata:
   name: md-cluster-tls
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:
@@ -324,7 +324,7 @@ Now, wait for `MariaDB` going on `Running` state and also wait for `StatefulSet`
 ```bash
 $ kubectl get mariadb -n demo md-cluster-tls
 NAME             VERSION   STATUS   AGE
-md-cluster-tls   10.5.8    Ready    2m49s
+md-cluster-tls   10.5.23    Ready    2m49s
 
 $ kubectl get pod -n demo | grep md-cluster-tls
 md-cluster-tls-0   1/1     Running   0          3m29s
@@ -367,7 +367,7 @@ ca.crt  tls.crt  tls.key
 root@md-cluster-tls-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 64
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -413,7 +413,7 @@ ca.crt  tls.crt  tls.key
 root@md-cluster-tls-1:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 34
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -461,7 +461,7 @@ $ kubectl exec -it -n demo md-cluster-tls-0 -- bash
 root@md-cluster-tls-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 92
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -484,7 +484,7 @@ ERROR 1045 (28000): Access denied for user 'new_user'@'localhost' (using passwor
 root@md-cluster-tls-0:/ mysql -unew_user -p1234 --ssl-ca=/etc/mysql/certs/server/ca.crt  --ssl-cert=/etc/mysql/certs/server/tls.crt --ssl-key=/etc/mysql/certs/server/tls.key
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 116
-Server version: 10.5.8-MariaDB-1:10.5.8+maria~focal mariadb.org binary distribution
+Server version: 10.5.23-MariaDB-1:10.5.23+maria~focal mariadb.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 

--- a/docs/guides/mariadb/update-version/cluster/examples/mdops-update.yaml
+++ b/docs/guides/mariadb/update-version/cluster/examples/mdops-update.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: sample-mariadb
   updateVersion:
-    targetVersion: "10.5.8"
+    targetVersion: "10.5.23"

--- a/docs/guides/mariadb/update-version/cluster/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/update-version/cluster/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/update-version/cluster/index.md
+++ b/docs/guides/mariadb/update-version/cluster/index.md
@@ -39,7 +39,7 @@ namespace/demo created
 
 ## Prepare MariaDB Cluster
 
-Now, we are going to deploy a `MariaDB` cluster database with version `10.4.17`.
+Now, we are going to deploy a `MariaDB` cluster database with version `10.4.32`.
 
 ### Deploy MariaDB cluster
 
@@ -54,7 +54,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.4.17"
+  version: "10.4.32"
   replicas: 3
   storageType: Durable
   storage:
@@ -80,14 +80,14 @@ Now, wait until `sample-mariadb` created has status `Ready`. i.e,
 ```bash
 $ kubectl get mariadb -n demo                                                                                                                                             
 NAME             VERSION    STATUS     AGE
-sample-mariadb   10.4.17    Ready     3m15s
+sample-mariadb   10.4.32    Ready     3m15s
 ```
 
 We are now ready to apply the `MariaDBOpsRequest` CR to update this database.
 
 ### update MariaDB Version
 
-Here, we are going to update `MariaDB` cluster from `10.4.17` to `10.5.8`.
+Here, we are going to update `MariaDB` cluster from `10.4.32` to `10.5.23`.
 
 #### Create MariaDBOpsRequest:
 
@@ -104,14 +104,14 @@ spec:
   databaseRef:
     name: sample-mariadb
   updateVersion:
-    targetVersion: "10.5.8"
+    targetVersion: "10.5.23"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `sample-mariadb` MariaDB database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `10.5.8`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `10.5.23`.
 
 Let's create the `MariaDBOpsRequest` CR we have shown above,
 
@@ -139,13 +139,13 @@ Now, we are going to verify whether the `MariaDB` and the related `StatefulSets`
 
 ```bash
 $ kubectl get mariadb -n demo sample-mariadb -o=jsonpath='{.spec.version}{"\n"}'
-10.5.8
+10.5.23
 
 $ kubectl get sts -n demo sample-mariadb -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-mariadb:10.5.8
+mariadb:10.5.23
 
 $ kubectl get pods -n demo sample-mariadb-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-mariadb:10.5.8
+mariadb:10.5.23
 ```
 
 You can see from above, our `MariaDB` cluster database has been updated with the new version. So, the update process is successfully completed.

--- a/docs/guides/mariadb/volume-expansion/volume-expansion/example/sample-mariadb.yaml
+++ b/docs/guides/mariadb/volume-expansion/volume-expansion/example/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/volume-expansion/volume-expansion/index.md
+++ b/docs/guides/mariadb/volume-expansion/volume-expansion/index.md
@@ -56,7 +56,7 @@ topolvm-provisioner   topolvm.cybozu.com      Delete          WaitForFirstConsum
 
 We can see from the output the `topolvm-provisioner` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We will use this storage class. You can install topolvm from [here](https://github.com/topolvm/topolvm).
 
-Now, we are going to deploy a `MariaDB` database of 3 replicas with version `10.5.8`.
+Now, we are going to deploy a `MariaDB` database of 3 replicas with version `10.5.23`.
 
 ### Deploy MariaDB
 
@@ -69,7 +69,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.8"
+  version: "10.5.23"
   replicas: 3
   storageType: Durable
   storage:
@@ -95,7 +95,7 @@ Now, wait until `sample-mariadb` has status `Ready`. i.e,
 ```bash
 $ kubectl get mariadb -n demo
 NAME             VERSION   STATUS   AGE
-sample-mariadb   10.5.8    Ready    5m4s
+sample-mariadb   10.5.23    Ready    5m4s
 ```
 
 Let's check volume size from statefulset, and from the persistent volume,

--- a/docs/guides/mongodb/backup/auto-backup/index.md
+++ b/docs/guides/mongodb/backup/auto-backup/index.md
@@ -396,7 +396,7 @@ If everything goes well, Stash should create a `BackupConfiguration` for our Mon
 ```bash
 ❯ kubectl get backupconfiguration -n demo-2
 NAME                   TASK                    SCHEDULE      PAUSED   PHASE   AGE
-app-sample-mongodb-2   mongodb-backup-10.5.8   */3 * * * *            Ready   3m24s
+app-sample-mongodb-2   mongodb-backup-10.5.23   */3 * * * *            Ready   3m24s
 ```
 
 Now, let's check the YAML of the `BackupConfiguration`.
@@ -582,7 +582,7 @@ If everything goes well, Stash should create a `BackupConfiguration` for our Mon
 ```bash
 ❯ kubectl get backupconfiguration -n demo-3
 NAME                   TASK                    SCHEDULE      PAUSED   PHASE   AGE
-app-sample-mongodb-3   mongodb-backup-10.5.8   */5 * * * *            Ready   106s
+app-sample-mongodb-3   mongodb-backup-10.5.23   */5 * * * *            Ready   106s
 ```
 
 Now, let's check the YAML of the `BackupConfiguration`.

--- a/docs/guides/mysql/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mysql/autoscaler/storage/cluster/index.md
@@ -60,7 +60,7 @@ Now, we are going to deploy a `MySQL` replicaset using a supported version by `K
 
 #### Deploy MySQL Cluster
 
-In this section, we are going to deploy a MySQL replicaset database with version `10.5.8`.  Then, in the next section we will set up autoscaling for this database using `MySQLAutoscaler` CRD. Below is the YAML of the `MySQL` CR that we are going to create,
+In this section, we are going to deploy a MySQL replicaset database with version `10.5.23`.  Then, in the next section we will set up autoscaling for this database using `MySQLAutoscaler` CRD. Below is the YAML of the `MySQL` CR that we are going to create,
 
 > If you want to autoscale MySQL `Standalone`, Just remove the `spec.Replicas` from the below yaml and rest of the steps are same.
 
@@ -98,7 +98,7 @@ Now, wait until `sample-mysql` has status `Ready`. i.e,
 ```bash
 $ kubectl get mysql -n demo
 NAME             VERSION   STATUS   AGE
-sample-mysql   10.5.8    Ready    3m46s
+sample-mysql   10.5.23    Ready    3m46s
 ```
 
 Let's check volume size from statefulset, and from the persistent volume,

--- a/docs/guides/mysql/backup/auto-backup/examples/sample-mysql-2.yaml
+++ b/docs/guides/mysql/backup/auto-backup/examples/sample-mysql-2.yaml
@@ -7,7 +7,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mysql-backup-template
     stash.appscode.com/schedule: "*/3 * * * *"
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/auto-backup/examples/sample-mysql-3.yaml
+++ b/docs/guides/mysql/backup/auto-backup/examples/sample-mysql-3.yaml
@@ -7,7 +7,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mysql-backup-template
     params.stash.appscode.com/args: --databases mysql
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/auto-backup/examples/sample-mysql.yaml
+++ b/docs/guides/mysql/backup/auto-backup/examples/sample-mysql.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     stash.appscode.com/backup-blueprint: mysql-backup-template
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/auto-backup/index.md
+++ b/docs/guides/mysql/backup/auto-backup/index.md
@@ -135,7 +135,7 @@ metadata:
   annotations:
     stash.appscode.com/backup-blueprint: mysql-backup-template
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   replicas: 1
   storageType: Durable
   storage:
@@ -321,7 +321,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mysql-backup-template
     stash.appscode.com/schedule: "*/3 * * * *"
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   replicas: 1
   storageType: Durable
   storage:
@@ -510,7 +510,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mysql-backup-template
     params.stash.appscode.com/args: --databases mysql
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/customization/examples/sample-mysql.yaml
+++ b/docs/guides/mysql/backup/customization/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/standalone/examples/restored-mysql.yaml
+++ b/docs/guides/mysql/backup/standalone/examples/restored-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restored-mysql
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/standalone/examples/sample-mysql.yaml
+++ b/docs/guides/mysql/backup/standalone/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/standalone/index.md
+++ b/docs/guides/mysql/backup/standalone/index.md
@@ -57,7 +57,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   replicas: 1
   storageType: Durable
   storage:
@@ -83,7 +83,7 @@ Let's check if the database is ready to use,
 ```bash
 $ kubectl get my -n demo sample-mysql
 NAME           VERSION   STATUS    AGE
-sample-mysql   8.0.29    Ready   4m22s
+sample-mysql   8.0.32    Ready   4m22s
 ```
 
 The database is `Ready`. Verify that KubeDB has created a Secret and a Service for this database using the following commands,
@@ -123,7 +123,7 @@ kind: AppBinding
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"sample-mysql","namespace":"demo"},"spec":{"replicas":1,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"50Mi"}}},"storageType":"Durable","terminationPolicy":"WipeOut","version":"8.0.29"}}
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"sample-mysql","namespace":"demo"},"spec":{"replicas":1,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"50Mi"}}},"storageType":"Durable","terminationPolicy":"WipeOut","version":"8.0.32"}}
   creationTimestamp: "2022-06-30T05:45:43Z"
   generation: 1
   labels:
@@ -165,7 +165,7 @@ spec:
   secret:
     name: sample-mysql-auth
   type: kubedb.com/mysql
-  version: 8.0.29
+  version: 8.0.32
 ```
 
 Stash uses the AppBinding CRD to connect with the target database. It requires the following two fields to set in AppBinding's `.spec` section.
@@ -445,7 +445,7 @@ metadata:
   name: restored-mysql
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   replicas: 1
   storageType: Durable
   storage:
@@ -471,7 +471,7 @@ If you check the database status, you will see it is stuck in **`Provisioning`**
 ```bash
 $ kubectl get my -n demo restored-mysql
 NAME             VERSION   STATUS         AGE
-restored-mysql   8.0.29    Provisioning   61s
+restored-mysql   8.0.32    Provisioning   61s
 ```
 
 #### Create RestoreSession:

--- a/docs/guides/mysql/cli/index.md
+++ b/docs/guides/mysql/cli/index.md
@@ -47,8 +47,8 @@ cat mysql-demo.yaml | kubectl create -f -
 ```bash
 $ kubectl get mysql
 NAME         VERSION   STATUS    AGE
-mysql-demo   8.0.27    Running   5m1s
-mysql-dev    5.7.36 Running   10m1s
+mysql-demo   8.0.32    Running   5m1s
+mysql-dev    5.7.41 Running   10m1s
 ```
 
 To get YAML of an object, use `--output=yaml` flag.
@@ -106,7 +106,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   terminationPolicy: Delete
-  version: 8.0.27
+  version: 8.0.32
 ```
 
 To get JSON of an object, use `--output=json` flag.
@@ -127,13 +127,13 @@ service/mysql-demo        ClusterIP   10.107.205.135   <none>        3306/TCP   
 service/mysql-demo-pods   ClusterIP   None             <none>        3306/TCP   2m17s   app.kubernetes.io/instance=mysql-demo,app.kubernetes.io/managed-by=kubedb.com,app.kubernetes.io/name=mysqls.kubedb.com
 
 NAME                          READY   AGE     CONTAINERS   IMAGES
-statefulset.apps/mysql-demo   1/1     2m17s   mysql        kubedb/mysql:8.0.27
+statefulset.apps/mysql-demo   1/1     2m17s   mysql        kubedb/mysql:8.0.32
 
 NAME                                            TYPE               VERSION   AGE
-appbinding.appcatalog.appscode.com/mysql-demo   kubedb.com/mysql   8.0.27    2m17s
+appbinding.appcatalog.appscode.com/mysql-demo   kubedb.com/mysql   8.0.32    2m17s
 
 NAME                          VERSION   STATUS   AGE
-mysql.kubedb.com/mysql-demo   8.0.27    Ready    2m17s
+mysql.kubedb.com/mysql-demo   8.0.32    Ready    2m17s
 ```
 
 Flag `--output=wide` is used to print additional information.
@@ -226,7 +226,7 @@ Auth Secret:
 AppBinding:
   Metadata:
     Annotations:
-      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-demo","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"version":"8.0.27"}}
+      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-demo","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"version":"8.0.32"}}
 
     Creation Timestamp:  2021-03-15T11:53:48Z
     Labels:
@@ -250,13 +250,13 @@ AppBinding:
       Stash:
         Addon:
           Backup Task:
-            Name:  mysql-backup-8.0.27
+            Name:  mysql-backup-8.0.32
           Restore Task:
-            Name:  mysql-restore-8.0.27
+            Name:  mysql-restore-8.0.32
     Secret:
       Name:   mysql-demo-auth
     Type:     kubedb.com/mysql
-    Version:  8.0.27
+    Version:  8.0.32
 
 Events:
   Type    Reason      Age   From             Message

--- a/docs/guides/mysql/cli/yamls/mysql-demo.yaml
+++ b/docs/guides/mysql/cli/yamls/mysql-demo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-demo
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mysql/clients/index.md
+++ b/docs/guides/mysql/clients/index.md
@@ -48,7 +48,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -84,7 +84,7 @@ $ watch -n 3 kubectl get my -n demo my-group
 Every 3.0s: kubectl get my -n demo my-group                      suaas-appscode: Wed Sep  9 10:54:34 2020
 
 NAME       VERSION   STATUS    AGE
-my-group   8.0.27    Running   16m
+my-group   8.0.32    Running   16m
 
 $ watch -n 3 kubectl get sts -n demo my-group
 ery 3.0s: kubectl get sts -n demo my-group                     suaas-appscode: Wed Sep  9 10:53:52 2020
@@ -183,7 +183,7 @@ Auth Secret:
 AppBinding:
   Metadata:
     Annotations:
-      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"my-group","namespace":"demo"},"spec":{"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"WipeOut","topology":{"group":{"name":"dc002fc3-c412-4d18-b1d4-66c1fbfbbc9b"},"mode":"GroupReplication"},"version":"8.0.27"}}
+      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"my-group","namespace":"demo"},"spec":{"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"WipeOut","topology":{"group":{"name":"dc002fc3-c412-4d18-b1d4-66c1fbfbbc9b"},"mode":"GroupReplication"},"version":"8.0.32"}}
 
     Creation Timestamp:  2021-03-15T12:18:35Z
     Labels:
@@ -207,16 +207,16 @@ AppBinding:
       Stash:
         Addon:
           Backup Task:
-            Name:  mysql-backup-8.0.27
+            Name:  mysql-backup-8.0.32
             Params:
               Name:   args
               Value:  --all-databases --set-gtid-purged=OFF
           Restore Task:
-            Name:  mysql-restore-8.0.27
+            Name:  mysql-restore-8.0.32
     Secret:
       Name:   my-group-auth
     Type:     kubedb.com/mysql
-    Version:  8.0.27
+    Version:  8.0.32
 
 Events:
   Type    Reason      Age   From             Message

--- a/docs/guides/mysql/clients/yamls/group-replication.yaml
+++ b/docs/guides/mysql/clients/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/clustering/group-replication/index.md
+++ b/docs/guides/mysql/clustering/group-replication/index.md
@@ -48,7 +48,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -161,7 +161,7 @@ Auth Secret:
 AppBinding:
   Metadata:
     Annotations:
-      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"my-group","namespace":"demo"},"spec":{"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"WipeOut","topology":{"group":{"name":"dc002fc3-c412-4d18-b1d4-66c1fbfbbc9b"},"mode":"GroupReplication"},"version":"8.0.29"}}
+      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"my-group","namespace":"demo"},"spec":{"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"WipeOut","topology":{"group":{"name":"dc002fc3-c412-4d18-b1d4-66c1fbfbbc9b"},"mode":"GroupReplication"},"version":"8.0.32"}}
 
     Creation Timestamp:  2022-06-28T11:54:10Z
     Labels:
@@ -194,7 +194,7 @@ AppBinding:
     Secret:
       Name:   my-group-auth
     Type:     kubedb.com/mysql
-    Version:  8.0.29
+    Version:  8.0.32
 
 Events:
   Type     Reason      Age   From               Message
@@ -292,7 +292,7 @@ spec:
     group:
       name: dc002fc3-c412-4d18-b1d4-66c1fbfbbc9b
     mode: GroupReplication
-  version: 8.0.29
+  version: 8.0.32
 status:
   observedGeneration: 2$4213139756412538772
   phase: Running
@@ -394,9 +394,9 @@ mysql: [Warning] Using a password on the command line interface can be insecure.
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
 | CHANNEL_NAME              | MEMBER_ID                            | MEMBER_HOST                       | MEMBER_PORT | MEMBER_STATE | MEMBER_ROLE | MEMBER_VERSION | MEMBER_COMMUNICATION_STACK |
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
-| group_replication_applier | 13aad5a5-f6d9-11ec-87bb-96e838330519 | my-group-2.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.29         | XCom                       |
-| group_replication_applier | 1739589f-f6d9-11ec-956c-c2c213efafa8 | my-group-1.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.29         | XCom                       |
-| group_replication_applier | 1ace16b5-f6d9-11ec-9a26-9ae7d6def698 | my-group-0.my-group-pods.demo.svc |        3306 | ONLINE       | PRIMARY     | 8.0.29         | XCom                       |
+| group_replication_applier | 13aad5a5-f6d9-11ec-87bb-96e838330519 | my-group-2.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.32         | XCom                       |
+| group_replication_applier | 1739589f-f6d9-11ec-956c-c2c213efafa8 | my-group-1.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.32         | XCom                       |
+| group_replication_applier | 1ace16b5-f6d9-11ec-9a26-9ae7d6def698 | my-group-0.my-group-pods.demo.svc |        3306 | ONLINE       | PRIMARY     | 8.0.32         | XCom                       |
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
 
 ```
@@ -496,9 +496,9 @@ mysql: [Warning] Using a password on the command line interface can be insecure.
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
 | CHANNEL_NAME              | MEMBER_ID                            | MEMBER_HOST                       | MEMBER_PORT | MEMBER_STATE | MEMBER_ROLE | MEMBER_VERSION | MEMBER_COMMUNICATION_STACK |
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
-| group_replication_applier | 13aad5a5-f6d9-11ec-87bb-96e838330519 | my-group-2.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY     | 8.0.29         | XCom                       |
-| group_replication_applier | 1739589f-f6d9-11ec-956c-c2c213efafa8 | my-group-1.my-group-pods.demo.svc |        3306 | ONLINE       | PRIMARY   | 8.0.29         | XCom                       |
-| group_replication_applier | 1ace16b5-f6d9-11ec-9a26-9ae7d6def698 | my-group-0.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.29         | XCom                       |
+| group_replication_applier | 13aad5a5-f6d9-11ec-87bb-96e838330519 | my-group-2.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY     | 8.0.32         | XCom                       |
+| group_replication_applier | 1739589f-f6d9-11ec-956c-c2c213efafa8 | my-group-1.my-group-pods.demo.svc |        3306 | ONLINE       | PRIMARY   | 8.0.32         | XCom                       |
+| group_replication_applier | 1ace16b5-f6d9-11ec-9a26-9ae7d6def698 | my-group-0.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.32         | XCom                       |
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
 
 

--- a/docs/guides/mysql/clustering/group-replication/yamls/group-replication.yaml
+++ b/docs/guides/mysql/clustering/group-replication/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/clustering/overview/images/yamls/group-replication.yaml
+++ b/docs/guides/mysql/clustering/overview/images/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/concepts/appbinding/index.md
+++ b/docs/guides/mysql/concepts/appbinding/index.md
@@ -34,7 +34,7 @@ kind: AppBinding
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-group","namespace":"demo"},"spec":{"configSecret":{"name":"my-configuration"},"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"version":"8.0.29"}}
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-group","namespace":"demo"},"spec":{"configSecret":{"name":"my-configuration"},"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"version":"8.0.32"}}
   creationTimestamp: "2022-06-28T10:08:03Z"
   generation: 1
   labels:
@@ -76,7 +76,7 @@ spec:
   secret:
     name: mysql-group-auth
   type: kubedb.com/mysql
-  version: 8.0.29
+  version: 8.0.32
 
 ```
 

--- a/docs/guides/mysql/concepts/catalog/index.md
+++ b/docs/guides/mysql/concepts/catalog/index.md
@@ -41,19 +41,19 @@ metadata:
     app.kubernetes.io/name: kubedb-catalog
     app.kubernetes.io/version: v2022.03.28
     helm.sh/chart: kubedb-catalog-v2022.03.28
-  name: 8.0.29
+  name: 8.0.32
   resourceVersion: "1575483"
   uid: 4e605d5f-a6f0-42cb-a125-b4b4fd02e41e
 spec:
   coordinator:
     image: kubedb/mysql-coordinator:v0.4.0-2-g49a2d26-dirty_linux_amd64
   db:
-    image: mysql:8.0.29
+    image: mysql:8.0.32
   distribution: Official
   exporter:
     image: kubedb/mysqld-exporter:v0.13.1
   initContainer:
-    image: kubedb/mysql-init:8.0.29_linux_amd64
+    image: kubedb/mysql-init:8.0.32_linux_amd64
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
@@ -67,10 +67,10 @@ spec:
   updateConstraints:
     denylist:
       groupReplication:
-      - < 8.0.29
+      - < 8.0.32
       standalone:
-      - < 8.0.29
-  version: 8.0.29
+      - < 8.0.32
+  version: 8.0.32
 ```
 
 ### metadata.name

--- a/docs/guides/mysql/concepts/database/index.md
+++ b/docs/guides/mysql/concepts/database/index.md
@@ -29,7 +29,7 @@ metadata:
   name: m1
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   topology:
     mode: GroupReplication
   authSecret:
@@ -113,9 +113,9 @@ spec:
 
 `spec.version` is a required field specifying the name of the [MySQLVersion](/docs/guides/mysql/concepts/catalog/index.md) crd where the docker images are specified. Currently, when you install KubeDB, it creates the following `MySQLVersion` resources,
 
-- `8.0.29`, `8.0.27`, `8.0.17`, `8.0.3-v4`
-- `8.0.27-innodb`
-- `5.7.36`, `5.7.35-v1`,`5.7.25-v2`
+- `8.0.32`, `8.0.32`, `8.0.17`, `8.0.3-v4`
+- `8.0.32-innodb`
+- `5.7.41`, `5.7.35-v1`,`5.7.25-v2`
 
 ### spec.topology
 
@@ -194,7 +194,7 @@ metadata:
   name: m1
   namespace: demo
 spec:
-  version: 8.0.27
+  version: 8.0.32
   init:
     script:
       configMap:

--- a/docs/guides/mysql/concepts/opsrequest/index.md
+++ b/docs/guides/mysql/concepts/opsrequest/index.md
@@ -39,7 +39,7 @@ spec:
     name: my-group
   type: UpdateVersion
   updateVersion:
-    targetVersion: 8.0.29
+    targetVersion: 8.0.32
 status:
   conditions:
   - lastTransitionTime: "2022-06-16T13:52:58Z"

--- a/docs/guides/mysql/configuration/config-file/index.md
+++ b/docs/guides/mysql/configuration/config-file/index.md
@@ -103,7 +103,7 @@ metadata:
   name: custom-mysql
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   configSecret:
     name: my-configuration
   storage:
@@ -129,19 +129,19 @@ Check the pod's log to see if the database is ready
 
 ```bash
 $ kubectl logs -f -n demo custom-mysql-0
-2022-06-28 13:22:10+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.29-1debian10 started.
+2022-06-28 13:22:10+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.32-1debian10 started.
 2022-06-28 13:22:10+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
 ....
 
 2022-06-28 13:22:20+00:00 [Note] [Entrypoint]: Database files initialized
 2022-06-28 13:22:20+00:00 [Note] [Entrypoint]: Starting temporary server
-2022-06-28T13:22:20.233556Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.29) starting as process 92
+2022-06-28T13:22:20.233556Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.32) starting as process 92
 2022-06-28T13:22:20.252075Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
 2022-06-28T13:22:20.543772Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
 ...
 2022-06-28 13:22:22+00:00 [Note] [Entrypoint]: Stopping temporary server
-2022-06-28T13:22:22.354537Z 10 [System] [MY-013172] [Server] Received SHUTDOWN from user root. Shutting down mysqld (Version: 8.0.29).
-2022-06-28T13:22:24.495121Z 0 [System] [MY-010910] [Server] /usr/sbin/mysqld: Shutdown complete (mysqld 8.0.29)  MySQL Community Server - GPL.
+2022-06-28T13:22:22.354537Z 10 [System] [MY-013172] [Server] Received SHUTDOWN from user root. Shutting down mysqld (Version: 8.0.32).
+2022-06-28T13:22:24.495121Z 0 [System] [MY-010910] [Server] /usr/sbin/mysqld: Shutdown complete (mysqld 8.0.32)  MySQL Community Server - GPL.
 2022-06-28 13:22:25+00:00 [Note] [Entrypoint]: Temporary server stopped
 
 2022-06-28 13:22:25+00:00 [Note] [Entrypoint]: MySQL init process done. Ready for start up.
@@ -149,7 +149,7 @@ $ kubectl logs -f -n demo custom-mysql-0
 ....
 2022-06-28T13:22:26.064259Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
 2022-06-28T13:22:26.076352Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/run/mysqld/mysqlx.sock
-2022-06-28T13:22:26.076407Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.29'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server - GPL.
+2022-06-28T13:22:26.076407Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.32'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server - GPL.
 
 ....
 ```

--- a/docs/guides/mysql/configuration/config-file/yamls/mysql-custom.yaml
+++ b/docs/guides/mysql/configuration/config-file/yamls/mysql-custom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-mysql
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   configSecret:
     name: my-configuration
   storage:

--- a/docs/guides/mysql/configuration/podtemplating/index.md
+++ b/docs/guides/mysql/configuration/podtemplating/index.md
@@ -60,7 +60,7 @@ Read about the fields in details in [PodTemplate concept](/docs/guides/mysql/con
 
 Below is the YAML for the MySQL created in this example. Here, [`spec.podTemplate.spec.env`](/docs/guides/mysql/concepts/database/index.md#specpodtemplatespecenv) specifies environment variables and [`spec.podTemplate.spec.args`](/docs/guides/mysql/concepts/database/index.md#specpodtemplatespecargs) provides extra arguments for [MySQL Docker Image](https://hub.docker.com/_/mysql/).
 
-In this tutorial, an initial database `myDB` will be created by providing `env` `MYSQL_DATABASE` while the server character set will be set to `utf8mb4` by adding extra `args`. Note that, `character-set-server` in `MySQL 5.7.36` is `latin1`.
+In this tutorial, an initial database `myDB` will be created by providing `env` `MYSQL_DATABASE` while the server character set will be set to `utf8mb4` by adding extra `args`. Note that, `character-set-server` in `MySQL 5.7.41` is `latin1`.
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -69,7 +69,7 @@ metadata:
   name: mysql-misc-config
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   storageType: "Durable"
   storage:
     storageClassName: "standard"
@@ -132,7 +132,7 @@ MySQL init process in progress...
 MySQL init process done. Ready for start up.
 ....
 2022-06-28T13:22:26.076407Z 0 [Note] mysqld: ready for connections.
-Version: '5.7.36'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server (GPL)
+Version: '5.7.41'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server (GPL)
 ....
 ```
 

--- a/docs/guides/mysql/configuration/podtemplating/yamls/mysql-misc-config.yaml
+++ b/docs/guides/mysql/configuration/podtemplating/yamls/mysql-misc-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-misc-config
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   storageType: "Durable"
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/custom-rbac/index.md
+++ b/docs/guides/mysql/custom-rbac/index.md
@@ -142,7 +142,7 @@ metadata:
   name: quick-mysql
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   storageType: Durable
   podTemplate:
     spec:
@@ -172,13 +172,13 @@ Check the pod's log to see if the database is ready
 ```bash
 $ kubectl logs -f -n demo quick-mysql-0
 ...
-2022-06-28 13:46:46+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.29-1debian10 started.
+2022-06-28 13:46:46+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.32-1debian10 started.
 2022-06-28 13:46:46+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
-2022-06-28 13:46:46+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.29-1debian10 started.
+2022-06-28 13:46:46+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.32-1debian10 started.
 
 ...
 2022-06-28T13:47:02.915445Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/run/mysqld/mysqlx.sock
-2022-06-28T13:47:02.915504Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.29'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server - GPL.
+2022-06-28T13:47:02.915504Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.32'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server - GPL.
 
 ```
 
@@ -204,7 +204,7 @@ metadata:
   name: minute-mysql
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   storageType: Durable
   podTemplate:
     spec:
@@ -234,14 +234,14 @@ Check the pod's log to see if the database is ready
 
 ```bash
 ...
-2022-06-28 13:48:53+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.29-1debian10 started.
+2022-06-28 13:48:53+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.32-1debian10 started.
 2022-06-28 13:48:53+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
-2022-06-28 13:48:53+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.29-1debian10 started.
+2022-06-28 13:48:53+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.32-1debian10 started.
 2022-06-28 13:48:53+00:00 [Note] [Entrypoint]: Initializing database files
-2022-06-28T13:48:53.986191Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.29) initializing of server in progress as process 43
+2022-06-28T13:48:53.986191Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.32) initializing of server in progress as process 43
 ...
 2022-06-28T13:49:11.543893Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/run/mysqld/mysqlx.sock
-2022-06-28T13:49:11.543917Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.29'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server - GPL.
+2022-06-28T13:49:11.543917Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.32'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server - GPL.
 
 
 

--- a/docs/guides/mysql/custom-rbac/yamls/my-custom-db-two.yaml
+++ b/docs/guides/mysql/custom-rbac/yamls/my-custom-db-two.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minute-mysql
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/mysql/custom-rbac/yamls/my-custom-db.yaml
+++ b/docs/guides/mysql/custom-rbac/yamls/my-custom-db.yaml
@@ -4,7 +4,7 @@ metadata:
   name: quick-mysql
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/mysql/monitoring/builtin-prometheus/index.md
+++ b/docs/guides/mysql/monitoring/builtin-prometheus/index.md
@@ -49,7 +49,7 @@ metadata:
   name: builtin-prom-mysql
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"
@@ -80,7 +80,7 @@ $ watch -n 3 kubectl get mysql -n demo builtin-prom-mysql
 Every 3.0s: kubectl get mysql -n demo builtin-prom-mysql        suaas-appscode: Tue Aug 25 16:07:29 2020
 
 NAME                 VERSION      STATUS    AGE
-builtin-prom-mysql   8.0.27    Running   3m33s
+builtin-prom-mysql   8.0.32    Running   3m33s
 ```
 
 KubeDB will create a separate stats service with name `{MySQL crd name}-stats` for monitoring purpose.

--- a/docs/guides/mysql/monitoring/builtin-prometheus/yamls/builtin-prom-mysql.yaml
+++ b/docs/guides/mysql/monitoring/builtin-prometheus/yamls/builtin-prom-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-mysql
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/monitoring/overview/index.md
+++ b/docs/guides/mysql/monitoring/overview/index.md
@@ -53,7 +53,7 @@ metadata:
   name: prom-operator-mysql
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/monitoring/prometheus-operator/index.md
+++ b/docs/guides/mysql/monitoring/prometheus-operator/index.md
@@ -111,7 +111,7 @@ metadata:
   name: coreos-prom-mysql
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"
@@ -151,7 +151,7 @@ $ watch -n 3 kubectl get mysql -n demo coreos-prom-mysql
 Every 3.0s: kubectl get mysql -n demo coreos-prom-mysql         suaas-appscode: Tue Aug 25 11:53:34 2020
 
 NAME                VERSION      STATUS    AGE
-coreos-prom-mysql   8.0.27    Running   2m53s
+coreos-prom-mysql   8.0.32    Running   2m53s
 ```
 
 KubeDB will create a separate stats service with name `{MySQL crd name}-stats` for monitoring purpose.

--- a/docs/guides/mysql/monitoring/prometheus-operator/yamls/prom-operator-mysql.yaml
+++ b/docs/guides/mysql/monitoring/prometheus-operator/yamls/prom-operator-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: prom-operator-mysql
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   terminationPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/private-registry/index.md
+++ b/docs/guides/mysql/private-registry/index.md
@@ -30,11 +30,11 @@ KubeDB operator supports using private Docker registry. This tutorial will show 
 $ kubectl get mysqlversions -n kube-system  -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,DB_IMAGE:.spec.db.image,EXPORTER_IMAGE:.spec.exporter.image,REPLICATION_MODE_DETECTOR_IMAGE:.spec.replicationModeDetector.image,INITCONTAINER_IMAGE:.spec.initContainer.image,DEPRECATED:.spec.deprecated
 NAME            VERSION   DB_IMAGE                    EXPORTER_IMAGE                   REPLICATION_MODE_DETECTOR_IMAGE            INITCONTAINER_IMAGE                    DEPRECATED
 5.7.35-v1       5.7.35    mysql:5.7.35                kubedb/mysqld-exporter:v0.13.1   kubedb/replication-mode-detector:v0.13.0   kubedb/mysql-init:5.7-v2               <none>
-5.7.36          5.7.36    mysql:5.7.36                kubedb/mysqld-exporter:v0.13.1   kubedb/replication-mode-detector:v0.13.0   kubedb/mysql-init:5.7-v2               <none>
+5.7.41          5.7.41    mysql:5.7.41                kubedb/mysqld-exporter:v0.13.1   kubedb/replication-mode-detector:v0.13.0   kubedb/mysql-init:5.7-v2               <none>
 8.0.17          8.0.17    mysql:8.0.17                kubedb/mysqld-exporter:v0.13.1   kubedb/replication-mode-detector:v0.13.0   kubedb/mysql-init:8.0.3-v1             <none>
-8.0.27          8.0.27    mysql:8.0.27                kubedb/mysqld-exporter:v0.13.1   kubedb/replication-mode-detector:v0.13.0   kubedb/mysql-init:8.0.26-v1            <none>
-8.0.27-innodb   8.0.27    mysql/mysql-server:8.0.27   kubedb/mysqld-exporter:v0.13.1   kubedb/replication-mode-detector:v0.13.0   kubedb/mysql-init:8.0.26-v1            <none>
-8.0.29          8.0.29    mysql:8.0.29                kubedb/mysqld-exporter:v0.13.1   kubedb/replication-mode-detector:v0.13.0   kubedb/mysql-init:8.0.29_linux_amd64   <none>
+8.0.32          8.0.32    mysql:8.0.32                kubedb/mysqld-exporter:v0.13.1   kubedb/replication-mode-detector:v0.13.0   kubedb/mysql-init:8.0.26-v1            <none>
+8.0.32-innodb   8.0.32    mysql/mysql-server:8.0.32   kubedb/mysqld-exporter:v0.13.1   kubedb/replication-mode-detector:v0.13.0   kubedb/mysql-init:8.0.26-v1            <none>
+8.0.32          8.0.32    mysql:8.0.32                kubedb/mysqld-exporter:v0.13.1   kubedb/replication-mode-detector:v0.13.0   kubedb/mysql-init:8.0.32_linux_amd64   <none>
 8.0.3-v4        8.0.3     mysql:8.0.3                 kubedb/mysqld-exporter:v0.13.1   kubedb/replication-mode-detector:v0.13.0   kubedb/mysql-init:8.0.3-v1             <none>
 
 ```
@@ -51,17 +51,17 @@ NAME            VERSION   DB_IMAGE                    EXPORTER_IMAGE            
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion
 metadata:
-  name: 8.0.29
+  name: 8.0.32
 spec:
   coordinator:
     image: PRIVATE_REGISTRY/mysql-coordinator:v0.4.0-2-g49a2d26-dirty_linux_amd64
   db:
-    image: PRIVATE_REGISTRY/mysql:8.0.29
+    image: PRIVATE_REGISTRY/mysql:8.0.32
   distribution: Official
   exporter:
     image: PRIVATE_REGISTRY/mysqld-exporter:v0.13.1
   initContainer:
-    image: PRIVATE_REGISTRY/mysql-init:8.0.29_linux_amd64
+    image: PRIVATE_REGISTRY/mysql-init:8.0.32_linux_amd64
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
@@ -75,10 +75,10 @@ spec:
   updateConstraints:
     denylist:
       groupReplication:
-      - < 8.0.29
+      - < 8.0.32
       standalone:
-      - < 8.0.29
-  version: 8.0.29
+      - < 8.0.32
+  version: 8.0.32
 ```
 
 - To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial. Run the following command to prepare your cluster for this tutorial:
@@ -123,7 +123,7 @@ metadata:
   name: mysql-pvt-reg
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mysql/private-registry/yamls/quickstart.yaml
+++ b/docs/guides/mysql/private-registry/yamls/quickstart.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/private-registry/yamls/standalone.yaml
+++ b/docs/guides/mysql/private-registry/yamls/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-pvt-reg
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mysql/quickstart/index.md
+++ b/docs/guides/mysql/quickstart/index.md
@@ -51,11 +51,11 @@ When you have installed KubeDB, it has created `MySQLVersion` crd for all suppor
 $ kubectl get mysqlversions
 NAME            VERSION   DISTRIBUTION   DB_IMAGE                    DEPRECATED   AGE
 5.7.35-v1       5.7.35    Official       mysql:5.7.35                             9s
-5.7.36          5.7.36    Official       mysql:5.7.36                             9s
+5.7.41          5.7.41    Official       mysql:5.7.41                             9s
 8.0.17          8.0.17    Official       mysql:8.0.17                             9s
-8.0.27          8.0.27    Official       mysql:8.0.27                             9s
-8.0.27-innodb   8.0.27    MySQL          mysql/mysql-server:8.0.27                9s
-8.0.29          8.0.29    Official       mysql:8.0.29                             9s
+8.0.32          8.0.32    Official       mysql:8.0.32                             9s
+8.0.32-innodb   8.0.32    MySQL          mysql/mysql-server:8.0.32                9s
+8.0.32          8.0.32    Official       mysql:8.0.32                             9s
 8.0.3-v4        8.0.3     Official       mysql:8.0.3                              9s
 
 ```
@@ -71,7 +71,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -90,7 +90,7 @@ mysql.kubedb.com/mysql-quickstart created
 
 Here,
 
-- `spec.version` is the name of the MySQLVersion CRD where the docker images are specified. In this tutorial, a MySQL `8.0.29` database is going to be created.
+- `spec.version` is the name of the MySQLVersion CRD where the docker images are specified. In this tutorial, a MySQL `8.0.32` database is going to be created.
 - `spec.storageType` specifies the type of storage that will be used for MySQL database. It can be `Durable` or `Ephemeral`. Default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create MySQL database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the StatefulSet created by KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests.
 - `spec.terminationPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `MySQL` crd or which resources KubeDB should keep or delete when you delete `MySQL` crd. If admission webhook is enabled, It prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`. Learn details of all `TerminationPolicy` [here](/docs/guides/mysql/concepts/database/index.md#specterminationpolicy)
@@ -169,7 +169,7 @@ Auth Secret:
 AppBinding:
   Metadata:
     Annotations:
-      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-quickstart","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"DoNotTerminate","version":"8.0.29"}}
+      kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-quickstart","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"DoNotTerminate","version":"8.0.32"}}
 
     Creation Timestamp:  2022-06-03T06:50:40Z
     Labels:
@@ -202,7 +202,7 @@ AppBinding:
     Secret:
       Name:   mysql-quickstart-auth
     Type:     kubedb.com/mysql
-    Version:  8.0.29
+    Version:  8.0.32
 
 Events:
   Type     Reason      Age   From             Message
@@ -244,7 +244,7 @@ kind: MySQL
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-quickstart","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"DoNotTerminate","version":"8.0.29"}}
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"MySQL","metadata":{"annotations":{},"name":"mysql-quickstart","namespace":"demo"},"spec":{"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","terminationPolicy":"DoNotTerminate","version":"8.0.32"}}
   creationTimestamp: "2022-06-03T06:50:40Z"
   finalizers:
   - kubedb.com
@@ -304,7 +304,7 @@ spec:
   storageType: Durable
   terminationPolicy: Delete
   useAddressType: DNS
-  version: 8.0.29
+  version: 8.0.32
 status:
   conditions:
   - lastTransitionTime: "2022-06-03T06:50:40Z"
@@ -365,7 +365,7 @@ root@mysql-quickstart-0:/# mysql -uroot -p"H(Y.s)pg&cX1Ds3J"
 
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 351
-Server version: 8.0.29 MySQL Community Server - GPL
+Server version: 8.0.32 MySQL Community Server - GPL
 
 Copyright (c) 2000, 2022, Oracle and/or its affiliates.
 
@@ -583,7 +583,7 @@ Run the following command to get MySQL resources,
 ```bash
 $ kubectl get my,sts,secret,svc,pvc -n demo
 NAME                                VERSION   STATUS   AGE
-mysql.kubedb.com/mysql-quickstart   8.0.27    Halted   22m
+mysql.kubedb.com/mysql-quickstart   8.0.32    Halted   22m
 
 NAME                           TYPE                                  DATA   AGE
 secret/default-token-lgbjm     kubernetes.io/service-account-token   3      27h

--- a/docs/guides/mysql/quickstart/yamls/quickstart.yaml
+++ b/docs/guides/mysql/quickstart/yamls/quickstart.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/scaling/horizontal-scaling/cluster/index.md
+++ b/docs/guides/mysql/scaling/horizontal-scaling/cluster/index.md
@@ -54,11 +54,11 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion
 NAME            VERSION   DISTRIBUTION   DB_IMAGE                    DEPRECATED   AGE
 5.7.35-v1       5.7.35    Official       mysql:5.7.35                             4d2h
-5.7.36          5.7.36    Official       mysql:5.7.36                             4d2h
+5.7.41          5.7.41    Official       mysql:5.7.41                             4d2h
 8.0.17          8.0.17    Official       mysql:8.0.17                             4d2h
-8.0.27          8.0.27    Official       mysql:8.0.27                             4d2h
-8.0.27-innodb   8.0.27    MySQL          mysql/mysql-server:8.0.27                4d2h
-8.0.29          8.0.29    Official       mysql:8.0.29                             4d2h
+8.0.32          8.0.32    Official       mysql:8.0.32                             4d2h
+8.0.32-innodb   8.0.32    MySQL          mysql/mysql-server:8.0.32                4d2h
+8.0.32          8.0.32    Official       mysql:8.0.32                             4d2h
 8.0.3-v4        8.0.3     Official       mysql:8.0.3                              4d2h
 8.0.31          8.0.31    Official       mysql:8.0.31                             4d2h
 8.0.31-innodb   8.0.31    MySQL          mysql/mysql-server:8.0.31                4d2h

--- a/docs/guides/mysql/scaling/vertical-scaling/cluster/index.md
+++ b/docs/guides/mysql/scaling/vertical-scaling/cluster/index.md
@@ -54,11 +54,11 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion
 NAME            VERSION   DISTRIBUTION   DB_IMAGE                    DEPRECATED   AGE
 5.7.35-v1       5.7.35    Official       mysql:5.7.35                             4d2h
-5.7.36          5.7.36    Official       mysql:5.7.36                             4d2h
+5.7.41          5.7.41    Official       mysql:5.7.41                             4d2h
 8.0.17          8.0.17    Official       mysql:8.0.17                             4d2h
-8.0.27          8.0.27    Official       mysql:8.0.27                             4d2h
-8.0.27-innodb   8.0.27    MySQL          mysql/mysql-server:8.0.27                4d2h
-8.0.29          8.0.29    Official       mysql:8.0.29                             4d2h
+8.0.32          8.0.32    Official       mysql:8.0.32                             4d2h
+8.0.32-innodb   8.0.32    MySQL          mysql/mysql-server:8.0.32                4d2h
+8.0.32          8.0.32    Official       mysql:8.0.32                             4d2h
 8.0.3-v4        8.0.3     Official       mysql:8.0.3                              4d2h
 8.0.31          8.0.31    Official       mysql:8.0.31                             4d2h
 8.0.31-innodb   8.0.31    MySQL          mysql/mysql-server:8.0.31                4d2h

--- a/docs/guides/mysql/scaling/vertical-scaling/cluster/yamls/group-replication.yaml
+++ b/docs/guides/mysql/scaling/vertical-scaling/cluster/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/scaling/vertical-scaling/standalone/index.md
+++ b/docs/guides/mysql/scaling/vertical-scaling/standalone/index.md
@@ -54,17 +54,17 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion
 NAME        VERSION   DB_IMAGE                  DEPRECATED   AGE
 5.7.25-v2   5.7.25    kubedb/mysql:5.7.25-v2                 3h55m
-5.7.36   5.7.29    kubedb/mysql:5.7.36                 3h55m
-5.7.36   5.7.31    kubedb/mysql:5.7.36                 3h55m
-5.7.36   5.7.33    kubedb/mysql:5.7.36                 3h55m
+5.7.41   5.7.29    kubedb/mysql:5.7.41                 3h55m
+5.7.41   5.7.31    kubedb/mysql:5.7.41                 3h55m
+5.7.41   5.7.33    kubedb/mysql:5.7.41                 3h55m
 8.0.14-v2   8.0.14    kubedb/mysql:8.0.14-v2                 3h55m
 8.0.20-v1   8.0.20    kubedb/mysql:8.0.20-v1                 3h55m
-8.0.27   8.0.21    kubedb/mysql:8.0.27                 3h55m
-8.0.27      8.0.27    kubedb/mysql:8.0.27                    3h55m
+8.0.32   8.0.21    kubedb/mysql:8.0.32                 3h55m
+8.0.32      8.0.32    kubedb/mysql:8.0.32                    3h55m
 8.0.3-v2    8.0.3     kubedb/mysql:8.0.3-v2                  3h55m
 ```
 
-The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a standalone using non-deprecated `MySQL`  version `8.0.27`.
+The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a standalone using non-deprecated `MySQL`  version `8.0.32`.
 
 **Deploy MySQL Standalone:**
 
@@ -77,7 +77,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -106,7 +106,7 @@ $ watch -n 3 kubectl get my -n demo my-standalone
 Every 3.0s: kubectl get my -n demo my-standalone                 suaas-appscode: Wed Jul  1 17:48:14 2020
 
 NAME            VERSION      STATUS    AGE
-my-standalone   8.0.27    Running   2m58s
+my-standalone   8.0.32    Running   2m58s
 
 $ watch -n 3 kubectl get sts -n demo my-standalone
 Every 3.0s: kubectl get sts -n demo my-standalone                suaas-appscode: Wed Jul  1 17:48:52 2020

--- a/docs/guides/mysql/scaling/vertical-scaling/standalone/yamls/standalone.yaml
+++ b/docs/guides/mysql/scaling/vertical-scaling/standalone/yamls/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/schema-manager/deploy-mysqldatabase/index.md
+++ b/docs/guides/mysql/schema-manager/deploy-mysqldatabase/index.md
@@ -55,7 +55,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -75,7 +75,7 @@ spec:
 
 Here,
 
-- `spec.version` is the name of the MySQLVersion CR. Here, we are using MySQL version `8.0.29`.
+- `spec.version` is the name of the MySQLVersion CR. Here, we are using MySQL version `8.0.32`.
 - `spec.storageType` specifies the type of storage that will be used for MySQL. It can be `Durable` or `Ephemeral`. The default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create the MySQL using `EmptyDir` volume.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the StatefulSet created by KubeDB operator to run database pods. So, each members will have a pod of this storage configuration. You can specify any StorageClass available in your cluster with appropriate resource requests.
 - `spec.allowedSchemas` specifies the namespace of allowed `Schema Manager`.
@@ -240,7 +240,7 @@ bash-4.4# mysql --user='v-kubernetes-k8s.dc833e-txGUfwPa' --password='bCfsp77bWz
 
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 287
-Server version: 8.0.29 MySQL Community Server - GPL
+Server version: 8.0.32 MySQL Community Server - GPL
 
 
 mysql> SHOW DATABASES;
@@ -308,7 +308,7 @@ bash-4.4# mysql -uroot -p$MYSQL_ROOT_PASSWORD
 
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 2358
-Server version: 8.0.29 MySQL Community Server - GPL
+Server version: 8.0.32 MySQL Community Server - GPL
 
 mysql> SHOW DATABASES;
 +--------------------+
@@ -382,7 +382,7 @@ bash-4.4# mysql -uroot -p$MYSQL_ROOT_PASSWORD
 
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 2358
-Server version: 8.0.29 MySQL Community Server - GPL
+Server version: 8.0.32 MySQL Community Server - GPL
 
 mysql> SHOW DATABASES;
 +--------------------+

--- a/docs/guides/mysql/schema-manager/deploy-mysqldatabase/yamls/mysql-server.yaml
+++ b/docs/guides/mysql/schema-manager/deploy-mysqldatabase/yamls/mysql-server.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/schema-manager/initializing-with-script/index.md
+++ b/docs/guides/mysql/schema-manager/initializing-with-script/index.md
@@ -55,7 +55,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -75,7 +75,7 @@ spec:
 
 Here,
 
-- `spec.version` is the name of the MySQLVersion CR. Here, we are using MySQL version `8.0.29`.
+- `spec.version` is the name of the MySQLVersion CR. Here, we are using MySQL version `8.0.32`.
 - `spec.storageType` specifies the type of storage that will be used for MySQL. It can be `Durable` or `Ephemeral`. The default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create the MySQL using `EmptyDir` volume.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the StatefulSet created by KubeDB operator to run database pods. So, each members will have a pod of this storage configuration. You can specify any StorageClass available in your cluster with appropriate resource requests.
 - `spec.allowedSchemas` specifies the namespace of allowed `Schema Manager`.
@@ -268,7 +268,7 @@ bash-4.4# mysql --user='v-kubernetes-k8s.dc833e-yb9r7uhs' --password='DueiiR-JyG
 
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 287
-Server version: 8.0.29 MySQL Community Server - GPL
+Server version: 8.0.32 MySQL Community Server - GPL
 
 mysql> SHOW DATABASES;
 +--------------------+

--- a/docs/guides/mysql/schema-manager/initializing-with-script/yamls/mysql-server.yaml
+++ b/docs/guides/mysql/schema-manager/initializing-with-script/yamls/mysql-server.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "8.0.29"
+  version: "8.0.32"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/tls/configure/index.md
+++ b/docs/guides/mysql/tls/configure/index.md
@@ -318,7 +318,7 @@ $ watch -n 3 kubectl get my -n demo some-mysql
 Every 3.0s: kubectl get my -n demo some-mysql                 suaas-appscode: Thu Aug 13 19:02:15 2020
 
 NAME           VERSION   STATUS    AGE
-some-mysql   8.0.27    Running   9m41s
+some-mysql   8.0.32    Running   9m41s
 
 $ watch -n 3 kubectl get sts -n demo some-mysql
 Every 3.0s: kubectl get sts -n demo some-mysql                suaas-appscode: Thu Aug 13 19:02:42 2020

--- a/docs/guides/mysql/update-version/majorversion/group-replication/index.md
+++ b/docs/guides/mysql/update-version/majorversion/group-replication/index.md
@@ -54,11 +54,11 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion 
 NAME            VERSION   DISTRIBUTION   DB_IMAGE                    DEPRECATED   AGE
 5.7.35-v1       5.7.35    Official       mysql:5.7.35                             13d
-5.7.36          5.7.36    Official       mysql:5.7.36                             13d
+5.7.41          5.7.41    Official       mysql:5.7.41                             13d
 8.0.17          8.0.17    Official       mysql:8.0.17                             13d
-8.0.27          8.0.27    Official       mysql:8.0.27                             13d
-8.0.27-innodb   8.0.27    MySQL          mysql/mysql-server:8.0.27                13d
-8.0.29          8.0.29    Official       mysql:8.0.29                             13d
+8.0.32          8.0.32    Official       mysql:8.0.32                             13d
+8.0.32-innodb   8.0.32    MySQL          mysql/mysql-server:8.0.32                13d
+8.0.32          8.0.32    Official       mysql:8.0.32                             13d
 8.0.3-v4        8.0.3     Official       mysql:8.0.3                              13d
 
 ```
@@ -67,10 +67,10 @@ The version above that does not show `DEPRECATED` true is supported by `KubeDB` 
 
 **Check update Constraints:**
 
-Database version update constraints is a constraint that shows whether it is possible or not possible to update from one version to another. Let's check the version update constraints of `MySQL` `5.7.36`,
+Database version update constraints is a constraint that shows whether it is possible or not possible to update from one version to another. Let's check the version update constraints of `MySQL` `5.7.41`,
 
 ```bash
-$ kubectl get mysqlversion 5.7.36 -o yaml | kubectl neat
+$ kubectl get mysqlversion 5.7.41 -o yaml | kubectl neat
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion
 metadata:
@@ -85,14 +85,14 @@ metadata:
     app.kubernetes.io/name: kubedb-catalog
     app.kubernetes.io/version: v2022.03.28
     helm.sh/chart: kubedb-catalog-v2022.03.28
-  name: 5.7.36
+  name: 5.7.41
   resourceVersion: "1092465"
   uid: 4cc87fc8-efd7-4e69-bb12-4454a2b1bf06
 spec:
   coordinator:
     image: kubedb/mysql-coordinator:v0.5.0
   db:
-    image: mysql:5.7.36
+    image: mysql:5.7.41
   distribution: Official
   exporter:
     image: kubedb/mysqld-exporter:v0.13.1
@@ -111,14 +111,14 @@ spec:
   updateConstraints:
     denylist:
       groupReplication:
-      - < 5.7.36
+      - < 5.7.41
       standalone:
-      - < 5.7.36
-  version: 5.7.36
+      - < 5.7.41
+  version: 5.7.41
 
 ```
 
-The above `spec.updateConstraints.denylist` of `5.7.36` is showing that updating below version of `5.7.36` is not possible for both group replication and standalone. That means, it is possible to update any version above `5.7.36`. Here, we are going to create a `MySQL` Group Replication using MySQL  `5.7.36`. Then we are going to update this version to `8.0.29`.
+The above `spec.updateConstraints.denylist` of `5.7.41` is showing that updating below version of `5.7.41` is not possible for both group replication and standalone. That means, it is possible to update any version above `5.7.41`. Here, we are going to create a `MySQL` Group Replication using MySQL  `5.7.41`. Then we are going to update this version to `8.0.32`.
 
 **Deploy MySQL Group Replication:**
 
@@ -131,7 +131,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -162,7 +162,7 @@ Now, watch `MySQL` is going to  `Running` state and also watch `StatefulSet` and
 $ watch -n 3 kubectl get my -n demo my-group
 
 NAME       VERSION      STATUS    AGE
-my-group   5.7.36    Running   5m52s
+my-group   5.7.41    Running   5m52s
 
 $ watch -n 3 kubectl get sts -n demo my-group
 
@@ -181,15 +181,15 @@ Let's verify the `MySQL`, the `StatefulSet` and its `Pod` image version,
 
 ```bash
 $ kubectl get my -n demo my-group -o=jsonpath='{.spec.version}{"\n"}'
-5.7.36
+5.7.41
 
 $ kubectl get sts -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
-"kubedb/mysql:5.7.36"
+"kubedb/mysql:5.7.41"
 
 $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.containers[1].image'
-"kubedb/mysql:5.7.36"
-"kubedb/mysql:5.7.36"
-"kubedb/mysql:5.7.36"
+"kubedb/mysql:5.7.41"
+"kubedb/mysql:5.7.41"
+"kubedb/mysql:5.7.41"
 ```
 
 Let's also verify that the StatefulSet’s pods have joined into a group replication,
@@ -217,7 +217,7 @@ We are ready to apply updating on this `MySQL` group replication.
 
 #### UpdateVesion
 
-Here, we are going to update the `MySQL` group replication from `5.7.36` to `8.0.29`.
+Here, we are going to update the `MySQL` group replication from `5.7.41` to `8.0.32`.
 
 **Create MySQLOpsRequest:**
 
@@ -234,14 +234,14 @@ spec:
   databaseRef:
     name: my-group
   updateVersion:
-    targetVersion: "8.0.29"
+    targetVersion: "8.0.32"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies expected version `8.0.29` after updating.
+- `spec.updateVersion.targetVersion` specifies expected version `8.0.32` after updating.
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 
@@ -291,7 +291,7 @@ Spec:
     Name:  my-group
   Type:    UpdateVersion
   UpdateVersion:
-    Target Version:  8.0.29
+    Target Version:  8.0.32
 Status:
   Conditions:
     Last Transition Time:  2022-06-30T07:55:16Z
@@ -340,15 +340,15 @@ Now, we are going to verify whether the `MySQL` and `StatefulSet` and it's `Pod`
 
 ```bash
 $ kubectl get my -n demo my-group -o=jsonpath='{.spec.version}{"\n"}'
-8.0.27
+8.0.32
 
 $ kubectl get sts -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
-"kubedb/mysql:8.0.29"
+"kubedb/mysql:8.0.32"
 
 $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.containers[1].image'
-"kubedb/mysql:8.0.29"
-"kubedb/mysql:8.0.29"
-"kubedb/mysql:8.0.29"
+"kubedb/mysql:8.0.32"
+"kubedb/mysql:8.0.32"
+"kubedb/mysql:8.0.32"
 ```
 
 Let's also check the StatefulSet pods have joined the `MySQL` group replication,
@@ -365,9 +365,9 @@ mysql: [Warning] Using a password on the command line interface can be insecure.
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
 | CHANNEL_NAME              | MEMBER_ID                            | MEMBER_HOST                       | MEMBER_PORT | MEMBER_STATE | MEMBER_ROLE | MEMBER_VERSION | MEMBER_COMMUNICATION_STACK |
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
-| group_replication_applier | b0e71e0c-f849-11ec-a315-46392c50e39c | my-group-1.my-group-pods.demo.svc |        3306 | ONLINE       | PRIMARY     | 8.0.29         | XCom                       |
-| group_replication_applier | b34b16d7-f849-11ec-9362-a2f432876ee4 | my-group-2.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.29         | XCom                       |
-| group_replication_applier | b5542a4a-f849-11ec-9a75-3e8abd17fee6 | my-group-0.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.29         | XCom                       |
+| group_replication_applier | b0e71e0c-f849-11ec-a315-46392c50e39c | my-group-1.my-group-pods.demo.svc |        3306 | ONLINE       | PRIMARY     | 8.0.32         | XCom                       |
+| group_replication_applier | b34b16d7-f849-11ec-9362-a2f432876ee4 | my-group-2.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.32         | XCom                       |
+| group_replication_applier | b5542a4a-f849-11ec-9a75-3e8abd17fee6 | my-group-0.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.32         | XCom                       |
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
 
 ```

--- a/docs/guides/mysql/update-version/majorversion/group-replication/yamls/group_replication.yaml
+++ b/docs/guides/mysql/update-version/majorversion/group-replication/yamls/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/update-version/majorversion/group-replication/yamls/upgrade_major_version_group.yaml
+++ b/docs/guides/mysql/update-version/majorversion/group-replication/yamls/upgrade_major_version_group.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: my-group
   updateVersion:
-    targetVersion: "8.0.29"
+    targetVersion: "8.0.32"

--- a/docs/guides/mysql/update-version/majorversion/standalone/index.md
+++ b/docs/guides/mysql/update-version/majorversion/standalone/index.md
@@ -54,11 +54,11 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion
 NAME            VERSION   DISTRIBUTION   DB_IMAGE                    DEPRECATED   AGE
 5.7.35-v1       5.7.35    Official       mysql:5.7.35                             13d
-5.7.36          5.7.36    Official       mysql:5.7.36                             13d
+5.7.41          5.7.41    Official       mysql:5.7.41                             13d
 8.0.17          8.0.17    Official       mysql:8.0.17                             13d
-8.0.27          8.0.27    Official       mysql:8.0.27                             13d
-8.0.27-innodb   8.0.27    MySQL          mysql/mysql-server:8.0.27                13d
-8.0.29          8.0.29    Official       mysql:8.0.29                             13d
+8.0.32          8.0.32    Official       mysql:8.0.32                             13d
+8.0.32-innodb   8.0.32    MySQL          mysql/mysql-server:8.0.32                13d
+8.0.32          8.0.32    Official       mysql:8.0.32                             13d
 8.0.3-v4        8.0.3     Official       mysql:8.0.3                              13d
 ```
 
@@ -66,10 +66,10 @@ The version above that does not show `DEPRECATED` `true` is supported by `KubeDB
 
 **Check update Constraints:**
 
-Database version update constraints is a constraint that shows whether it is possible or not possible to update from one version to another. Let's check the version update constraints of `MySQL` `5.7.36`,
+Database version update constraints is a constraint that shows whether it is possible or not possible to update from one version to another. Let's check the version update constraints of `MySQL` `5.7.41`,
 
 ```bash
-$ kubectl get mysqlversion 5.7.36 -o yaml | kubectl neat
+$ kubectl get mysqlversion 5.7.41 -o yaml | kubectl neat
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion
 metadata:
@@ -84,14 +84,14 @@ metadata:
     app.kubernetes.io/name: kubedb-catalog
     app.kubernetes.io/version: v2022.03.28
     helm.sh/chart: kubedb-catalog-v2022.03.28
-  name: 5.7.36
+  name: 5.7.41
   resourceVersion: "1092465"
   uid: 4cc87fc8-efd7-4e69-bb12-4454a2b1bf06
 spec:
   coordinator:
     image: kubedb/mysql-coordinator:v0.5.0
   db:
-    image: mysql:5.7.36
+    image: mysql:5.7.41
   distribution: Official
   exporter:
     image: kubedb/mysqld-exporter:v0.13.1
@@ -110,14 +110,14 @@ spec:
   updateConstraints:
     denylist:
       groupReplication:
-      - < 5.7.36
+      - < 5.7.41
       standalone:
-      - < 5.7.36
-  version: 5.7.36
+      - < 5.7.41
+  version: 5.7.41
 
 ```
 
-The above `spec.updateConstraints.denylist` is showing that updating below version of `5.7.36` is not possible for both standalone and group replication. That means, it is possible to update any version above `5.7.36`. Here, we are going to create a `MySQL` standalone using MySQL  `5.7.36`. Then we are going to update this version to `8.0.29`.
+The above `spec.updateConstraints.denylist` is showing that updating below version of `5.7.41` is not possible for both standalone and group replication. That means, it is possible to update any version above `5.7.41`. Here, we are going to create a `MySQL` standalone using MySQL  `5.7.41`. Then we are going to update this version to `8.0.32`.
 
 **Deploy MySQL standalone:**
 
@@ -130,7 +130,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -158,7 +158,7 @@ Now, watch `MySQL` is going to  `Running` state and also watch `StatefulSet` and
 $ watch -n 3 kubectl get my -n demo my-standalone
 
 NAME            VERSION      STATUS    AGE
-my-standalone   5.7.36    Running   3m
+my-standalone   5.7.41    Running   3m
 
 $ watch -n 3 kubectl get sts -n demo my-standalone
 
@@ -175,20 +175,20 @@ Let's verify the `MySQL`, the `StatefulSet` and its `Pod` image version,
 
 ```bash
 $ kubectl get my -n demo my-standalone -o=jsonpath='{.spec.version}{"\n"}'
-5.7.36
+5.7.41
 
 $ kubectl get sts -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-kubedb/my:5.7.36
+kubedb/my:5.7.41
 
 $ kubectl get pod -n demo my-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-kubedb/my:5.7.36
+kubedb/my:5.7.41
 ```
 
 We are ready to apply updating on this `MySQL` standalone.
 
 #### UpdateVersion
 
-Here, we are going to update `MySQL` standalone from `5.7.36` to `8.0.29`.
+Here, we are going to update `MySQL` standalone from `5.7.41` to `8.0.32`.
 
 **Create MySQLOpsRequest:**
 
@@ -205,14 +205,14 @@ spec:
     name: my-standalone
   type: UpdateVersion
   updateVersion:
-    targetVersion: "8.0.29"
+    targetVersion: "8.0.32"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies expected version `8.0.29` after updating.
+- `spec.updateVersion.targetVersion` specifies expected version `8.0.32` after updating.
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 
@@ -256,7 +256,7 @@ Spec:
     Name:  my-standalone
   Type:    UpdateVersion
   UpdateVersion:
-    TargetVersion:  8.0.29
+    TargetVersion:  8.0.32
 Status:
   Conditions:
     Last Transition Time:  2022-06-30T07:55:16Z
@@ -302,13 +302,13 @@ Now, we are going to verify whether the `MySQL`, `StatefulSet` and it's `Pod` ha
 
 ```bash
 $ kubectl get my -n demo my-standalone -o=jsonpath='{.spec.version}{"\n"}'
-8.0.29
+8.0.32
 
 $ kubectl get sts -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-mysql:8.0.29
+mysql:8.0.32
 
 $ kubectl get pod -n demo my-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-mysql:8.0.29
+mysql:8.0.32
 ```
 
 You can see above that our `MySQL`standalone has been updated with the new version. It verifies that we have successfully updated our standalone.

--- a/docs/guides/mysql/update-version/majorversion/standalone/yamls/standalone.yaml
+++ b/docs/guides/mysql/update-version/majorversion/standalone/yamls/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/update-version/majorversion/standalone/yamls/upgrade_major_version_standalone.yaml
+++ b/docs/guides/mysql/update-version/majorversion/standalone/yamls/upgrade_major_version_standalone.yaml
@@ -8,4 +8,4 @@ spec:
     name: my-standalone
   type: UpdateVersion
   updateVersion:
-    targetVersion: "8.0.29"
+    targetVersion: "8.0.32"

--- a/docs/guides/mysql/update-version/minorversion/group-replication/index.md
+++ b/docs/guides/mysql/update-version/minorversion/group-replication/index.md
@@ -54,11 +54,11 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion
 NAME            VERSION   DISTRIBUTION   DB_IMAGE                    DEPRECATED   AGE
 5.7.35-v1       5.7.35    Official       mysql:5.7.35                             13d
-5.7.36          5.7.36    Official       mysql:5.7.36                             13d
+5.7.41          5.7.41    Official       mysql:5.7.41                             13d
 8.0.17          8.0.17    Official       mysql:8.0.17                             13d
-8.0.27          8.0.27    Official       mysql:8.0.27                             13d
-8.0.27-innodb   8.0.27    MySQL          mysql/mysql-server:8.0.27                13d
-8.0.29          8.0.29    Official       mysql:8.0.29                             13d
+8.0.32          8.0.32    Official       mysql:8.0.32                             13d
+8.0.32-innodb   8.0.32    MySQL          mysql/mysql-server:8.0.32                13d
+8.0.32          8.0.32    Official       mysql:8.0.32                             13d
 8.0.3-v4        8.0.3     Official       mysql:8.0.3                              13d
 
 ```
@@ -67,10 +67,10 @@ The version above that does not show `DEPRECATED` true is supported by `KubeDB` 
 
 **Check update Constraints:**
 
-Database version update constraints is a constraint that shows whether it is possible or not possible to update from one version to another. Let's check the version update constraints of `MySQL` `8.0.27`,
+Database version update constraints is a constraint that shows whether it is possible or not possible to update from one version to another. Let's check the version update constraints of `MySQL` `8.0.32`,
 
 ```bash
-$ kubectl get mysqlversion 8.0.27 -o yaml
+$ kubectl get mysqlversion 8.0.32 -o yaml
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion
 metadata:
@@ -85,14 +85,14 @@ metadata:
     app.kubernetes.io/name: kubedb-catalog
     app.kubernetes.io/version: v2022.03.28
     helm.sh/chart: kubedb-catalog-v2022.03.28
-  name: 8.0.27
+  name: 8.0.32
   resourceVersion: "1092466"
   uid: fa68b792-a8b3-47a3-a32e-66a47f79c177
 spec:
   coordinator:
     image: kubedb/mysql-coordinator:v0.5.0
   db:
-    image: mysql:8.0.27
+    image: mysql:8.0.32
   distribution: Official
   exporter:
     image: kubedb/mysqld-exporter:v0.13.1
@@ -111,14 +111,14 @@ spec:
   updateConstraints:
     denylist:
       groupReplication:
-      - < 8.0.27
+      - < 8.0.32
       standalone:
-      - < 8.0.27
-  version: 8.0.27
+      - < 8.0.32
+  version: 8.0.32
 
 ```
 
-The above `spec.updateConstraints.denylist` of `8.0.27` is showing that updating below version of `8.0.27` is not possible for both group replication and standalone. That means, it is possible to update any version above `8.0.27`. Here, we are going to create a `MySQL` Group Replication using MySQL  `8.0.27`. Then we are going to update this version to `8.0.29`.
+The above `spec.updateConstraints.denylist` of `8.0.32` is showing that updating below version of `8.0.32` is not possible for both group replication and standalone. That means, it is possible to update any version above `8.0.32`. Here, we are going to create a `MySQL` Group Replication using MySQL  `8.0.32`. Then we are going to update this version to `8.0.32`.
 
 **Deploy MySQL Group Replication:**
 
@@ -131,7 +131,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -165,7 +165,7 @@ $ watch -n 3 kubectl get my -n demo my-group
 
 
 NAME       VERSION   STATUS         AGE
-my-group   8.0.27    Ready          5m
+my-group   8.0.32    Ready          5m
 
 $ watch -n 3 kubectl get sts -n demo my-group
 
@@ -184,15 +184,15 @@ Let's verify the `MySQL`, the `StatefulSet` and its `Pod` image version,
 
 ```bash
 $ kubectl get my -n demo my-group -o=jsonpath='{.spec.version}{"\n"}'
-8.0.27
+8.0.32
 
 $ kubectl get sts -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
-"mysql:8.0.27"
+"mysql:8.0.32"
 
 $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.containers[1].image'
-"mysql:8.0.27"
-"mysql:8.0.27"
-"mysql:8.0.27"
+"mysql:8.0.32"
+"mysql:8.0.32"
+"mysql:8.0.32"
 ```
 
 Let's also verify that the StatefulSet’s pods have joined into the group replication,
@@ -209,9 +209,9 @@ mysql: [Warning] Using a password on the command line interface can be insecure.
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
 | CHANNEL_NAME              | MEMBER_ID                            | MEMBER_HOST                       | MEMBER_PORT | MEMBER_STATE | MEMBER_ROLE | MEMBER_VERSION | MEMBER_COMMUNICATION_STACK |
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
-| group_replication_applier | 6e7f3cc4-f84d-11ec-adcd-d23a2a3ef58a | my-group-1.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.27         | XCom                       |
-| group_replication_applier | 70c60c5b-f84d-11ec-821b-4af781e22a9f | my-group-2.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.27         | XCom                       |
-| group_replication_applier | 71fdc498-f84d-11ec-a6f3-b2ee89425e4f | my-group-0.my-group-pods.demo.svc |        3306 | ONLINE       | PRIMARY     | 8.0.27         | XCom                       |
+| group_replication_applier | 6e7f3cc4-f84d-11ec-adcd-d23a2a3ef58a | my-group-1.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.32         | XCom                       |
+| group_replication_applier | 70c60c5b-f84d-11ec-821b-4af781e22a9f | my-group-2.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.32         | XCom                       |
+| group_replication_applier | 71fdc498-f84d-11ec-a6f3-b2ee89425e4f | my-group-0.my-group-pods.demo.svc |        3306 | ONLINE       | PRIMARY     | 8.0.32         | XCom                       |
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
 
 ```
@@ -220,7 +220,7 @@ We are ready to apply updating on this `MySQL` group replication.
 
 #### UpdateVersion
 
-Here, we are going to update the `MySQL` group replication from `8.0.27` to `8.0.29`.
+Here, we are going to update the `MySQL` group replication from `8.0.32` to `8.0.32`.
 
 **Create MySQLOpsRequest:**
 
@@ -237,14 +237,14 @@ spec:
   databaseRef:
     name: my-group
   updateVersion:
-    targetVersion: "8.0.29"
+    targetVersion: "8.0.32"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies expected version `8.0.29` after updating.
+- `spec.updateVersion.targetVersion` specifies expected version `8.0.32` after updating.
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 
@@ -288,7 +288,7 @@ Spec:
     Name:  my-group
   Type:    UpdateVersion
   UpdateVersion:
-    TargetVersion:  8.0.29
+    TargetVersion:  8.0.32
 Status:
   Conditions:
     Last Transition Time:  2022-06-30T08:26:36Z
@@ -339,15 +339,15 @@ Now, we are going to verify whether the `MySQL` and `StatefulSet` and it's `Pod`
 
 ```bash
 $ kubectl get my -n demo my-group -o=jsonpath='{.spec.version}{"\n"}'
-5.7.36
+5.7.41
 
 $ kubectl get sts -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
-"mysql:8.0.29"
+"mysql:8.0.32"
 
 $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.containers[1].image'
-"mysql:8.0.29"
-"mysql:8.0.29"
-"mysql:8.0.29"
+"mysql:8.0.32"
+"mysql:8.0.32"
+"mysql:8.0.32"
 ```
 
 Let's also check the StatefulSet pods have joined the `MySQL` group replication,
@@ -364,9 +364,9 @@ mysql: [Warning] Using a password on the command line interface can be insecure.
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
 | CHANNEL_NAME              | MEMBER_ID                            | MEMBER_HOST                       | MEMBER_PORT | MEMBER_STATE | MEMBER_ROLE | MEMBER_VERSION | MEMBER_COMMUNICATION_STACK |
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
-| group_replication_applier | 6e7f3cc4-f84d-11ec-adcd-d23a2a3ef58a | my-group-1.my-group-pods.demo.svc |        3306 | ONLINE       | PRIMARY     | 8.0.29         | XCom                       |
-| group_replication_applier | 70c60c5b-f84d-11ec-821b-4af781e22a9f | my-group-2.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.29         | XCom                       |
-| group_replication_applier | 71fdc498-f84d-11ec-a6f3-b2ee89425e4f | my-group-0.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.29         | XCom                       |
+| group_replication_applier | 6e7f3cc4-f84d-11ec-adcd-d23a2a3ef58a | my-group-1.my-group-pods.demo.svc |        3306 | ONLINE       | PRIMARY     | 8.0.32         | XCom                       |
+| group_replication_applier | 70c60c5b-f84d-11ec-821b-4af781e22a9f | my-group-2.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.32         | XCom                       |
+| group_replication_applier | 71fdc498-f84d-11ec-a6f3-b2ee89425e4f | my-group-0.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.32         | XCom                       |
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
 
 ```

--- a/docs/guides/mysql/update-version/minorversion/group-replication/yamls/group_replication.yaml
+++ b/docs/guides/mysql/update-version/minorversion/group-replication/yamls/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.27"
+  version: "8.0.32"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/update-version/minorversion/group-replication/yamls/upgrade_minor_version_group.yaml
+++ b/docs/guides/mysql/update-version/minorversion/group-replication/yamls/upgrade_minor_version_group.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: my-group
   updateVersion:
-    targetVersion: "8.0.29"
+    targetVersion: "8.0.32"

--- a/docs/guides/mysql/update-version/minorversion/standalone/index.md
+++ b/docs/guides/mysql/update-version/minorversion/standalone/index.md
@@ -54,11 +54,11 @@ When you have installed `KubeDB`, it has created `MySQLVersion` CR for all suppo
 $ kubectl get mysqlversion
 NAME            VERSION   DISTRIBUTION   DB_IMAGE                    DEPRECATED   AGE
 5.7.35-v1       5.7.35    Official       mysql:5.7.35                             13d
-5.7.36          5.7.36    Official       mysql:5.7.36                             13d
+5.7.41          5.7.41    Official       mysql:5.7.41                             13d
 8.0.17          8.0.17    Official       mysql:8.0.17                             13d
-8.0.27          8.0.27    Official       mysql:8.0.27                             13d
-8.0.27-innodb   8.0.27    MySQL          mysql/mysql-server:8.0.27                13d
-8.0.29          8.0.29    Official       mysql:8.0.29                             13d
+8.0.32          8.0.32    Official       mysql:8.0.32                             13d
+8.0.32-innodb   8.0.32    MySQL          mysql/mysql-server:8.0.32                13d
+8.0.32          8.0.32    Official       mysql:8.0.32                             13d
 8.0.3-v4        8.0.3     Official       mysql:8.0.3                              13d
 
 ```
@@ -67,10 +67,10 @@ The version above that does not show `DEPRECATED` `true` is supported by `KubeDB
 
 **Check update Constraints:**
 
-Database version update constraints is a constraint that shows whether it is possible or not possible to update from one version to another. Let's check the version update constraints of `MySQL` `5.7.36`,
+Database version update constraints is a constraint that shows whether it is possible or not possible to update from one version to another. Let's check the version update constraints of `MySQL` `5.7.41`,
 
 ```bash
-$ kubectl get mysqlversion 5.7.36 -o yaml
+$ kubectl get mysqlversion 5.7.41 -o yaml
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion
 metadata:
@@ -85,14 +85,14 @@ metadata:
     app.kubernetes.io/name: kubedb-catalog
     app.kubernetes.io/version: v2022.03.28
     helm.sh/chart: kubedb-catalog-v2022.03.28
-  name: 5.7.36
+  name: 5.7.41
   resourceVersion: "1092465"
   uid: 4cc87fc8-efd7-4e69-bb12-4454a2b1bf06
 spec:
   coordinator:
     image: kubedb/mysql-coordinator:v0.5.0
   db:
-    image: mysql:5.7.36
+    image: mysql:5.7.41
   distribution: Official
   exporter:
     image: kubedb/mysqld-exporter:v0.13.1
@@ -111,14 +111,14 @@ spec:
   updateConstraints:
     denylist:
       groupReplication:
-      - < 5.7.36
+      - < 5.7.41
       standalone:
-      - < 5.7.36
-  version: 5.7.36
+      - < 5.7.41
+  version: 5.7.41
 
 ```
 
-The above `spec.updateConstraints.denylist` is showing that updating below version of `5.7.36` is not possible for both standalone and group replication. That means, it is possible to update any version above `5.7.36`. Here, we are going to create a `MySQL` standalone using MySQL  `5.7.36`. Then we are going to update this version to `5.7.36`.
+The above `spec.updateConstraints.denylist` is showing that updating below version of `5.7.41` is not possible for both standalone and group replication. That means, it is possible to update any version above `5.7.41`. Here, we are going to create a `MySQL` standalone using MySQL  `5.7.41`. Then we are going to update this version to `5.7.41`.
 
 **Deploy MySQL standalone:**
 
@@ -131,7 +131,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -159,7 +159,7 @@ Now, watch `MySQL` is going to  `Running` state and also watch `StatefulSet` and
 $ watch -n 3 kubectl get my -n demo my-standalone
 
 NAME            VERSION      STATUS    AGE
-my-standalone   5.7.36    Running   3m
+my-standalone   5.7.41    Running   3m
 
 $ watch -n 3 kubectl get sts -n demo my-standalone
 
@@ -176,20 +176,20 @@ Let's verify the `MySQL`, the `StatefulSet` and its `Pod` image version,
 
 ```bash
 $ kubectl get my -n demo my-standalone -o=jsonpath='{.spec.version}{"\n"}'
-5.7.36
+5.7.41
 
 $ kubectl get sts -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-mysql:5.7.36
+mysql:5.7.41
 
 $ kubectl get pod -n demo my-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-mysql:5.7.36
+mysql:5.7.41
 ```
 
 We are ready to apply updating on this `MySQL` standalone.
 
 #### UpdateVersion
 
-Here, we are going to update `MySQL` standalone from `5.7.36` to `5.7.36`.
+Here, we are going to update `MySQL` standalone from `5.7.41` to `5.7.41`.
 
 **Create MySQLOpsRequest:**
 
@@ -206,14 +206,14 @@ spec:
     name: my-standalone
   type: UpdateVersion
   updateVersion:
-    targetVersion: "5.7.36"
+    targetVersion: "5.7.41"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies expected version `5.7.36` after updating.
+- `spec.updateVersion.targetVersion` specifies expected version `5.7.41` after updating.
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 
@@ -256,7 +256,7 @@ Spec:
     Name:  my-standalone
   Type:    UpdateVersion
   UpdateVersion:
-    TargetVersion:  5.7.36
+    TargetVersion:  5.7.41
 Status:
   Conditions:
     Last Transition Time:  2022-06-30T09:05:14Z
@@ -303,13 +303,13 @@ Now, we are going to verify whether the `MySQL`, `StatefulSet` and it's `Pod` ha
 
 ```bash
 $ kubectl get my -n demo my-standalone -o=jsonpath='{.spec.version}{"\n"}'
-5.7.36
+5.7.41
 
 $ kubectl get sts -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-kubedb/my:5.7.36
+kubedb/my:5.7.41
 
 $ kubectl get pod -n demo my-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-kubedb/my:5.7.36
+kubedb/my:5.7.41
 ```
 
 You can see above that our `MySQL`standalone has been updated with the new version. It verifies that we have successfully updated our standalone.

--- a/docs/guides/mysql/update-version/minorversion/standalone/yamls/standalone.yaml
+++ b/docs/guides/mysql/update-version/minorversion/standalone/yamls/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/update-version/minorversion/standalone/yamls/upgrade_minor_version_standalone.yaml
+++ b/docs/guides/mysql/update-version/minorversion/standalone/yamls/upgrade_minor_version_standalone.yaml
@@ -8,4 +8,4 @@ spec:
     name: my-standalone
   type: UpdateVersion
   updateVersion:
-    targetVersion: "5.7.36"
+    targetVersion: "5.7.41"

--- a/docs/guides/percona-xtradb/update-version/cluster/index.md
+++ b/docs/guides/percona-xtradb/update-version/cluster/index.md
@@ -39,7 +39,7 @@ namespace/demo created
 
 ## Prepare PerconaXtraDB Cluster
 
-Now, we are going to deploy a `PerconaXtraDB` cluster database with version `10.4.17`.
+Now, we are going to deploy a `PerconaXtraDB` cluster database with version `10.4.32`.
 
 ### Deploy PerconaXtraDB cluster
 

--- a/docs/guides/postgres/concepts/opsrequest.md
+++ b/docs/guides/postgres/concepts/opsrequest.md
@@ -39,7 +39,7 @@ spec:
     name: pg-group
   type: UpdateVersion
   updateVersion:
-    targetVersion: 8.0.27
+    targetVersion: 8.0.32
 status:
   conditions:
   - lastTransitionTime: "2020-06-11T09:59:05Z"

--- a/docs/guides/proxysql/autoscaler/compute/cluster/examples/sample-mysql.yaml
+++ b/docs/guides/proxysql/autoscaler/compute/cluster/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/autoscaler/compute/cluster/index.md
+++ b/docs/guides/proxysql/autoscaler/compute/cluster/index.md
@@ -49,7 +49,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -74,7 +74,7 @@ Let's wait for the MySQL to be Ready.
 ```bash
 $ kubectl get mysql -n demo 
 NAME           VERSION   STATUS   AGE
-mysql-server   5.7.36    Ready    3m51s
+mysql-server   5.7.41    Ready    3m51s
 ```
 
 ## Autoscaling of ProxySQL Cluster

--- a/docs/guides/proxysql/clustering/proxysql-cluster/examples/sample-mysql.yaml
+++ b/docs/guides/proxysql/clustering/proxysql-cluster/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/clustering/proxysql-cluster/index.md
+++ b/docs/guides/proxysql/clustering/proxysql-cluster/index.md
@@ -46,7 +46,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -71,7 +71,7 @@ Let's wait for the MySQL to be Ready.
 ```bash
 $ kubectl get mysql -n demo 
 NAME           VERSION   STATUS   AGE
-mysql-server   5.7.36    Ready    3m51s
+mysql-server   5.7.41    Ready    3m51s
 ```
 
 Let's first create an user in the backend mysql server and a database to test test the proxy traffic . 
@@ -83,7 +83,7 @@ root@mysql-server-0:/# mysql -uroot -p$MYSQL_ROOT_PASSWORD
 mysql: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 195
-Server version: 5.7.36-log MySQL Community Server (GPL)
+Server version: 5.7.41-log MySQL Community Server (GPL)
 
 Copyright (c) 2000, 2021, Oracle and/or its affiliates.
 
@@ -174,7 +174,7 @@ $ kubectl exec -it -n demo proxy-server-0 -- bash
 root@proxy-server-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032 --prompt "ProxySQLAdmin > "
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 316
-Server version: 8.0.27 (ProxySQL Admin Module)
+Server version: 8.0.32 (ProxySQL Admin Module)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -199,7 +199,7 @@ $ kubectl exec -it -n demo proxy-server-1 -- bash
 root@proxy-server-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032 --prompt "ProxySQLAdmin >"
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 316
-Server version: 8.0.27 (ProxySQL Admin Module)
+Server version: 8.0.32 (ProxySQL Admin Module)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -225,7 +225,7 @@ $ kubectl exec -it -n demo proxy-server-2 -- bash
 root@proxy-server-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032 --prompt "ProxySQLAdmin >"
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 316
-Server version: 8.0.27 (ProxySQL Admin Module)
+Server version: 8.0.32 (ProxySQL Admin Module)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -256,7 +256,7 @@ $ kubectl exec -it -n demo proxy-server-1 -- bash
 root@proxy-server-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032 --prompt "ProxySQLAdmin >"
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 316
-Server version: 8.0.27 (ProxySQL Admin Module)
+Server version: 8.0.32 (ProxySQL Admin Module)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -320,7 +320,7 @@ $ kubectl exec -it -n demo proxy-server-1 -- bash
 root@proxy-server-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032 --prompt "ProxySQLAdmin >"
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 316
-Server version: 8.0.27 (ProxySQL Admin Module)
+Server version: 8.0.32 (ProxySQL Admin Module)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 

--- a/docs/guides/proxysql/concepts/appbinding/index.md
+++ b/docs/guides/proxysql/concepts/appbinding/index.md
@@ -49,7 +49,7 @@ spec:
   secret:
     name: sample-mariadb-auth
   type: kubedb.com/mariadb
-  version: 10.5.8
+  version: 10.5.23
 ```
 
 Here, we are going to describe the sections of an `AppBinding` crd.

--- a/docs/guides/proxysql/concepts/declarative-configuration/index.md
+++ b/docs/guides/proxysql/concepts/declarative-configuration/index.md
@@ -99,7 +99,7 @@ spec:
             default_schema: "information_schema"
             commands_stats: "true"
             sessions_sort: "true"
-            server_version: "8.0.27"
+            server_version: "8.0.32"
             monitor_history: 60000
             ping_timeout_server: 200
             default_query_timeout: 36000000
@@ -178,7 +178,7 @@ spec:
       default_schema: "information_schema"
       commands_stats: "true"
       sessions_sort: "true"
-      server_version: "8.0.27"
+      server_version: "8.0.32"
       monitor_history: 60000
       ping_timeout_server: 200
       default_query_timeout: 36000000

--- a/docs/guides/proxysql/monitoring/builtin-prometheus/examples/mysql.yaml
+++ b/docs/guides/proxysql/monitoring/builtin-prometheus/examples/mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-grp
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/monitoring/builtin-prometheus/index.md
+++ b/docs/guides/proxysql/monitoring/builtin-prometheus/index.md
@@ -49,7 +49,7 @@ metadata:
   name: mysql-grp
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/monitoring/prometheus-operator/examples/mysql.yaml
+++ b/docs/guides/proxysql/monitoring/prometheus-operator/examples/mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-grp
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/monitoring/prometheus-operator/index.md
+++ b/docs/guides/proxysql/monitoring/prometheus-operator/index.md
@@ -111,7 +111,7 @@ metadata:
   name: mysql-grp
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/quickstart/mysqlgrp/examples/appbinding.yaml
+++ b/docs/guides/proxysql/quickstart/mysqlgrp/examples/appbinding.yaml
@@ -17,4 +17,4 @@ spec:
   tlsSecret:
     name: mysql-server-client-cert 
   type: mysql
-  version: 8.0.27
+  version: 8.0.32

--- a/docs/guides/proxysql/quickstart/mysqlgrp/examples/sample-mysql.yaml
+++ b/docs/guides/proxysql/quickstart/mysqlgrp/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/quickstart/mysqlgrp/index.md
+++ b/docs/guides/proxysql/quickstart/mysqlgrp/index.md
@@ -45,7 +45,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -70,7 +70,7 @@ Let's wait for the MySQL to be Ready.
 ```bash
 $ kubectl get mysql -n demo 
 NAME           VERSION   STATUS   AGE
-mysql-server   5.7.36    Ready    3m51s
+mysql-server   5.7.41    Ready    3m51s
 ```
 
 Let's first create a user in the backend mysql server and a database to test the proxy traffic .
@@ -82,7 +82,7 @@ root@mysql-server-0:/# mysql -uroot -p$MYSQL_ROOT_PASSWORD
 mysql: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 195
-Server version: 5.7.36-log MySQL Community Server (GPL)
+Server version: 5.7.41-log MySQL Community Server (GPL)
 
 Copyright (c) 2000, 2021, Oracle and/or its affiliates.
 
@@ -186,7 +186,7 @@ $ kubectl exec -it -n demo proxy-mysql-0 -- bash                                
 root@proxy-mysql-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032 --prompt="ProxySQLAdmin > " 
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 1204
-Server version: 8.0.27 (ProxySQL Admin Module)
+Server version: 8.0.32 (ProxySQL Admin Module)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -284,7 +284,7 @@ root@ubuntu-867d4588d8-tl7hh:/# mysql -utest -ppass -hproxy-server.demo.svc -P60
 mysql: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 1881
-Server version: 8.0.27 (ProxySQL)
+Server version: 8.0.32 (ProxySQL)
 
 Copyright (c) 2000, 2022, Oracle and/or its affiliates.
 

--- a/docs/guides/proxysql/quickstart/xtradbext/index.md
+++ b/docs/guides/proxysql/quickstart/xtradbext/index.md
@@ -333,7 +333,7 @@ $ kubectl exec -it -n demo proxy-mysql-0 -- bash                                
 root@proxy-mysql-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032 --prompt="ProxySQLAdmin > " 
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 1204
-Server version: 8.0.27 (ProxySQL Admin Module)
+Server version: 8.0.32 (ProxySQL Admin Module)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -430,7 +430,7 @@ root@ubuntu-867d4588d8-tl7hh:/# mysql -utest -ppass -hproxy-server.demo.svc -P60
 mysql: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 1881
-Server version: 8.0.27 (ProxySQL)
+Server version: 8.0.32 (ProxySQL)
 
 Copyright (c) 2000, 2022, Oracle and/or its affiliates.
 

--- a/docs/guides/proxysql/reconfigure-tls/cluster/examples/sample-mysql.yaml
+++ b/docs/guides/proxysql/reconfigure-tls/cluster/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/reconfigure-tls/cluster/index.md
+++ b/docs/guides/proxysql/reconfigure-tls/cluster/index.md
@@ -50,7 +50,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -77,7 +77,7 @@ Let's now wait for the mysql instance to be ready,
 ```bash
 $ kubectl get mysql -n demo
 NAME           VERSION   STATUS   AGE
-mysql-server   5.7.36    Ready    3m16s
+mysql-server   5.7.41    Ready    3m16s
 
 $ kubectl get pods -n demo
 NAME             READY   STATUS    RESTARTS   AGE
@@ -95,7 +95,7 @@ root@mysql-server-0:/# mysql -uroot -p$MYSQL_ROOT_PASSWORD
 mysql: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 106
-Server version: 5.7.36-log MySQL Community Server (GPL)
+Server version: 5.7.41-log MySQL Community Server (GPL)
 
 Copyright (c) 2000, 2021, Oracle and/or its affiliates.
 
@@ -154,7 +154,7 @@ $ kubectl exec -it -n demo proxy-server-0 -- bash
 root@proxy-server-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 18
-Server version: 8.0.27 (ProxySQL Admin Module)
+Server version: 8.0.32 (ProxySQL Admin Module)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -188,7 +188,7 @@ Let's check it with the follwing command.
 root@proxy-server-0:/# mysql -utest -ppass -h127.0.0.1 -P6033
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 914
-Server version: 8.0.27 (ProxySQL)
+Server version: 8.0.32 (ProxySQL)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -206,7 +206,7 @@ Current pager:		stdout
 Using outfile:		''
 Using delimiter:	;
 Server:			MySQL
-Server version:		8.0.27 (ProxySQL)
+Server version:		8.0.32 (ProxySQL)
 Protocol version:	10
 Connection:		127.0.0.1 via TCP/IP
 Server characterset:	latin1
@@ -340,7 +340,7 @@ The `mysql-have_ssl` variables should be true by this time.
 root@proxy-server-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 22
-Server version: 8.0.27 (ProxySQL Admin Module)
+Server version: 8.0.32 (ProxySQL Admin Module)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -410,7 +410,7 @@ We can see that the connection is refused. Now try with the tls certificates.
 root@proxy-server-0:/# mysql -utest -ppass -h127.0.0.01 -P6033 --ssl-ca=/var/lib/frontend/client/ca.crt --ssl-cert=/var/lib/frontend/client/tls.crt --ssl-key=/var/lib/frontend/client/tls.key
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 107
-Server version: 8.0.27 (ProxySQL)
+Server version: 8.0.32 (ProxySQL)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -428,7 +428,7 @@ Current pager:		stdout
 Using outfile:		''
 Using delimiter:	;
 Server:			MySQL
-Server version:		8.0.27 (ProxySQL)
+Server version:		8.0.32 (ProxySQL)
 Protocol version:	10
 Connection:		127.0.0.01 via TCP/IP
 Server characterset:	latin1
@@ -764,7 +764,7 @@ Let's check the effect.
 root@proxy-server-1:/# mysql -uadmin -padmin -h127.0.0.1 -P6032
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 25
-Server version: 8.0.27 (ProxySQL Admin Module)
+Server version: 8.0.32 (ProxySQL Admin Module)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -795,7 +795,7 @@ MySQL [(none)]> ^DBye
 root@proxy-server-1:/# mysql -utest -ppass -h127.0.0.1 -P6033
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 267
-Server version: 8.0.27 (ProxySQL)
+Server version: 8.0.32 (ProxySQL)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 

--- a/docs/guides/proxysql/reconfigure/cluster/examples/sample-mysql.yaml
+++ b/docs/guides/proxysql/reconfigure/cluster/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/reconfigure/cluster/index.md
+++ b/docs/guides/proxysql/reconfigure/cluster/index.md
@@ -48,7 +48,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -73,7 +73,7 @@ Let's wait for the MySQL to be Ready.
 ```bash
 $ kubectl get mysql -n demo 
 NAME           VERSION   STATUS   AGE
-mysql-server   5.7.36    Ready    3m51s
+mysql-server   5.7.41    Ready    3m51s
 ```
 
 ### Prepare ProxySQL Cluster
@@ -122,7 +122,7 @@ root@mysql-server-0:/# mysql -uroot -p$MYSQL_ROOT_PASSWORD
 mysql: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 195
-Server version: 5.7.36-log MySQL Community Server (GPL)
+Server version: 5.7.41-log MySQL Community Server (GPL)
 
 Copyright (c) 2000, 2021, Oracle and/or its affiliates.
 
@@ -163,7 +163,7 @@ $ kubectl exec -it -n demo proxy-server-0 -- bash
 root@proxy-server-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032 --prompt "ProxySQLAdmin > "
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 71
-Server version: 8.0.27 (ProxySQL Admin Module)
+Server version: 8.0.32 (ProxySQL Admin Module)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 

--- a/docs/guides/proxysql/scaling/horizontal-scaling/cluster/examples/sample-mysql.yaml
+++ b/docs/guides/proxysql/scaling/horizontal-scaling/cluster/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/scaling/horizontal-scaling/cluster/index.md
+++ b/docs/guides/proxysql/scaling/horizontal-scaling/cluster/index.md
@@ -47,7 +47,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/scaling/vertical-scaling/cluster/example/sample-mysql.yaml
+++ b/docs/guides/proxysql/scaling/vertical-scaling/cluster/example/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/scaling/vertical-scaling/cluster/index.md
+++ b/docs/guides/proxysql/scaling/vertical-scaling/cluster/index.md
@@ -46,7 +46,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/tls/configure/examples/sample-mysql.yaml
+++ b/docs/guides/proxysql/tls/configure/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/tls/configure/index.md
+++ b/docs/guides/proxysql/tls/configure/index.md
@@ -50,7 +50,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -251,7 +251,7 @@ root@mysql-server-0:/# mysql -uroot -p$MYSQL_ROOT_PASSWORD
 mysql: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 26692
-Server version: 5.7.36-log MySQL Community Server (GPL)
+Server version: 5.7.41-log MySQL Community Server (GPL)
 
 Copyright (c) 2000, 2021, Oracle and/or its affiliates.
 
@@ -307,7 +307,7 @@ ERROR 1045 (28000): ProxySQL Error: Access denied for user 'test' (using passwor
 root@proxy-server-0:/ mysql -utest -ppass -h127.0.0.1 -P6033 --ssl-ca=/var/lib/frontend/server/ca.crt --ssl-cert=/var/lib/frontend/server/tls.crt --ssl-key=/var/lib/frontend/server/tls.key
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 1573
-Server version: 8.0.27 (ProxySQL)
+Server version: 8.0.32 (ProxySQL)
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -325,7 +325,7 @@ Current pager:		stdout
 Using outfile:		''
 Using delimiter:	;
 Server:			MySQL
-Server version:		8.0.27 (ProxySQL)
+Server version:		8.0.32 (ProxySQL)
 Protocol version:	10
 Connection:		127.0.0.1 via TCP/IP
 Server characterset:	latin1

--- a/docs/guides/proxysql/update-version/cluster/examples/sample-mysql.yaml
+++ b/docs/guides/proxysql/update-version/cluster/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/proxysql/update-version/cluster/index.md
+++ b/docs/guides/proxysql/update-version/cluster/index.md
@@ -46,7 +46,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "5.7.36"
+  version: "5.7.41"
   replicas: 3
   topology:
     mode: GroupReplication


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.11.29-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/75
Signed-off-by: 1gtm <1gtm@appscode.com>