### PR TITLE
Prepare for release v2023.12.1-rc.1

### DIFF
--- a/docs/CHANGELOG-v2023.12.1-rc.1.md
+++ b/docs/CHANGELOG-v2023.12.1-rc.1.md
@@ -1,0 +1,355 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2023.12.1-rc.1
+    name: Changelog-v2023.12.1-rc.1
+    parent: welcome
+    weight: 20231201
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.12.1-rc.1/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.12.1-rc.1/
+---
+
+# KubeDB v2023.12.1-rc.1 (2023-12-01)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.38.0-rc.1](https://github.com/kubedb/apimachinery/releases/tag/v0.38.0-rc.1)
+
+- [de0bb4e2](https://github.com/kubedb/apimachinery/commit/de0bb4e2) Update kubestash apimachienry
+- [545731a9](https://github.com/kubedb/apimachinery/commit/545731a9) Add default KubeBuilder client (#1081)
+- [f260aa8e](https://github.com/kubedb/apimachinery/commit/f260aa8e) Add SecurityContext field in catalogs; Set default accordingly (#1080)
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.23.0-rc.1](https://github.com/kubedb/autoscaler/releases/tag/v0.23.0-rc.1)
+
+- [193fb07b](https://github.com/kubedb/autoscaler/commit/193fb07b) Prepare for release v0.23.0-rc.1 (#159)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.38.0-rc.1](https://github.com/kubedb/cli/releases/tag/v0.38.0-rc.1)
+
+- [a99b2857](https://github.com/kubedb/cli/commit/a99b2857) Prepare for release v0.38.0-rc.1 (#738)
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/dashboard/releases/tag/v0.14.0-rc.1)
+
+- [7031fb23](https://github.com/kubedb/dashboard/commit/7031fb23) Prepare for release v0.14.0-rc.1 (#86)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.38.0-rc.1](https://github.com/kubedb/elasticsearch/releases/tag/v0.38.0-rc.1)
+
+- [bd0fd357](https://github.com/kubedb/elasticsearch/commit/bd0fd357e) Prepare for release v0.38.0-rc.1 (#680)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.1.0-rc.1)
+
+- [f6a9e4c](https://github.com/kubedb/elasticsearch-restic-plugin/commit/f6a9e4c) Prepare for release v0.1.0-rc.1 (#9)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2023.12.1-rc.1](https://github.com/kubedb/installer/releases/tag/v2023.12.1-rc.1)
+
+- [876956a1](https://github.com/kubedb/installer/commit/876956a1) Prepare for release v2023.12.1-rc.1 (#727)
+- [d021b61b](https://github.com/kubedb/installer/commit/d021b61b) Add `runAsUser` field in all catalogs (#725)
+- [38e2ba3e](https://github.com/kubedb/installer/commit/38e2ba3e) Add `--default-seccomp-profile-type` flag (#724)
+- [ee86f5bc](https://github.com/kubedb/installer/commit/ee86f5bc) Add `databases` flag for mysql addon (#723)
+- [e67541cf](https://github.com/kubedb/installer/commit/e67541cf) Add postgres restic addon (#726)
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.9.0-rc.1](https://github.com/kubedb/kafka/releases/tag/v0.9.0-rc.1)
+
+- [0516c18](https://github.com/kubedb/kafka/commit/0516c18) Prepare for release v0.9.0-rc.1 (#50)
+- [6554778](https://github.com/kubedb/kafka/commit/6554778) Set default KubeBuilder client (#49)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.1.0-rc.1)
+
+- [4bd44b8](https://github.com/kubedb/kubedb-manifest-plugin/commit/4bd44b8) Prepare for release v0.1.0-rc.1 (#29)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.22.0-rc.1](https://github.com/kubedb/mariadb/releases/tag/v0.22.0-rc.1)
+
+- [9c157c66](https://github.com/kubedb/mariadb/commit/9c157c66) Prepare for release v0.22.0-rc.1 (#235)
+- [1d0c2579](https://github.com/kubedb/mariadb/commit/1d0c2579) Pass version in SetDefaults func (#234)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.1.0-rc.1)
+
+- [a2afbc9](https://github.com/kubedb/mariadb-archiver/commit/a2afbc9) Prepare for release v0.1.0-rc.1 (#4)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.18.0-rc.1](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.18.0-rc.1)
+
+- [118bcda4](https://github.com/kubedb/mariadb-coordinator/commit/118bcda4) Prepare for release v0.18.0-rc.1 (#93)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.31.0-rc.1](https://github.com/kubedb/memcached/releases/tag/v0.31.0-rc.1)
+
+- [fab2a879](https://github.com/kubedb/memcached/commit/fab2a879) Prepare for release v0.31.0-rc.1 (#406)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.31.0-rc.1](https://github.com/kubedb/mongodb/releases/tag/v0.31.0-rc.1)
+
+- [de48eeb7](https://github.com/kubedb/mongodb/commit/de48eeb7) Prepare for release v0.31.0-rc.1 (#582)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.1.0-rc.1)
+
+- [92b28e8](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/92b28e8) Prepare for release v0.1.0-rc.1 (#4)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.1.0-rc.1)
+
+- [1daa490](https://github.com/kubedb/mongodb-restic-plugin/commit/1daa490) Prepare for release v0.1.0-rc.1 (#14)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.31.0-rc.1](https://github.com/kubedb/mysql/releases/tag/v0.31.0-rc.1)
+
+- [79cb58c1](https://github.com/kubedb/mysql/commit/79cb58c1) Prepare for release v0.31.0-rc.1 (#574)
+- [e5b37c00](https://github.com/kubedb/mysql/commit/e5b37c00) Pass version in SetDefaults func (#573)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/mysql-archiver/releases/tag/v0.1.0-rc.1)
+
+- [8c65d14](https://github.com/kubedb/mysql-archiver/commit/8c65d14) Prepare for release v0.1.0-rc.1 (#3)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.16.0-rc.1)
+
+- [63cb0a33](https://github.com/kubedb/mysql-coordinator/commit/63cb0a33) Prepare for release v0.16.0-rc.1 (#90)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.1.0-rc.1)
+
+- [f77476b](https://github.com/kubedb/mysql-restic-plugin/commit/f77476b) Prepare for release v0.1.0-rc.1 (#13)
+- [81ceb55](https://github.com/kubedb/mysql-restic-plugin/commit/81ceb55) Add `databases` flag (#12)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/mysql-router-init/releases/tag/v0.16.0-rc.1)
+
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.25.0-rc.1](https://github.com/kubedb/ops-manager/releases/tag/v0.25.0-rc.1)
+
+- [98dbd6c0](https://github.com/kubedb/ops-manager/commit/98dbd6c0) Prepare for release v0.25.0-rc.1 (#494)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.25.0-rc.1](https://github.com/kubedb/percona-xtradb/releases/tag/v0.25.0-rc.1)
+
+- [bad0b334](https://github.com/kubedb/percona-xtradb/commit/bad0b334) Prepare for release v0.25.0-rc.1 (#333)
+- [b8447936](https://github.com/kubedb/percona-xtradb/commit/b8447936) Pass version in SetDefaults func (#332)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.11.0-rc.1](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.11.0-rc.1)
+
+- [7a66da3](https://github.com/kubedb/percona-xtradb-coordinator/commit/7a66da3) Prepare for release v0.11.0-rc.1 (#50)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.22.0-rc.1](https://github.com/kubedb/pg-coordinator/releases/tag/v0.22.0-rc.1)
+
+- [9f9614e6](https://github.com/kubedb/pg-coordinator/commit/9f9614e6) Prepare for release v0.22.0-rc.1 (#140)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.25.0-rc.1](https://github.com/kubedb/pgbouncer/releases/tag/v0.25.0-rc.1)
+
+- [e3e9f84d](https://github.com/kubedb/pgbouncer/commit/e3e9f84d) Prepare for release v0.25.0-rc.1 (#297)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.38.0-rc.1](https://github.com/kubedb/postgres/releases/tag/v0.38.0-rc.1)
+
+- [0e493a1c](https://github.com/kubedb/postgres/commit/0e493a1cd) Prepare for release v0.38.0-rc.1 (#685)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/postgres-archiver/releases/tag/v0.1.0-rc.1)
+
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.1.0-rc.1)
+
+- [57a7bdf](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/57a7bdf) Prepare for release v0.1.0-rc.1 (#7)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.1.0-rc.1)
+
+- [584bbad](https://github.com/kubedb/postgres-restic-plugin/commit/584bbad) Prepare for release v0.1.0-rc.1 (#6)
+- [da1ecd7](https://github.com/kubedb/postgres-restic-plugin/commit/da1ecd7) Refactor (#5)
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.38.0-rc.1](https://github.com/kubedb/provisioner/releases/tag/v0.38.0-rc.1)
+
+- [086300d9](https://github.com/kubedb/provisioner/commit/086300d90) Prepare for release v0.38.0-rc.1 (#61)
+- [0dfe3742](https://github.com/kubedb/provisioner/commit/0dfe37425) Ensure archiver CRDs (#60)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.25.0-rc.1](https://github.com/kubedb/proxysql/releases/tag/v0.25.0-rc.1)
+
+- [1f87cbc5](https://github.com/kubedb/proxysql/commit/1f87cbc5) Prepare for release v0.25.0-rc.1 (#314)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.31.0-rc.1](https://github.com/kubedb/redis/releases/tag/v0.31.0-rc.1)
+
+- [a3d4b7b8](https://github.com/kubedb/redis/commit/a3d4b7b8) Prepare for release v0.31.0-rc.1 (#497)
+- [bb101b6a](https://github.com/kubedb/redis/commit/bb101b6a) Pass version in SetDefaults func (#496)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.17.0-rc.1](https://github.com/kubedb/redis-coordinator/releases/tag/v0.17.0-rc.1)
+
+- [7e5fbf31](https://github.com/kubedb/redis-coordinator/commit/7e5fbf31) Prepare for release v0.17.0-rc.1 (#81)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.1.0-rc.1)
+
+- [8cae5ef](https://github.com/kubedb/redis-restic-plugin/commit/8cae5ef) Prepare for release v0.1.0-rc.1 (#10)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.25.0-rc.1](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.25.0-rc.1)
+
+- [758906fe](https://github.com/kubedb/replication-mode-detector/commit/758906fe) Prepare for release v0.25.0-rc.1 (#245)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/schema-manager/releases/tag/v0.14.0-rc.1)
+
+- [f7e384b2](https://github.com/kubedb/schema-manager/commit/f7e384b2) Prepare for release v0.14.0-rc.1 (#86)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.23.0-rc.1](https://github.com/kubedb/tests/releases/tag/v0.23.0-rc.1)
+
+- [8f82cf9a](https://github.com/kubedb/tests/commit/8f82cf9a) Prepare for release v0.23.0-rc.1 (#272)
+- [0bfcc3b6](https://github.com/kubedb/tests/commit/0bfcc3b6) Fix kafka restart-pods test (#271)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/ui-server/releases/tag/v0.14.0-rc.1)
+
+- [82f78763](https://github.com/kubedb/ui-server/commit/82f78763) Prepare for release v0.14.0-rc.1 (#95)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/webhook-server/releases/tag/v0.14.0-rc.1)
+
+- [01d13baa](https://github.com/kubedb/webhook-server/commit/01d13baa) Prepare for release v0.14.0-rc.1 (#72)
+- [e869d0ce](https://github.com/kubedb/webhook-server/commit/e869d0ce) Initialize default KubeBuilder client (#71)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.12.1-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/76
Signed-off-by: 1gtm <1gtm@appscode.com>