### PR TITLE
Prepare for release v2024.2.14

### DIFF
--- a/docs/CHANGELOG-v2024.2.14.md
+++ b/docs/CHANGELOG-v2024.2.14.md
@@ -1,0 +1,504 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2024.2.14
+    name: Changelog-v2024.2.14
+    parent: welcome
+    weight: 20240214
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.2.14/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.2.14/
+---
+
+# KubeDB v2024.2.14 (2024-02-15)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.42.0](https://github.com/kubedb/apimachinery/releases/tag/v0.42.0)
+
+- [c7516aec](https://github.com/kubedb/apimachinery/commit/c7516aec0) Set default resource to Pgpool (#1155)
+- [f0a2324e](https://github.com/kubedb/apimachinery/commit/f0a2324ea) Set RuntimeDefault profile for k8s version >= 1.25 (#1154)
+- [099055e1](https://github.com/kubedb/apimachinery/commit/099055e1b) Update for release Stash@v2024.2.9-rc.0 (#1152)
+- [1aa5ad0e](https://github.com/kubedb/apimachinery/commit/1aa5ad0e3) Remove Default Capabilities for Postgres (#1146)
+- [24e6e985](https://github.com/kubedb/apimachinery/commit/24e6e9859) Fix Default Resources Issue (#1150)
+- [992de061](https://github.com/kubedb/apimachinery/commit/992de061d) Fix RabbitMQ default container resource (#1149)
+- [64f555c3](https://github.com/kubedb/apimachinery/commit/64f555c39) Fix SingleStore SatafulSet Name (#1147)
+- [3a9f337b](https://github.com/kubedb/apimachinery/commit/3a9f337b0) Add ZooKeeper SASL auth variables (#1141)
+- [07e7be0f](https://github.com/kubedb/apimachinery/commit/07e7be0f4) Add Redis Init Constants (#1148)
+- [aa33c6e8](https://github.com/kubedb/apimachinery/commit/aa33c6e8b) Add Monitoring API for RabbitMQ (#1139)
+- [89a65996](https://github.com/kubedb/apimachinery/commit/89a659963) Make the expansionMode required value (#1145)
+- [87259e66](https://github.com/kubedb/apimachinery/commit/87259e660) Update deps
+- [a0073eae](https://github.com/kubedb/apimachinery/commit/a0073eae1) Use v7 external-snapshotter (#1143)
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.27.0](https://github.com/kubedb/autoscaler/releases/tag/v0.27.0)
+
+- [b5882bd5](https://github.com/kubedb/autoscaler/commit/b5882bd5) Prepare for release v0.27.0 (#189)
+- [d06726d1](https://github.com/kubedb/autoscaler/commit/d06726d1) Update deps
+- [4e0c85cd](https://github.com/kubedb/autoscaler/commit/4e0c85cd) Make the expansionMode required (#188)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.42.0](https://github.com/kubedb/cli/releases/tag/v0.42.0)
+
+- [3b3001df](https://github.com/kubedb/cli/commit/3b3001df) Prepare for release v0.42.0 (#757)
+
+
+
+## [kubedb/crd-manager](https://github.com/kubedb/crd-manager)
+
+### [v0.0.5](https://github.com/kubedb/crd-manager/releases/tag/v0.0.5)
+
+- [4c2b767](https://github.com/kubedb/crd-manager/commit/4c2b767) Prepare for release v0.0.5 (#15)
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.18.0](https://github.com/kubedb/dashboard/releases/tag/v0.18.0)
+
+- [50d29c49](https://github.com/kubedb/dashboard/commit/50d29c49) Prepare for release v0.18.0 (#107)
+
+
+
+## [kubedb/db-client-go](https://github.com/kubedb/db-client-go)
+
+### [v0.0.11](https://github.com/kubedb/db-client-go/releases/tag/v0.0.11)
+
+- [fffdeec5](https://github.com/kubedb/db-client-go/commit/fffdeec5) Prepare for release v0.0.11 (#89)
+- [50462091](https://github.com/kubedb/db-client-go/commit/50462091) List spaces for kibana dashboard (#87)
+
+
+
+## [kubedb/druid](https://github.com/kubedb/druid)
+
+### [v0.0.5](https://github.com/kubedb/druid/releases/tag/v0.0.5)
+
+- [984932b](https://github.com/kubedb/druid/commit/984932b) Prepare for release v0.0.5 (#11)
+- [3f4b971](https://github.com/kubedb/druid/commit/3f4b971) Add daily workflow (#10)
+- [fc316de](https://github.com/kubedb/druid/commit/fc316de) Update druid container name (#9)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.42.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.42.0)
+
+- [8442a2bc](https://github.com/kubedb/elasticsearch/commit/8442a2bca) Prepare for release v0.42.0 (#705)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.5.0](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.5.0)
+
+- [028f9ca](https://github.com/kubedb/elasticsearch-restic-plugin/commit/028f9ca) Prepare for release v0.5.0 (#21)
+- [843f7f5](https://github.com/kubedb/elasticsearch-restic-plugin/commit/843f7f5) Remove set snapshot time method (#20)
+
+
+
+## [kubedb/ferretdb](https://github.com/kubedb/ferretdb)
+
+### [v0.0.5](https://github.com/kubedb/ferretdb/releases/tag/v0.0.5)
+
+- [16eb419](https://github.com/kubedb/ferretdb/commit/16eb419) Prepare for release v0.0.5 (#10)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2024.2.14](https://github.com/kubedb/installer/releases/tag/v2024.2.14)
+
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.13.0](https://github.com/kubedb/kafka/releases/tag/v0.13.0)
+
+- [8cb1975c](https://github.com/kubedb/kafka/commit/8cb1975c) Prepare for release v0.13.0 (#77)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.5.0](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.5.0)
+
+- [89311ad](https://github.com/kubedb/kubedb-manifest-plugin/commit/89311ad) Prepare for release v0.5.0 (#43)
+- [82e9a01](https://github.com/kubedb/kubedb-manifest-plugin/commit/82e9a01) Fix mariadb restore bug (#42)
+- [836cbc8](https://github.com/kubedb/kubedb-manifest-plugin/commit/836cbc8) Remove set snapshot time method (#41)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.26.0](https://github.com/kubedb/mariadb/releases/tag/v0.26.0)
+
+- [d8f0fa0c](https://github.com/kubedb/mariadb/commit/d8f0fa0c2) Prepare for release v0.26.0 (#259)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.2.0](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.2.0)
+
+- [1c0154e](https://github.com/kubedb/mariadb-archiver/commit/1c0154e) Prepare for release v0.2.0 (#9)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.22.0](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.22.0)
+
+- [8cecf8c5](https://github.com/kubedb/mariadb-coordinator/commit/8cecf8c5) Prepare for release v0.22.0 (#109)
+
+
+
+## [kubedb/mariadb-csi-snapshotter-plugin](https://github.com/kubedb/mariadb-csi-snapshotter-plugin)
+
+### [v0.2.0](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/releases/tag/v0.2.0)
+
+- [e19e8a6](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/e19e8a6) Prepare for release v0.2.0 (#12)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.35.0](https://github.com/kubedb/memcached/releases/tag/v0.35.0)
+
+- [7bb88826](https://github.com/kubedb/memcached/commit/7bb88826) Prepare for release v0.35.0 (#424)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.35.0](https://github.com/kubedb/mongodb/releases/tag/v0.35.0)
+
+- [30351cda](https://github.com/kubedb/mongodb/commit/30351cda8) Prepare for release v0.35.0 (#613)
+- [199918b7](https://github.com/kubedb/mongodb/commit/199918b70) Use volumesnapshot time to find pitr snapshot (#612)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.3.0](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.3.0)
+
+- [1af87b7](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/1af87b7) Prepare for release v0.3.0 (#17)
+- [9e4e191](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/9e4e191) Use volume snapshot time (#16)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.5.0](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.5.0)
+
+- [ff70017](https://github.com/kubedb/mongodb-restic-plugin/commit/ff70017) Prepare for release v0.5.0 (#28)
+- [e1e0c2d](https://github.com/kubedb/mongodb-restic-plugin/commit/e1e0c2d) Remove set snapshot time method (#27)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.35.0](https://github.com/kubedb/mysql/releases/tag/v0.35.0)
+
+- [e229f704](https://github.com/kubedb/mysql/commit/e229f7046) Prepare for release v0.35.0 (#611)
+- [eddafc3d](https://github.com/kubedb/mysql/commit/eddafc3db) Add TLS Support for Archiver Backup and Restore (#608)
+- [19c6df5a](https://github.com/kubedb/mysql/commit/19c6df5a1) Use volumesnapshot time + Fix bug (#610)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.3.0](https://github.com/kubedb/mysql-archiver/releases/tag/v0.3.0)
+
+- [4e4d8ee](https://github.com/kubedb/mysql-archiver/commit/4e4d8ee) Prepare for release v0.3.0 (#22)
+- [3feca82](https://github.com/kubedb/mysql-archiver/commit/3feca82) Add TLS Support for Archiver Backup
+- [d89a55f](https://github.com/kubedb/mysql-archiver/commit/d89a55f) Change certificate path
+- [a4de1f5](https://github.com/kubedb/mysql-archiver/commit/a4de1f5) Add tls support for archiver backup and restore
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.20.0](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.20.0)
+
+- [850c5ca7](https://github.com/kubedb/mysql-coordinator/commit/850c5ca7) Prepare for release v0.20.0 (#104)
+
+
+
+## [kubedb/mysql-csi-snapshotter-plugin](https://github.com/kubedb/mysql-csi-snapshotter-plugin)
+
+### [v0.3.0](https://github.com/kubedb/mysql-csi-snapshotter-plugin/releases/tag/v0.3.0)
+
+- [b1c5ff1](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/b1c5ff1) Prepare for release v0.3.0 (#11)
+- [e0f1b29](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/e0f1b29) Use volume snapshot creation time (#10)
+- [c8adb8b](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/c8adb8b) Set volumesnapshot time (#9)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.5.0](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.5.0)
+
+- [cdefd85](https://github.com/kubedb/mysql-restic-plugin/commit/cdefd85) Prepare for release v0.5.0 (#26)
+- [5a76022](https://github.com/kubedb/mysql-restic-plugin/commit/5a76022) Remove set snapshot time method (#25)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.20.0](https://github.com/kubedb/mysql-router-init/releases/tag/v0.20.0)
+
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.29.0](https://github.com/kubedb/ops-manager/releases/tag/v0.29.0)
+
+- [1a71ef8b](https://github.com/kubedb/ops-manager/commit/1a71ef8b1) Prepare for release v0.29.0 (#540)
+- [13d9a9c6](https://github.com/kubedb/ops-manager/commit/13d9a9c63) Update deps
+- [c8bbf908](https://github.com/kubedb/ops-manager/commit/c8bbf9080) Fix upgrade ops request for pg (#538)
+- [99fe7461](https://github.com/kubedb/ops-manager/commit/99fe7461f) Make the expansionMode required (#539)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.29.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.29.0)
+
+- [e25b687e](https://github.com/kubedb/percona-xtradb/commit/e25b687e0) Prepare for release v0.29.0 (#355)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.15.0](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.15.0)
+
+- [c75e8445](https://github.com/kubedb/percona-xtradb-coordinator/commit/c75e8445) Prepare for release v0.15.0 (#64)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.26.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.26.0)
+
+- [08f5dded](https://github.com/kubedb/pg-coordinator/commit/08f5dded) Prepare for release v0.26.0 (#155)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.29.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.29.0)
+
+- [632d6eaa](https://github.com/kubedb/pgbouncer/commit/632d6eaa) Prepare for release v0.29.0 (#318)
+
+
+
+## [kubedb/pgpool](https://github.com/kubedb/pgpool)
+
+### [v0.0.5](https://github.com/kubedb/pgpool/releases/tag/v0.0.5)
+
+- [c2e585a](https://github.com/kubedb/pgpool/commit/c2e585a) Prepare for release v0.0.5 (#14)
+- [f898a28](https://github.com/kubedb/pgpool/commit/f898a28) Fix default resource issue (#13)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.42.0](https://github.com/kubedb/postgres/releases/tag/v0.42.0)
+
+- [660e99f1](https://github.com/kubedb/postgres/commit/660e99f13) Prepare for release v0.42.0 (#717)
+- [91e2e653](https://github.com/kubedb/postgres/commit/91e2e653e) Use volumesnapshot time to find pitr snapshot (#716)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.3.0](https://github.com/kubedb/postgres-archiver/releases/tag/v0.3.0)
+
+- [ad9cbee](https://github.com/kubedb/postgres-archiver/commit/ad9cbee) Prepare for release v0.3.0 (#22)
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.3.0](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.3.0)
+
+- [d08a28d](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/d08a28d) Prepare for release v0.3.0 (#20)
+- [936c61d](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/936c61d) Set volumesnapshot time (#19)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.5.0](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.5.0)
+
+- [999bae4](https://github.com/kubedb/postgres-restic-plugin/commit/999bae4) Prepare for release v0.5.0 (#19)
+- [61f525f](https://github.com/kubedb/postgres-restic-plugin/commit/61f525f) Remove set snapshot time method (#18)
+
+
+
+## [kubedb/provider-aws](https://github.com/kubedb/provider-aws)
+
+### [v0.4.0](https://github.com/kubedb/provider-aws/releases/tag/v0.4.0)
+
+
+
+
+## [kubedb/provider-azure](https://github.com/kubedb/provider-azure)
+
+### [v0.4.0](https://github.com/kubedb/provider-azure/releases/tag/v0.4.0)
+
+
+
+
+## [kubedb/provider-gcp](https://github.com/kubedb/provider-gcp)
+
+### [v0.4.0](https://github.com/kubedb/provider-gcp/releases/tag/v0.4.0)
+
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.42.0](https://github.com/kubedb/provisioner/releases/tag/v0.42.0)
+
+- [31ce3b71](https://github.com/kubedb/provisioner/commit/31ce3b71a) Prepare for release v0.42.0 (#82)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.29.0](https://github.com/kubedb/proxysql/releases/tag/v0.29.0)
+
+- [e0bbc700](https://github.com/kubedb/proxysql/commit/e0bbc700d) Prepare for release v0.29.0 (#336)
+
+
+
+## [kubedb/rabbitmq](https://github.com/kubedb/rabbitmq)
+
+### [v0.0.5](https://github.com/kubedb/rabbitmq/releases/tag/v0.0.5)
+
+- [51824910](https://github.com/kubedb/rabbitmq/commit/51824910) Prepare for release v0.0.5 (#11)
+- [bc455b5c](https://github.com/kubedb/rabbitmq/commit/bc455b5c) Add support for Monitoring (#10)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.35.0](https://github.com/kubedb/redis/releases/tag/v0.35.0)
+
+- [1347a8db](https://github.com/kubedb/redis/commit/1347a8db) Prepare for release v0.35.0 (#526)
+- [d19f55d0](https://github.com/kubedb/redis/commit/d19f55d0) Fix Sentinel TLS (#525)
+- [ed7698cc](https://github.com/kubedb/redis/commit/ed7698cc) Add Init Script (#524)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.21.0](https://github.com/kubedb/redis-coordinator/releases/tag/v0.21.0)
+
+- [779d62d9](https://github.com/kubedb/redis-coordinator/commit/779d62d9) Prepare for release v0.21.0 (#95)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.5.0](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.5.0)
+
+- [621119a](https://github.com/kubedb/redis-restic-plugin/commit/621119a) Prepare for release v0.5.0 (#22)
+- [a4755fe](https://github.com/kubedb/redis-restic-plugin/commit/a4755fe) Remove set snapshot time method (#21)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.29.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.29.0)
+
+- [5c11f939](https://github.com/kubedb/replication-mode-detector/commit/5c11f939) Prepare for release v0.29.0 (#259)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.18.0](https://github.com/kubedb/schema-manager/releases/tag/v0.18.0)
+
+- [b1ff9ec4](https://github.com/kubedb/schema-manager/commit/b1ff9ec4) Prepare for release v0.18.0 (#103)
+
+
+
+## [kubedb/singlestore](https://github.com/kubedb/singlestore)
+
+### [v0.0.5](https://github.com/kubedb/singlestore/releases/tag/v0.0.5)
+
+- [cb62edf](https://github.com/kubedb/singlestore/commit/cb62edf) Prepare for release v0.0.5 (#13)
+- [00d05d3](https://github.com/kubedb/singlestore/commit/00d05d3) Fix StatefulSet Naming (#12)
+
+
+
+## [kubedb/singlestore-coordinator](https://github.com/kubedb/singlestore-coordinator)
+
+### [v0.0.5](https://github.com/kubedb/singlestore-coordinator/releases/tag/v0.0.5)
+
+- [bd572f5](https://github.com/kubedb/singlestore-coordinator/commit/bd572f5) Prepare for release v0.0.5 (#7)
+
+
+
+## [kubedb/solr](https://github.com/kubedb/solr)
+
+### [v0.0.5](https://github.com/kubedb/solr/releases/tag/v0.0.5)
+
+- [bfd0a91](https://github.com/kubedb/solr/commit/bfd0a91) Prepare for release v0.0.5 (#13)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.27.0](https://github.com/kubedb/tests/releases/tag/v0.27.0)
+
+- [66976892](https://github.com/kubedb/tests/commit/66976892) Prepare for release v0.27.0 (#308)
+- [6f489bb3](https://github.com/kubedb/tests/commit/6f489bb3) Update deps
+- [c6ed22ca](https://github.com/kubedb/tests/commit/c6ed22ca) Update for VolumeExpansion api changes (#307)
+- [35565778](https://github.com/kubedb/tests/commit/35565778) Remove SecurityConext for minio server
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.18.0](https://github.com/kubedb/ui-server/releases/tag/v0.18.0)
+
+- [09fb0fd2](https://github.com/kubedb/ui-server/commit/09fb0fd2) Prepare for release v0.18.0 (#111)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.18.0](https://github.com/kubedb/webhook-server/releases/tag/v0.18.0)
+
+- [2de37258](https://github.com/kubedb/webhook-server/commit/2de37258) Prepare for release v0.18.0 (#96)
+
+
+
+## [kubedb/zookeeper](https://github.com/kubedb/zookeeper)
+
+### [v0.0.5](https://github.com/kubedb/zookeeper/releases/tag/v0.0.5)
+
+- [23daf8b](https://github.com/kubedb/zookeeper/commit/23daf8b) Prepare for release v0.0.5 (#11)
+- [05a11e8](https://github.com/kubedb/zookeeper/commit/05a11e8) Fix ZooKeeper Standalone (#10)
+- [7712e98](https://github.com/kubedb/zookeeper/commit/7712e98) Add ZooKeeper Config (#9)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.2.14
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/85
Signed-off-by: 1gtm <1gtm@appscode.com>