### PR TITLE
Prepare for release v2024.1.7-beta.0

### DIFF
--- a/docs/CHANGELOG-v2024.1.7-beta.0.md
+++ b/docs/CHANGELOG-v2024.1.7-beta.0.md
@@ -1,0 +1,518 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2024.1.7-beta.0
+    name: Changelog-v2024.1.7-beta.0
+    parent: welcome
+    weight: 20240107
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.1.7-beta.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.1.7-beta.0/
+---
+
+# KubeDB v2024.1.7-beta.0 (2024-01-08)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.41.0-beta.0](https://github.com/kubedb/apimachinery/releases/tag/v0.41.0-beta.0)
+
+- [45cbf75e](https://github.com/kubedb/apimachinery/commit/45cbf75e3) Update deps
+- [dc224c1a](https://github.com/kubedb/apimachinery/commit/dc224c1a1) Remove crd informer (#1102)
+- [87c402a1](https://github.com/kubedb/apimachinery/commit/87c402a1a) Remove discovery.ResourceMapper (#1101)
+- [a1d475ce](https://github.com/kubedb/apimachinery/commit/a1d475ceb) Replace deprecated PollImmediate (#1100)
+- [75db4a37](https://github.com/kubedb/apimachinery/commit/75db4a378) Add ConfigureOpenAPI helper (#1099)
+- [83be295b](https://github.com/kubedb/apimachinery/commit/83be295b0) update sidekick deps
+- [032b2721](https://github.com/kubedb/apimachinery/commit/032b27211) Fix linter
+- [389a934c](https://github.com/kubedb/apimachinery/commit/389a934c7) Use k8s 1.29 client libs (#1093)
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.26.0-beta.0](https://github.com/kubedb/autoscaler/releases/tag/v0.26.0-beta.0)
+
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.41.0-beta.0](https://github.com/kubedb/cli/releases/tag/v0.41.0-beta.0)
+
+- [c0165e83](https://github.com/kubedb/cli/commit/c0165e83) Prepare for release v0.41.0-beta.0 (#747)
+- [d9c905e5](https://github.com/kubedb/cli/commit/d9c905e5) Update deps (#746)
+- [bc415a1d](https://github.com/kubedb/cli/commit/bc415a1d) Update deps (#745)
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.17.0-beta.0](https://github.com/kubedb/dashboard/releases/tag/v0.17.0-beta.0)
+
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.41.0-beta.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.41.0-beta.0)
+
+- [3ab4d77d](https://github.com/kubedb/elasticsearch/commit/3ab4d77d2) Prepare for release v0.41.0-beta.0 (#694)
+- [c38c61cb](https://github.com/kubedb/elasticsearch/commit/c38c61cbc) Dynamically start crd controller (#693)
+- [6a798d30](https://github.com/kubedb/elasticsearch/commit/6a798d309) Update deps (#692)
+- [bdf034a4](https://github.com/kubedb/elasticsearch/commit/bdf034a49) Update deps (#691)
+- [ea22eecb](https://github.com/kubedb/elasticsearch/commit/ea22eecb2) Add openapi configuration for webhook server (#690)
+- [b97636cd](https://github.com/kubedb/elasticsearch/commit/b97636cd1) Update lint command
+- [0221ac14](https://github.com/kubedb/elasticsearch/commit/0221ac14e) Update deps
+- [b4cb8d60](https://github.com/kubedb/elasticsearch/commit/b4cb8d603) Use k8s 1.29 client libs (#689)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.4.0-beta.0](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.4.0-beta.0)
+
+- [5e9aef5](https://github.com/kubedb/elasticsearch-restic-plugin/commit/5e9aef5) Prepare for release v0.4.0-beta.0 (#15)
+- [2fdcafa](https://github.com/kubedb/elasticsearch-restic-plugin/commit/2fdcafa) Use k8s 1.29 client libs (#14)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2024.1.7-beta.0](https://github.com/kubedb/installer/releases/tag/v2024.1.7-beta.0)
+
+- [45c11e3e](https://github.com/kubedb/installer/commit/45c11e3e) Prepare for release v2024.1.7-beta.0 (#773)
+- [d8634da5](https://github.com/kubedb/installer/commit/d8634da5) Fix CI
+- [b8e850cc](https://github.com/kubedb/installer/commit/b8e850cc) Fix linter
+- [69dff8a6](https://github.com/kubedb/installer/commit/69dff8a6) Selectively disable feature gates (#771)
+- [0f925055](https://github.com/kubedb/installer/commit/0f925055) Use common feature gates across charts (#770)
+- [4856a14e](https://github.com/kubedb/installer/commit/4856a14e) Update crds for kubedb/apimachinery@87c402a1 (#768)
+- [570bfc35](https://github.com/kubedb/installer/commit/570bfc35) Configure crd-manager features (#769)
+- [91a890d3](https://github.com/kubedb/installer/commit/91a890d3) Add crd-manager chart (#767)
+- [bd03b2b4](https://github.com/kubedb/installer/commit/bd03b2b4) Require kubernetes 1.20+
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.12.0-beta.0](https://github.com/kubedb/kafka/releases/tag/v0.12.0-beta.0)
+
+- [f9350578](https://github.com/kubedb/kafka/commit/f9350578) Prepare for release v0.12.0-beta.0 (#62)
+- [692f2bef](https://github.com/kubedb/kafka/commit/692f2bef) Dynamically start crd controller (#61)
+- [a50dc8b4](https://github.com/kubedb/kafka/commit/a50dc8b4) Update deps (#60)
+- [7ff28ed7](https://github.com/kubedb/kafka/commit/7ff28ed7) Update deps (#59)
+- [16130571](https://github.com/kubedb/kafka/commit/16130571) Add openapi configuration for webhook server (#58)
+- [cc465de9](https://github.com/kubedb/kafka/commit/cc465de9) Use k8s 1.29 client libs (#57)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.4.0-beta.0](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.4.0-beta.0)
+
+- [c315615](https://github.com/kubedb/kubedb-manifest-plugin/commit/c315615) Prepare for release v0.4.0-beta.0 (#36)
+- [5ce328d](https://github.com/kubedb/kubedb-manifest-plugin/commit/5ce328d) Use k8s 1.29 client libs (#34)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.25.0-beta.0](https://github.com/kubedb/mariadb/releases/tag/v0.25.0-beta.0)
+
+- [b93ddce3](https://github.com/kubedb/mariadb/commit/b93ddce3d) Prepare for release v0.25.0-beta.0 (#247)
+- [8099af6d](https://github.com/kubedb/mariadb/commit/8099af6d9) Dynamically start crd controller (#246)
+- [0a9dd9e0](https://github.com/kubedb/mariadb/commit/0a9dd9e03) Update deps (#245)
+- [5c548629](https://github.com/kubedb/mariadb/commit/5c548629e) Update deps (#244)
+- [0f9ea4f2](https://github.com/kubedb/mariadb/commit/0f9ea4f20) Update deps
+- [89641d3c](https://github.com/kubedb/mariadb/commit/89641d3c7) Use k8s 1.29 client libs (#242)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.1.0-beta.0](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.1.0-beta.0)
+
+- [8c8e09a](https://github.com/kubedb/mariadb-archiver/commit/8c8e09a) Prepare for release v0.1.0-beta.0 (#4)
+- [90ae04c](https://github.com/kubedb/mariadb-archiver/commit/90ae04c) Use k8s 1.29 client libs (#3)
+- [b3067c8](https://github.com/kubedb/mariadb-archiver/commit/b3067c8) Fix binlog command
+- [5cc0b6a](https://github.com/kubedb/mariadb-archiver/commit/5cc0b6a) Fix release workflow
+- [910b7ce](https://github.com/kubedb/mariadb-archiver/commit/910b7ce) Prepare for release v0.1.0 (#1)
+- [3801668](https://github.com/kubedb/mariadb-archiver/commit/3801668) mysql -> mariadb
+- [4e905fb](https://github.com/kubedb/mariadb-archiver/commit/4e905fb) Implemenet new algorithm for archiver and restorer (#5)
+- [22701c8](https://github.com/kubedb/mariadb-archiver/commit/22701c8) Fix 5.7.x build
+- [6da2b1c](https://github.com/kubedb/mariadb-archiver/commit/6da2b1c) Update build matrix
+- [e2f6244](https://github.com/kubedb/mariadb-archiver/commit/e2f6244) Use separate dockerfile per mysql version (#9)
+- [e800623](https://github.com/kubedb/mariadb-archiver/commit/e800623) Prepare for release v0.2.0 (#8)
+- [b9f6ec5](https://github.com/kubedb/mariadb-archiver/commit/b9f6ec5) Install mysqlbinlog (#7)
+- [c46d991](https://github.com/kubedb/mariadb-archiver/commit/c46d991) Use appscode-images as base image (#6)
+- [721eaa8](https://github.com/kubedb/mariadb-archiver/commit/721eaa8) Prepare for release v0.1.0 (#4)
+- [8c65d14](https://github.com/kubedb/mariadb-archiver/commit/8c65d14) Prepare for release v0.1.0-rc.1 (#3)
+- [f79286a](https://github.com/kubedb/mariadb-archiver/commit/f79286a) Prepare for release v0.1.0-rc.0 (#2)
+- [dcd2e30](https://github.com/kubedb/mariadb-archiver/commit/dcd2e30) Fix wal-g binary
+- [6c20a4a](https://github.com/kubedb/mariadb-archiver/commit/6c20a4a) Fix build
+- [f034e7b](https://github.com/kubedb/mariadb-archiver/commit/f034e7b) Add build script (#1)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.21.0-beta.0](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.21.0-beta.0)
+
+- [28677618](https://github.com/kubedb/mariadb-coordinator/commit/28677618) Prepare for release v0.21.0-beta.0 (#100)
+- [655a2c66](https://github.com/kubedb/mariadb-coordinator/commit/655a2c66) Update deps (#99)
+- [ef206cfe](https://github.com/kubedb/mariadb-coordinator/commit/ef206cfe) Update deps (#98)
+- [ef72c98b](https://github.com/kubedb/mariadb-coordinator/commit/ef72c98b) Use k8s 1.29 client libs (#97)
+
+
+
+## [kubedb/mariadb-csi-snapshotter-plugin](https://github.com/kubedb/mariadb-csi-snapshotter-plugin)
+
+### [v0.1.0-beta.0](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/releases/tag/v0.1.0-beta.0)
+
+- [09f68b7](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/09f68b7) Prepare for release v0.1.0-beta.0 (#4)
+- [7407444](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/7407444) Use k8s 1.29 client libs (#3)
+- [933e138](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/933e138) Prepare for release v0.1.0 (#2)
+- [5d38f94](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/5d38f94) Enable GH actions
+- [2a97178](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/2a97178) Replace mysql with mariadb
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.34.0-beta.0](https://github.com/kubedb/memcached/releases/tag/v0.34.0-beta.0)
+
+- [6fe1686a](https://github.com/kubedb/memcached/commit/6fe1686a) Prepare for release v0.34.0-beta.0 (#416)
+- [1cfb0544](https://github.com/kubedb/memcached/commit/1cfb0544) Dynamically start crd controller (#415)
+- [171faff2](https://github.com/kubedb/memcached/commit/171faff2) Update deps (#414)
+- [639495c7](https://github.com/kubedb/memcached/commit/639495c7) Update deps (#413)
+- [223d295a](https://github.com/kubedb/memcached/commit/223d295a) Use k8s 1.29 client libs (#412)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.34.0-beta.0](https://github.com/kubedb/mongodb/releases/tag/v0.34.0-beta.0)
+
+- [7ff67238](https://github.com/kubedb/mongodb/commit/7ff672382) Prepare for release v0.34.0-beta.0 (#600)
+- [beca63a4](https://github.com/kubedb/mongodb/commit/beca63a48) Dynamically start crd controller (#599)
+- [17d90616](https://github.com/kubedb/mongodb/commit/17d90616d) Update deps (#598)
+- [bc25ca00](https://github.com/kubedb/mongodb/commit/bc25ca001) Update deps (#597)
+- [4ce5a94a](https://github.com/kubedb/mongodb/commit/4ce5a94a4) Configure openapi for webhook server (#596)
+- [8d8206db](https://github.com/kubedb/mongodb/commit/8d8206db3) Update ci versions
+- [bfdd519f](https://github.com/kubedb/mongodb/commit/bfdd519fc) Update deps
+- [01a7c268](https://github.com/kubedb/mongodb/commit/01a7c2685) Use k8s 1.29 client libs (#594)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.2.0-beta.0](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.2.0-beta.0)
+
+- [ef74421](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/ef74421) Prepare for release v0.2.0-beta.0 (#9)
+- [c2c9bd4](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/c2c9bd4) Use k8s 1.29 client libs (#8)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.4.0-beta.0](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.4.0-beta.0)
+
+- [4f0b021](https://github.com/kubedb/mongodb-restic-plugin/commit/4f0b021) Prepare for release v0.4.0-beta.0 (#20)
+- [91ee7c0](https://github.com/kubedb/mongodb-restic-plugin/commit/91ee7c0) Use k8s 1.29 client libs (#19)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.34.0-beta.0](https://github.com/kubedb/mysql/releases/tag/v0.34.0-beta.0)
+
+- [354f6f3e](https://github.com/kubedb/mysql/commit/354f6f3e1) Prepare for release v0.34.0-beta.0 (#593)
+- [01498d02](https://github.com/kubedb/mysql/commit/01498d025) Dynamically start crd controller (#592)
+- [e68015cf](https://github.com/kubedb/mysql/commit/e68015cfd) Update deps (#591)
+- [67029acc](https://github.com/kubedb/mysql/commit/67029acc9) Update deps (#590)
+- [87d2de4a](https://github.com/kubedb/mysql/commit/87d2de4a1) Include kubestash catalog chart in makefile (#588)
+- [e5874ffb](https://github.com/kubedb/mysql/commit/e5874ffb7) Add openapi configuration for webhook server (#589)
+- [977d3cd3](https://github.com/kubedb/mysql/commit/977d3cd38) Update deps
+- [3df86853](https://github.com/kubedb/mysql/commit/3df868533) Use k8s 1.29 client libs (#586)
+- [d159ad05](https://github.com/kubedb/mysql/commit/d159ad052) Ensure MySQLArchiver crd (#585)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.2.0-beta.0](https://github.com/kubedb/mysql-archiver/releases/tag/v0.2.0-beta.0)
+
+- [5833776](https://github.com/kubedb/mysql-archiver/commit/5833776) Prepare for release v0.2.0-beta.0 (#12)
+- [f3e68b2](https://github.com/kubedb/mysql-archiver/commit/f3e68b2) Use k8s 1.29 client libs (#11)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.19.0-beta.0](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.19.0-beta.0)
+
+- [e0cc149f](https://github.com/kubedb/mysql-coordinator/commit/e0cc149f) Prepare for release v0.19.0-beta.0 (#97)
+- [67aeb229](https://github.com/kubedb/mysql-coordinator/commit/67aeb229) Update deps (#96)
+- [2fa4423f](https://github.com/kubedb/mysql-coordinator/commit/2fa4423f) Update deps (#95)
+- [b0735769](https://github.com/kubedb/mysql-coordinator/commit/b0735769) Use k8s 1.29 client libs (#94)
+
+
+
+## [kubedb/mysql-csi-snapshotter-plugin](https://github.com/kubedb/mysql-csi-snapshotter-plugin)
+
+### [v0.2.0-beta.0](https://github.com/kubedb/mysql-csi-snapshotter-plugin/releases/tag/v0.2.0-beta.0)
+
+- [d285eff](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/d285eff) Prepare for release v0.2.0-beta.0 (#4)
+- [7a46441](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/7a46441) Use k8s 1.29 client libs (#2)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.4.0-beta.0](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.4.0-beta.0)
+
+- [742d2ce](https://github.com/kubedb/mysql-restic-plugin/commit/742d2ce) Prepare for release v0.4.0-beta.0 (#19)
+- [0402847](https://github.com/kubedb/mysql-restic-plugin/commit/0402847) Use k8s 1.29 client libs (#18)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.19.0-beta.0](https://github.com/kubedb/mysql-router-init/releases/tag/v0.19.0-beta.0)
+
+- [85f8c6f](https://github.com/kubedb/mysql-router-init/commit/85f8c6f) Update deps (#38)
+- [7dd201c](https://github.com/kubedb/mysql-router-init/commit/7dd201c) Use k8s 1.29 client libs (#37)
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.28.0-beta.0](https://github.com/kubedb/ops-manager/releases/tag/v0.28.0-beta.0)
+
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.28.0-beta.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.28.0-beta.0)
+
+- [0ceb3028](https://github.com/kubedb/percona-xtradb/commit/0ceb30284) Prepare for release v0.28.0-beta.0 (#346)
+- [e7d35606](https://github.com/kubedb/percona-xtradb/commit/e7d356062) Dynamically start crd controller (#345)
+- [5d07b565](https://github.com/kubedb/percona-xtradb/commit/5d07b5655) Update deps (#344)
+- [1a639f84](https://github.com/kubedb/percona-xtradb/commit/1a639f840) Update deps (#343)
+- [4f8b24ab](https://github.com/kubedb/percona-xtradb/commit/4f8b24aba) Update deps
+- [e5254020](https://github.com/kubedb/percona-xtradb/commit/e52540202) Use k8s 1.29 client libs (#341)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.14.0-beta.0](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.14.0-beta.0)
+
+- [963756eb](https://github.com/kubedb/percona-xtradb-coordinator/commit/963756eb) Prepare for release v0.14.0-beta.0 (#57)
+- [5489bb8c](https://github.com/kubedb/percona-xtradb-coordinator/commit/5489bb8c) Update deps (#56)
+- [a8424e18](https://github.com/kubedb/percona-xtradb-coordinator/commit/a8424e18) Update deps (#55)
+- [ee4add86](https://github.com/kubedb/percona-xtradb-coordinator/commit/ee4add86) Use k8s 1.29 client libs (#54)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.25.0-beta.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.25.0-beta.0)
+
+- [30973540](https://github.com/kubedb/pg-coordinator/commit/30973540) Prepare for release v0.25.0-beta.0 (#147)
+- [7b84e198](https://github.com/kubedb/pg-coordinator/commit/7b84e198) Update deps (#146)
+- [f1bfe818](https://github.com/kubedb/pg-coordinator/commit/f1bfe818) Update deps (#145)
+- [1de05a6e](https://github.com/kubedb/pg-coordinator/commit/1de05a6e) Use k8s 1.29 client libs (#144)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.28.0-beta.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.28.0-beta.0)
+
+- [3c6bc335](https://github.com/kubedb/pgbouncer/commit/3c6bc335) Prepare for release v0.28.0-beta.0 (#310)
+- [73c5f6fb](https://github.com/kubedb/pgbouncer/commit/73c5f6fb) Dynamically start crd controller (#309)
+- [f9edc2cd](https://github.com/kubedb/pgbouncer/commit/f9edc2cd) Update deps (#308)
+- [d54251c0](https://github.com/kubedb/pgbouncer/commit/d54251c0) Update deps (#307)
+- [de40a35e](https://github.com/kubedb/pgbouncer/commit/de40a35e) Update deps
+- [8c325577](https://github.com/kubedb/pgbouncer/commit/8c325577) Use k8s 1.29 client libs (#305)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.41.0-beta.0](https://github.com/kubedb/postgres/releases/tag/v0.41.0-beta.0)
+
+- [d1bd909b](https://github.com/kubedb/postgres/commit/d1bd909ba) Prepare for release v0.41.0-beta.0 (#703)
+- [5e8101e3](https://github.com/kubedb/postgres/commit/5e8101e39) Dynamically start crd controller (#702)
+- [47dbbff5](https://github.com/kubedb/postgres/commit/47dbbff53) Update deps (#701)
+- [84f99c58](https://github.com/kubedb/postgres/commit/84f99c58b) Disable fairness api
+- [a715765d](https://github.com/kubedb/postgres/commit/a715765dc) Set --restricted=false for ci tests (#700)
+- [fe9af597](https://github.com/kubedb/postgres/commit/fe9af5977) Add Postgres test fix (#699)
+- [8bae8886](https://github.com/kubedb/postgres/commit/8bae88860) Configure openapi for webhook server (#698)
+- [9ce2efce](https://github.com/kubedb/postgres/commit/9ce2efce5) Update deps
+- [24e4e9ca](https://github.com/kubedb/postgres/commit/24e4e9ca5) Use k8s 1.29 client libs (#697)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.2.0-beta.0](https://github.com/kubedb/postgres-archiver/releases/tag/v0.2.0-beta.0)
+
+- [a9cbe08](https://github.com/kubedb/postgres-archiver/commit/a9cbe08) Prepare for release v0.2.0-beta.0 (#16)
+- [183e97c](https://github.com/kubedb/postgres-archiver/commit/183e97c) Use k8s 1.29 client libs (#15)
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.2.0-beta.0](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.2.0-beta.0)
+
+- [f0e546a](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/f0e546a) Prepare for release v0.2.0-beta.0 (#12)
+- [aae7294](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/aae7294) Use k8s 1.29 client libs (#11)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.4.0-beta.0](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.4.0-beta.0)
+
+
+
+
+## [kubedb/provider-aws](https://github.com/kubedb/provider-aws)
+
+### [v0.3.0-beta.0](https://github.com/kubedb/provider-aws/releases/tag/v0.3.0-beta.0)
+
+
+
+
+## [kubedb/provider-azure](https://github.com/kubedb/provider-azure)
+
+### [v0.3.0-beta.0](https://github.com/kubedb/provider-azure/releases/tag/v0.3.0-beta.0)
+
+
+
+
+## [kubedb/provider-gcp](https://github.com/kubedb/provider-gcp)
+
+### [v0.3.0-beta.0](https://github.com/kubedb/provider-gcp/releases/tag/v0.3.0-beta.0)
+
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.41.0-beta.0](https://github.com/kubedb/provisioner/releases/tag/v0.41.0-beta.0)
+
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.28.0-beta.0](https://github.com/kubedb/proxysql/releases/tag/v0.28.0-beta.0)
+
+- [c0805050](https://github.com/kubedb/proxysql/commit/c0805050e) Prepare for release v0.28.0-beta.0 (#324)
+- [88ef1f1d](https://github.com/kubedb/proxysql/commit/88ef1f1de) Dynamically start crd controller (#323)
+- [8c0a96ac](https://github.com/kubedb/proxysql/commit/8c0a96ac7) Update deps (#322)
+- [e96797e4](https://github.com/kubedb/proxysql/commit/e96797e48) Update deps (#321)
+- [e8fd529b](https://github.com/kubedb/proxysql/commit/e8fd529b2) Update deps
+- [b2e9a1df](https://github.com/kubedb/proxysql/commit/b2e9a1df8) Use k8s 1.29 client libs (#319)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.34.0-beta.0](https://github.com/kubedb/redis/releases/tag/v0.34.0-beta.0)
+
+- [7e844ab1](https://github.com/kubedb/redis/commit/7e844ab1) Prepare for release v0.34.0-beta.0 (#513)
+- [6318d04f](https://github.com/kubedb/redis/commit/6318d04f) Dynamically start crd controller (#512)
+- [92b8a3a9](https://github.com/kubedb/redis/commit/92b8a3a9) Update deps (#511)
+- [f0fb4c69](https://github.com/kubedb/redis/commit/f0fb4c69) Update deps (#510)
+- [c99d9498](https://github.com/kubedb/redis/commit/c99d9498) Update deps
+- [90299544](https://github.com/kubedb/redis/commit/90299544) Use k8s 1.29 client libs (#508)
+- [fced7010](https://github.com/kubedb/redis/commit/fced7010) Update redis versions in nightly tests (#507)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.20.0-beta.0](https://github.com/kubedb/redis-coordinator/releases/tag/v0.20.0-beta.0)
+
+- [4c36accd](https://github.com/kubedb/redis-coordinator/commit/4c36accd) Prepare for release v0.20.0-beta.0 (#88)
+- [c8658380](https://github.com/kubedb/redis-coordinator/commit/c8658380) Update deps (#87)
+- [c99c2e9b](https://github.com/kubedb/redis-coordinator/commit/c99c2e9b) Update deps (#86)
+- [22c7beb4](https://github.com/kubedb/redis-coordinator/commit/22c7beb4) Use k8s 1.29 client libs (#85)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.4.0-beta.0](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.4.0-beta.0)
+
+- [da2796a](https://github.com/kubedb/redis-restic-plugin/commit/da2796a) Prepare for release v0.4.0-beta.0 (#16)
+- [0553c6f](https://github.com/kubedb/redis-restic-plugin/commit/0553c6f) Use k8s 1.29 client libs (#15)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.28.0-beta.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.28.0-beta.0)
+
+- [572668c8](https://github.com/kubedb/replication-mode-detector/commit/572668c8) Prepare for release v0.28.0-beta.0 (#252)
+- [39ba3ce0](https://github.com/kubedb/replication-mode-detector/commit/39ba3ce0) Update deps (#251)
+- [d3d2ad96](https://github.com/kubedb/replication-mode-detector/commit/d3d2ad96) Update deps (#250)
+- [633d7b76](https://github.com/kubedb/replication-mode-detector/commit/633d7b76) Use k8s 1.29 client libs (#249)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.17.0-beta.0](https://github.com/kubedb/schema-manager/releases/tag/v0.17.0-beta.0)
+
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.26.0-beta.0](https://github.com/kubedb/tests/releases/tag/v0.26.0-beta.0)
+
+- [5f3fabd7](https://github.com/kubedb/tests/commit/5f3fabd7) Prepare for release v0.26.0-beta.0 (#284)
+- [27a24dff](https://github.com/kubedb/tests/commit/27a24dff) Update deps (#283)
+- [b9021186](https://github.com/kubedb/tests/commit/b9021186) Update deps (#282)
+- [589ca51c](https://github.com/kubedb/tests/commit/589ca51c) mongodb vertical scaling fix (#281)
+- [feaa0f6a](https://github.com/kubedb/tests/commit/feaa0f6a) Add `--restricted` flag (#280)
+- [2423ee38](https://github.com/kubedb/tests/commit/2423ee38) Fix linter errors
+- [dcd64c7c](https://github.com/kubedb/tests/commit/dcd64c7c) Update lint command
+- [c3ef1fa4](https://github.com/kubedb/tests/commit/c3ef1fa4) Use k8s 1.29 client libs (#279)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.17.0-beta.0](https://github.com/kubedb/ui-server/releases/tag/v0.17.0-beta.0)
+
+- [6e8f80dc](https://github.com/kubedb/ui-server/commit/6e8f80dc) Prepare for release v0.17.0-beta.0 (#104)
+- [6a05721f](https://github.com/kubedb/ui-server/commit/6a05721f) Update deps (#103)
+- [3c24fd5e](https://github.com/kubedb/ui-server/commit/3c24fd5e) Update deps (#102)
+- [25e29443](https://github.com/kubedb/ui-server/commit/25e29443) Use k8s 1.29 client libs (#101)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.17.0-beta.0](https://github.com/kubedb/webhook-server/releases/tag/v0.17.0-beta.0)
+
+- [dfdeb6c3](https://github.com/kubedb/webhook-server/commit/dfdeb6c3) Prepare for release v0.17.0-beta.0 (#82)
+- [bf54df2a](https://github.com/kubedb/webhook-server/commit/bf54df2a) Update deps (#81)
+- [c7d17faa](https://github.com/kubedb/webhook-server/commit/c7d17faa) Update deps (#79)
+- [170573b1](https://github.com/kubedb/webhook-server/commit/170573b1) Use k8s 1.29 client libs (#78)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.1.7-beta.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/80
Signed-off-by: 1gtm <1gtm@appscode.com>