### PR TITLE
Prepare for release v2024.1.28-rc.1

### DIFF
--- a/docs/CHANGELOG-v2024.1.28-rc.1.md
+++ b/docs/CHANGELOG-v2024.1.28-rc.1.md
@@ -1,0 +1,509 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2024.1.28-rc.1
+    name: Changelog-v2024.1.28-rc.1
+    parent: welcome
+    weight: 20240128
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.1.28-rc.1/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.1.28-rc.1/
+---
+
+# KubeDB v2024.1.28-rc.1 (2024-01-29)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.41.0-rc.1](https://github.com/kubedb/apimachinery/releases/tag/v0.41.0-rc.1)
+
+- [2a63b8b1](https://github.com/kubedb/apimachinery/commit/2a63b8b1a) Update deps
+- [2293744e](https://github.com/kubedb/apimachinery/commit/2293744e3) Update deps
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.26.0-rc.1](https://github.com/kubedb/autoscaler/releases/tag/v0.26.0-rc.1)
+
+- [09c7c1b3](https://github.com/kubedb/autoscaler/commit/09c7c1b3) Prepare for release v0.26.0-rc.1 (#186)
+- [edae8156](https://github.com/kubedb/autoscaler/commit/edae8156) Update deps (#185)
+- [b063256c](https://github.com/kubedb/autoscaler/commit/b063256c) Update deps (#184)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.41.0-rc.1](https://github.com/kubedb/cli/releases/tag/v0.41.0-rc.1)
+
+- [a67dadc9](https://github.com/kubedb/cli/commit/a67dadc9) Prepare for release v0.41.0-rc.1 (#753)
+- [d1b206ee](https://github.com/kubedb/cli/commit/d1b206ee) Update deps (#752)
+- [50f15d19](https://github.com/kubedb/cli/commit/50f15d19) Update deps (#751)
+
+
+
+## [kubedb/crd-manager](https://github.com/kubedb/crd-manager)
+
+### [v0.0.3](https://github.com/kubedb/crd-manager/releases/tag/v0.0.3)
+
+- [c4d0c24](https://github.com/kubedb/crd-manager/commit/c4d0c24) Prepare for release v0.0.3 (#11)
+- [5a149ca](https://github.com/kubedb/crd-manager/commit/5a149ca) Add new db to the list
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.17.0-rc.1](https://github.com/kubedb/dashboard/releases/tag/v0.17.0-rc.1)
+
+- [1720f9d5](https://github.com/kubedb/dashboard/commit/1720f9d5) Prepare for release v0.17.0-rc.1 (#105)
+- [b0f55bcf](https://github.com/kubedb/dashboard/commit/b0f55bcf) Update deps (#104)
+- [e342f79c](https://github.com/kubedb/dashboard/commit/e342f79c) Update deps (#103)
+
+
+
+## [kubedb/druid](https://github.com/kubedb/druid)
+
+### [v0.0.3](https://github.com/kubedb/druid/releases/tag/v0.0.3)
+
+- [f564e7c](https://github.com/kubedb/druid/commit/f564e7c) Prepare for release v0.0.3 (#7)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.41.0-rc.1](https://github.com/kubedb/elasticsearch/releases/tag/v0.41.0-rc.1)
+
+- [f287ef9f](https://github.com/kubedb/elasticsearch/commit/f287ef9f1) Prepare for release v0.41.0-rc.1 (#703)
+- [fcabe6ba](https://github.com/kubedb/elasticsearch/commit/fcabe6bae) Update deps (#702)
+- [861d01f3](https://github.com/kubedb/elasticsearch/commit/861d01f30) Update deps (#701)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.4.0-rc.1](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.4.0-rc.1)
+
+- [675caf7](https://github.com/kubedb/elasticsearch-restic-plugin/commit/675caf7) Prepare for release v0.4.0-rc.1 (#18)
+
+
+
+## [kubedb/ferretdb](https://github.com/kubedb/ferretdb)
+
+### [v0.0.3](https://github.com/kubedb/ferretdb/releases/tag/v0.0.3)
+
+- [be756f6](https://github.com/kubedb/ferretdb/commit/be756f6) Prepare for release v0.0.3 (#7)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2024.1.28-rc.1](https://github.com/kubedb/installer/releases/tag/v2024.1.28-rc.1)
+
+- [12e4d649](https://github.com/kubedb/installer/commit/12e4d649) Prepare for release v2024.1.28-rc.1 (#836)
+- [ce5ca0dc](https://github.com/kubedb/installer/commit/ce5ca0dc) Remove kubedb-one chart
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.12.0-rc.1](https://github.com/kubedb/kafka/releases/tag/v0.12.0-rc.1)
+
+- [511914c2](https://github.com/kubedb/kafka/commit/511914c2) Prepare for release v0.12.0-rc.1 (#75)
+- [fb908cf2](https://github.com/kubedb/kafka/commit/fb908cf2) Update deps (#74)
+- [cccaf86c](https://github.com/kubedb/kafka/commit/cccaf86c) Update deps (#73)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.4.0-rc.1](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.4.0-rc.1)
+
+- [5daf9ce](https://github.com/kubedb/kubedb-manifest-plugin/commit/5daf9ce) Prepare for release v0.4.0-rc.1 (#39)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.25.0-rc.1](https://github.com/kubedb/mariadb/releases/tag/v0.25.0-rc.1)
+
+- [2ca44131](https://github.com/kubedb/mariadb/commit/2ca441314) Prepare for release v0.25.0-rc.1 (#255)
+- [dad5b837](https://github.com/kubedb/mariadb/commit/dad5b837a) Update deps (#254)
+- [a210c867](https://github.com/kubedb/mariadb/commit/a210c8675) Fix appbinding scheme (#251)
+- [81f985cd](https://github.com/kubedb/mariadb/commit/81f985cd7) Update deps (#253)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.1.0-rc.1)
+
+- [8743316](https://github.com/kubedb/mariadb-archiver/commit/8743316) Prepare for release v0.1.0-rc.1 (#7)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.21.0-rc.1)
+
+- [4289bcd1](https://github.com/kubedb/mariadb-coordinator/commit/4289bcd1) Prepare for release v0.21.0-rc.1 (#105)
+- [34f610f7](https://github.com/kubedb/mariadb-coordinator/commit/34f610f7) Update deps (#104)
+- [13dbe3f7](https://github.com/kubedb/mariadb-coordinator/commit/13dbe3f7) Update deps (#103)
+
+
+
+## [kubedb/mariadb-csi-snapshotter-plugin](https://github.com/kubedb/mariadb-csi-snapshotter-plugin)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/releases/tag/v0.1.0-rc.1)
+
+- [066b41c](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/066b41c) Prepare for release v0.1.0-rc.1 (#7)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.34.0-rc.1](https://github.com/kubedb/memcached/releases/tag/v0.34.0-rc.1)
+
+- [928f00e2](https://github.com/kubedb/memcached/commit/928f00e2) Prepare for release v0.34.0-rc.1 (#422)
+- [42aa5dcc](https://github.com/kubedb/memcached/commit/42aa5dcc) Update deps (#421)
+- [d9fd6358](https://github.com/kubedb/memcached/commit/d9fd6358) Update deps (#420)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.34.0-rc.1](https://github.com/kubedb/mongodb/releases/tag/v0.34.0-rc.1)
+
+- [2e96a733](https://github.com/kubedb/mongodb/commit/2e96a7338) Prepare for release v0.34.0-rc.1 (#610)
+- [9a7e16bd](https://github.com/kubedb/mongodb/commit/9a7e16bdb) Update deps (#609)
+- [369b51e8](https://github.com/kubedb/mongodb/commit/369b51e8a) Update deps (#608)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.2.0-rc.1](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.2.0-rc.1)
+
+- [5b28353](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/5b28353) Prepare for release v0.2.0-rc.1 (#14)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.4.0-rc.1](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.4.0-rc.1)
+
+- [3fa6286](https://github.com/kubedb/mongodb-restic-plugin/commit/3fa6286) Prepare for release v0.4.0-rc.1 (#25)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.34.0-rc.1](https://github.com/kubedb/mysql/releases/tag/v0.34.0-rc.1)
+
+- [f3133290](https://github.com/kubedb/mysql/commit/f31332908) Prepare for release v0.34.0-rc.1 (#607)
+- [0f3ddf23](https://github.com/kubedb/mysql/commit/0f3ddf233) Update deps (#606)
+- [1a5d7bd1](https://github.com/kubedb/mysql/commit/1a5d7bd13) Fix appbinding scheme (#603)
+- [c643ded9](https://github.com/kubedb/mysql/commit/c643ded94) Update deps (#605)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.2.0-rc.1](https://github.com/kubedb/mysql-archiver/releases/tag/v0.2.0-rc.1)
+
+- [d0fbef5](https://github.com/kubedb/mysql-archiver/commit/d0fbef5) Prepare for release v0.2.0-rc.1 (#19)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.19.0-rc.1](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.19.0-rc.1)
+
+- [40a2b6eb](https://github.com/kubedb/mysql-coordinator/commit/40a2b6eb) Prepare for release v0.19.0-rc.1 (#102)
+- [8b80958d](https://github.com/kubedb/mysql-coordinator/commit/8b80958d) Update deps (#101)
+- [df438239](https://github.com/kubedb/mysql-coordinator/commit/df438239) Update deps (#100)
+
+
+
+## [kubedb/mysql-csi-snapshotter-plugin](https://github.com/kubedb/mysql-csi-snapshotter-plugin)
+
+### [v0.2.0-rc.1](https://github.com/kubedb/mysql-csi-snapshotter-plugin/releases/tag/v0.2.0-rc.1)
+
+- [ac60bf4](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/ac60bf4) Prepare for release v0.2.0-rc.1 (#7)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.4.0-rc.1](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.4.0-rc.1)
+
+- [55897ab](https://github.com/kubedb/mysql-restic-plugin/commit/55897ab) Prepare for release v0.4.0-rc.1 (#23)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.19.0-rc.1](https://github.com/kubedb/mysql-router-init/releases/tag/v0.19.0-rc.1)
+
+- [6a5deed](https://github.com/kubedb/mysql-router-init/commit/6a5deed) Update deps (#40)
+- [0078f09](https://github.com/kubedb/mysql-router-init/commit/0078f09) Update deps (#39)
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.28.0-rc.1](https://github.com/kubedb/ops-manager/releases/tag/v0.28.0-rc.1)
+
+- [67604c6b](https://github.com/kubedb/ops-manager/commit/67604c6b0) Prepare for release v0.28.0-rc.1 (#535)
+- [283d07cf](https://github.com/kubedb/ops-manager/commit/283d07cf4) Update deps (#534)
+- [81a5f6e3](https://github.com/kubedb/ops-manager/commit/81a5f6e3c) Update deps (#533)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.28.0-rc.1](https://github.com/kubedb/percona-xtradb/releases/tag/v0.28.0-rc.1)
+
+- [b567db53](https://github.com/kubedb/percona-xtradb/commit/b567db53a) Prepare for release v0.28.0-rc.1 (#353)
+- [c0ddb330](https://github.com/kubedb/percona-xtradb/commit/c0ddb330b) Update deps (#352)
+- [d461df3e](https://github.com/kubedb/percona-xtradb/commit/d461df3ed) Fix appbinding scheme (#349)
+- [2752f7e3](https://github.com/kubedb/percona-xtradb/commit/2752f7e36) Update deps (#351)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.14.0-rc.1)
+
+- [da619fa3](https://github.com/kubedb/percona-xtradb-coordinator/commit/da619fa3) Prepare for release v0.14.0-rc.1 (#62)
+- [c39daf56](https://github.com/kubedb/percona-xtradb-coordinator/commit/c39daf56) Update deps (#61)
+- [42dc1a95](https://github.com/kubedb/percona-xtradb-coordinator/commit/42dc1a95) Update deps (#60)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.25.0-rc.1](https://github.com/kubedb/pg-coordinator/releases/tag/v0.25.0-rc.1)
+
+- [9a720273](https://github.com/kubedb/pg-coordinator/commit/9a720273) Prepare for release v0.25.0-rc.1 (#153)
+- [f103f1fc](https://github.com/kubedb/pg-coordinator/commit/f103f1fc) Update deps (#152)
+- [84b92d89](https://github.com/kubedb/pg-coordinator/commit/84b92d89) Update deps (#151)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.28.0-rc.1](https://github.com/kubedb/pgbouncer/releases/tag/v0.28.0-rc.1)
+
+- [0ca01e53](https://github.com/kubedb/pgbouncer/commit/0ca01e53) Prepare for release v0.28.0-rc.1 (#316)
+- [4b76d2cb](https://github.com/kubedb/pgbouncer/commit/4b76d2cb) Update deps (#315)
+- [f32676bc](https://github.com/kubedb/pgbouncer/commit/f32676bc) Update deps (#314)
+
+
+
+## [kubedb/pgpool](https://github.com/kubedb/pgpool)
+
+### [v0.0.3](https://github.com/kubedb/pgpool/releases/tag/v0.0.3)
+
+- [3696365](https://github.com/kubedb/pgpool/commit/3696365) Prepare for release v0.0.3 (#8)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.41.0-rc.1](https://github.com/kubedb/postgres/releases/tag/v0.41.0-rc.1)
+
+- [071b2645](https://github.com/kubedb/postgres/commit/071b26455) Prepare for release v0.41.0-rc.1 (#712)
+- [c9f1d5b6](https://github.com/kubedb/postgres/commit/c9f1d5b68) Update deps (#711)
+- [723fb80c](https://github.com/kubedb/postgres/commit/723fb80c0) Update deps (#710)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.2.0-rc.1](https://github.com/kubedb/postgres-archiver/releases/tag/v0.2.0-rc.1)
+
+- [8f66790](https://github.com/kubedb/postgres-archiver/commit/8f66790) Prepare for release v0.2.0-rc.1 (#20)
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.2.0-rc.1](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.2.0-rc.1)
+
+- [369c9a3](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/369c9a3) Prepare for release v0.2.0-rc.1 (#17)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.4.0-rc.1](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.4.0-rc.1)
+
+- [e5c6d21](https://github.com/kubedb/postgres-restic-plugin/commit/e5c6d21) Prepare for release v0.4.0-rc.1 (#16)
+
+
+
+## [kubedb/provider-aws](https://github.com/kubedb/provider-aws)
+
+### [v0.3.0-rc.1](https://github.com/kubedb/provider-aws/releases/tag/v0.3.0-rc.1)
+
+
+
+
+## [kubedb/provider-azure](https://github.com/kubedb/provider-azure)
+
+### [v0.3.0-rc.1](https://github.com/kubedb/provider-azure/releases/tag/v0.3.0-rc.1)
+
+
+
+
+## [kubedb/provider-gcp](https://github.com/kubedb/provider-gcp)
+
+### [v0.3.0-rc.1](https://github.com/kubedb/provider-gcp/releases/tag/v0.3.0-rc.1)
+
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.41.0-rc.1](https://github.com/kubedb/provisioner/releases/tag/v0.41.0-rc.1)
+
+- [bb8fd5aa](https://github.com/kubedb/provisioner/commit/bb8fd5aad) Prepare for release v0.41.0-rc.1 (#80)
+- [9d4fa8ab](https://github.com/kubedb/provisioner/commit/9d4fa8abd) Update deps (#79)
+- [154d0403](https://github.com/kubedb/provisioner/commit/154d0403b) Update deps (#78)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.28.0-rc.1](https://github.com/kubedb/proxysql/releases/tag/v0.28.0-rc.1)
+
+- [0ff6f90d](https://github.com/kubedb/proxysql/commit/0ff6f90d2) Prepare for release v0.28.0-rc.1 (#334)
+- [382d3283](https://github.com/kubedb/proxysql/commit/382d3283e) Update deps (#333)
+- [0b4da810](https://github.com/kubedb/proxysql/commit/0b4da8101) Update deps (#332)
+
+
+
+## [kubedb/rabbitmq](https://github.com/kubedb/rabbitmq)
+
+### [v0.0.3](https://github.com/kubedb/rabbitmq/releases/tag/v0.0.3)
+
+- [3f6ecf3f](https://github.com/kubedb/rabbitmq/commit/3f6ecf3f) Prepare for release v0.0.3 (#7)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.34.0-rc.1](https://github.com/kubedb/redis/releases/tag/v0.34.0-rc.1)
+
+- [5e171587](https://github.com/kubedb/redis/commit/5e171587) Prepare for release v0.34.0-rc.1 (#522)
+- [71665b9b](https://github.com/kubedb/redis/commit/71665b9b) Update deps (#521)
+- [302f1f19](https://github.com/kubedb/redis/commit/302f1f19) Update deps (#520)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.20.0-rc.1](https://github.com/kubedb/redis-coordinator/releases/tag/v0.20.0-rc.1)
+
+- [055ceaf1](https://github.com/kubedb/redis-coordinator/commit/055ceaf1) Prepare for release v0.20.0-rc.1 (#93)
+- [79575d26](https://github.com/kubedb/redis-coordinator/commit/79575d26) Update deps (#92)
+- [a5b4c4b4](https://github.com/kubedb/redis-coordinator/commit/a5b4c4b4) Update deps (#91)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.4.0-rc.1](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.4.0-rc.1)
+
+- [67a8942](https://github.com/kubedb/redis-restic-plugin/commit/67a8942) Prepare for release v0.4.0-rc.1 (#19)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.28.0-rc.1](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.28.0-rc.1)
+
+- [de39974e](https://github.com/kubedb/replication-mode-detector/commit/de39974e) Prepare for release v0.28.0-rc.1 (#257)
+- [e1ef5191](https://github.com/kubedb/replication-mode-detector/commit/e1ef5191) Update deps (#256)
+- [7b4e4149](https://github.com/kubedb/replication-mode-detector/commit/7b4e4149) Update deps (#255)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.17.0-rc.1](https://github.com/kubedb/schema-manager/releases/tag/v0.17.0-rc.1)
+
+- [c6293601](https://github.com/kubedb/schema-manager/commit/c6293601) Prepare for release v0.17.0-rc.1 (#101)
+- [09585d2f](https://github.com/kubedb/schema-manager/commit/09585d2f) Update deps (#100)
+- [d3a90582](https://github.com/kubedb/schema-manager/commit/d3a90582) Update deps (#99)
+
+
+
+## [kubedb/singlestore](https://github.com/kubedb/singlestore)
+
+### [v0.0.3](https://github.com/kubedb/singlestore/releases/tag/v0.0.3)
+
+- [fe72e9f](https://github.com/kubedb/singlestore/commit/fe72e9f) Prepare for release v0.0.3 (#10)
+
+
+
+## [kubedb/singlestore-coordinator](https://github.com/kubedb/singlestore-coordinator)
+
+### [v0.0.3](https://github.com/kubedb/singlestore-coordinator/releases/tag/v0.0.3)
+
+- [7b99fd6](https://github.com/kubedb/singlestore-coordinator/commit/7b99fd6) Prepare for release v0.0.3 (#4)
+
+
+
+## [kubedb/solr](https://github.com/kubedb/solr)
+
+### [v0.0.3](https://github.com/kubedb/solr/releases/tag/v0.0.3)
+
+- [c4ef8d7](https://github.com/kubedb/solr/commit/c4ef8d7) Prepare for release v0.0.3 (#7)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.26.0-rc.1](https://github.com/kubedb/tests/releases/tag/v0.26.0-rc.1)
+
+- [5a527051](https://github.com/kubedb/tests/commit/5a527051) Prepare for release v0.26.0-rc.1 (#299)
+- [03d71b6d](https://github.com/kubedb/tests/commit/03d71b6d) Update deps (#298)
+- [2d928008](https://github.com/kubedb/tests/commit/2d928008) Update deps (#297)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.17.0-rc.1](https://github.com/kubedb/ui-server/releases/tag/v0.17.0-rc.1)
+
+- [ed2c04e7](https://github.com/kubedb/ui-server/commit/ed2c04e7) Prepare for release v0.17.0-rc.1 (#109)
+- [645c4ac2](https://github.com/kubedb/ui-server/commit/645c4ac2) Update deps (#108)
+- [e75f0f9e](https://github.com/kubedb/ui-server/commit/e75f0f9e) Update deps (#107)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.17.0-rc.1](https://github.com/kubedb/webhook-server/releases/tag/v0.17.0-rc.1)
+
+- [a49ecca7](https://github.com/kubedb/webhook-server/commit/a49ecca7) Prepare for release v0.17.0-rc.1 (#94)
+- [5f8de57b](https://github.com/kubedb/webhook-server/commit/5f8de57b) Update deps (#93)
+- [8c22ce2d](https://github.com/kubedb/webhook-server/commit/8c22ce2d) Update deps (#92)
+
+
+
+## [kubedb/zookeeper](https://github.com/kubedb/zookeeper)
+
+### [v0.0.3](https://github.com/kubedb/zookeeper/releases/tag/v0.0.3)
+
+- [d77faed](https://github.com/kubedb/zookeeper/commit/d77faed) Prepare for release v0.0.3 (#7)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.1.28-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/83
Signed-off-by: 1gtm <1gtm@appscode.com>