### PR TITLE
Prepare for release v2024.3.9-rc.0

### DIFF
--- a/docs/CHANGELOG-v2024.3.9-rc.0.md
+++ b/docs/CHANGELOG-v2024.3.9-rc.0.md
@@ -1,0 +1,415 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2024.3.9-rc.0
+    name: Changelog-v2024.3.9-rc.0
+    parent: welcome
+    weight: 20240309
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.3.9-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.3.9-rc.0/
+---
+
+# KubeDB v2024.3.9-rc.0 (2024-03-10)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.43.0-rc.0](https://github.com/kubedb/apimachinery/releases/tag/v0.43.0-rc.0)
+
+- [bfad33d2](https://github.com/kubedb/apimachinery/commit/bfad33d2e) Add MariaDB Archiver API (#1170)
+- [403b7380](https://github.com/kubedb/apimachinery/commit/403b7380b) Add KafkaAutoscaler APIs (#1168)
+- [64fea9fd](https://github.com/kubedb/apimachinery/commit/64fea9fd1) Add Pgpool monitoring (#1160)
+- [9553f55b](https://github.com/kubedb/apimachinery/commit/9553f55ba) SingleStore Monitoring and UI (#1166)
+- [ea1e9882](https://github.com/kubedb/apimachinery/commit/ea1e9882d) Add service gateway info to db status (#1157)
+- [5b267a5c](https://github.com/kubedb/apimachinery/commit/5b267a5c4) Persist zookeeper digest credentials. (#1167)
+- [f45cf6e6](https://github.com/kubedb/apimachinery/commit/f45cf6e65) Set db-specific exporter port
+- [310f4e20](https://github.com/kubedb/apimachinery/commit/310f4e20d) Update client-go deps
+- [a28e6433](https://github.com/kubedb/apimachinery/commit/a28e6433f) Set the metrics-port for rabbitmq & zookeeper (#1165)
+- [429a2b10](https://github.com/kubedb/apimachinery/commit/429a2b10f) Fix solr helper condition. (#1164)
+- [5344c20e](https://github.com/kubedb/apimachinery/commit/5344c20e4) Update APIs for external dependency (#1162)
+- [40d63454](https://github.com/kubedb/apimachinery/commit/40d634543) Add Monitoring API (#1153)
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/autoscaler/releases/tag/v0.28.0-rc.0)
+
+- [8d58e694](https://github.com/kubedb/autoscaler/commit/8d58e694) Prepare for release v0.28.0-rc.0 (#191)
+- [9ef5c754](https://github.com/kubedb/autoscaler/commit/9ef5c754) Add Kafka Autoscaler (#190)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.43.0-rc.0](https://github.com/kubedb/cli/releases/tag/v0.43.0-rc.0)
+
+- [3410dd4f](https://github.com/kubedb/cli/commit/3410dd4f) Prepare for release v0.43.0-rc.0 (#760)
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.19.0-rc.0](https://github.com/kubedb/dashboard/releases/tag/v0.19.0-rc.0)
+
+- [35522dd1](https://github.com/kubedb/dashboard/commit/35522dd1) Prepare for release v0.19.0-rc.0 (#108)
+
+
+
+## [kubedb/db-client-go](https://github.com/kubedb/db-client-go)
+
+### [v0.0.12](https://github.com/kubedb/db-client-go/releases/tag/v0.0.12)
+
+- [c9d1ac6f](https://github.com/kubedb/db-client-go/commit/c9d1ac6f) Prepare for release v0.0.12 (#91)
+- [6da3a3e5](https://github.com/kubedb/db-client-go/commit/6da3a3e5) Pgpool backend reference change (#90)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.43.0-rc.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.43.0-rc.0)
+
+- [0c68e7b1](https://github.com/kubedb/elasticsearch/commit/0c68e7b10) Prepare for release v0.43.0-rc.0 (#707)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.6.0-rc.0](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.6.0-rc.0)
+
+- [de9ec11](https://github.com/kubedb/elasticsearch-restic-plugin/commit/de9ec11) Prepare for release v0.6.0-rc.0 (#22)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2024.3.9-rc.0](https://github.com/kubedb/installer/releases/tag/v2024.3.9-rc.0)
+
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.14.0-rc.0](https://github.com/kubedb/kafka/releases/tag/v0.14.0-rc.0)
+
+- [c7038c02](https://github.com/kubedb/kafka/commit/c7038c02) Prepare for release v0.14.0-rc.0 (#80)
+- [089c99b7](https://github.com/kubedb/kafka/commit/089c99b7) Fix Kafka node specific resource (#79)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.6.0-rc.0](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.6.0-rc.0)
+
+- [8f8df05](https://github.com/kubedb/kubedb-manifest-plugin/commit/8f8df05) Prepare for release v0.6.0-rc.0 (#44)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.27.0-rc.0](https://github.com/kubedb/mariadb/releases/tag/v0.27.0-rc.0)
+
+- [1389a6f8](https://github.com/kubedb/mariadb/commit/1389a6f85) Prepare for release v0.27.0-rc.0 (#260)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.3.0-rc.0](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.3.0-rc.0)
+
+- [4e9bb56](https://github.com/kubedb/mariadb-archiver/commit/4e9bb56) Prepare for release v0.3.0-rc.0 (#10)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.23.0-rc.0](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.23.0-rc.0)
+
+- [2380c6e5](https://github.com/kubedb/mariadb-coordinator/commit/2380c6e5) Prepare for release v0.23.0-rc.0 (#110)
+
+
+
+## [kubedb/mariadb-csi-snapshotter-plugin](https://github.com/kubedb/mariadb-csi-snapshotter-plugin)
+
+### [v0.3.0-rc.0](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/releases/tag/v0.3.0-rc.0)
+
+- [d385351](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/d385351) Prepare for release v0.3.0-rc.0 (#14)
+- [69c4631](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/69c4631) Set volumesnapshot time (#10)
+- [be6eba4](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/be6eba4) Refactor (#13)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.36.0-rc.0](https://github.com/kubedb/memcached/releases/tag/v0.36.0-rc.0)
+
+- [2a54bc53](https://github.com/kubedb/memcached/commit/2a54bc53) Prepare for release v0.36.0-rc.0 (#425)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.36.0-rc.0](https://github.com/kubedb/mongodb/releases/tag/v0.36.0-rc.0)
+
+- [58e27888](https://github.com/kubedb/mongodb/commit/58e278887) Prepare for release v0.36.0-rc.0 (#617)
+- [1ead0453](https://github.com/kubedb/mongodb/commit/1ead04536) ignore mongos repl mode detector (#616)
+- [c0797130](https://github.com/kubedb/mongodb/commit/c0797130c) Add replication mode detector container for shard (#614)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.4.0-rc.0](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.4.0-rc.0)
+
+- [83b0a1d](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/83b0a1d) Prepare for release v0.4.0-rc.0 (#19)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.6.0-rc.0](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.6.0-rc.0)
+
+- [8f5c92d](https://github.com/kubedb/mongodb-restic-plugin/commit/8f5c92d) Prepare for release v0.6.0-rc.0 (#31)
+- [e790456](https://github.com/kubedb/mongodb-restic-plugin/commit/e790456) fix order of lock and unlock secondary (#30)
+- [a0281df](https://github.com/kubedb/mongodb-restic-plugin/commit/a0281df) Fix component-name issue for sharded cluster (#29)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.36.0-rc.0](https://github.com/kubedb/mysql/releases/tag/v0.36.0-rc.0)
+
+- [7e213885](https://github.com/kubedb/mysql/commit/7e2138855) Prepare for release v0.36.0-rc.0 (#613)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.4.0-rc.0](https://github.com/kubedb/mysql-archiver/releases/tag/v0.4.0-rc.0)
+
+- [00c0f0e](https://github.com/kubedb/mysql-archiver/commit/00c0f0e) Prepare for release v0.4.0-rc.0 (#24)
+- [9fe9cd2](https://github.com/kubedb/mysql-archiver/commit/9fe9cd2) Fix Multiple Timeline not Restoring Issue (#23)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.21.0-rc.0](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.21.0-rc.0)
+
+- [9da51c98](https://github.com/kubedb/mysql-coordinator/commit/9da51c98) Prepare for release v0.21.0-rc.0 (#105)
+
+
+
+## [kubedb/mysql-csi-snapshotter-plugin](https://github.com/kubedb/mysql-csi-snapshotter-plugin)
+
+### [v0.4.0-rc.0](https://github.com/kubedb/mysql-csi-snapshotter-plugin/releases/tag/v0.4.0-rc.0)
+
+- [718dbc2](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/718dbc2) Prepare for release v0.4.0-rc.0 (#12)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.6.0-rc.0](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.6.0-rc.0)
+
+- [3dcb7b8](https://github.com/kubedb/mysql-restic-plugin/commit/3dcb7b8) Prepare for release v0.6.0-rc.0 (#28)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.21.0-rc.0](https://github.com/kubedb/mysql-router-init/releases/tag/v0.21.0-rc.0)
+
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.30.0-rc.0](https://github.com/kubedb/ops-manager/releases/tag/v0.30.0-rc.0)
+
+- [f6c944e9](https://github.com/kubedb/ops-manager/commit/f6c944e92) Prepare for release v0.30.0-rc.0 (#542)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.30.0-rc.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.30.0-rc.0)
+
+- [d69b6040](https://github.com/kubedb/percona-xtradb/commit/d69b6040c) Prepare for release v0.30.0-rc.0 (#357)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.16.0-rc.0](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.16.0-rc.0)
+
+- [93f7f940](https://github.com/kubedb/percona-xtradb-coordinator/commit/93f7f940) Prepare for release v0.16.0-rc.0 (#65)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.27.0-rc.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.27.0-rc.0)
+
+- [d1f6731b](https://github.com/kubedb/pg-coordinator/commit/d1f6731b) Prepare for release v0.27.0-rc.0 (#157)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.30.0-rc.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.30.0-rc.0)
+
+- [b5e9f18b](https://github.com/kubedb/pgbouncer/commit/b5e9f18b) Prepare for release v0.30.0-rc.0 (#319)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.43.0-rc.0](https://github.com/kubedb/postgres/releases/tag/v0.43.0-rc.0)
+
+- [6b772e80](https://github.com/kubedb/postgres/commit/6b772e809) Prepare for release v0.43.0-rc.0 (#720)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.4.0-rc.0](https://github.com/kubedb/postgres-archiver/releases/tag/v0.4.0-rc.0)
+
+- [95a3f5a](https://github.com/kubedb/postgres-archiver/commit/95a3f5a) Prepare for release v0.4.0-rc.0 (#23)
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.4.0-rc.0](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.4.0-rc.0)
+
+- [7dfe005](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/7dfe005) Prepare for release v0.4.0-rc.0 (#21)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.6.0-rc.0](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.6.0-rc.0)
+
+- [ed4a89c](https://github.com/kubedb/postgres-restic-plugin/commit/ed4a89c) Prepare for release v0.6.0-rc.0 (#20)
+
+
+
+## [kubedb/provider-aws](https://github.com/kubedb/provider-aws)
+
+### [v0.5.0-rc.0](https://github.com/kubedb/provider-aws/releases/tag/v0.5.0-rc.0)
+
+
+
+
+## [kubedb/provider-azure](https://github.com/kubedb/provider-azure)
+
+### [v0.5.0-rc.0](https://github.com/kubedb/provider-azure/releases/tag/v0.5.0-rc.0)
+
+
+
+
+## [kubedb/provider-gcp](https://github.com/kubedb/provider-gcp)
+
+### [v0.5.0-rc.0](https://github.com/kubedb/provider-gcp/releases/tag/v0.5.0-rc.0)
+
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.43.0-rc.0](https://github.com/kubedb/provisioner/releases/tag/v0.43.0-rc.0)
+
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.30.0-rc.0](https://github.com/kubedb/proxysql/releases/tag/v0.30.0-rc.0)
+
+- [b2e583b8](https://github.com/kubedb/proxysql/commit/b2e583b8a) Prepare for release v0.30.0-rc.0 (#337)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.36.0-rc.0](https://github.com/kubedb/redis/releases/tag/v0.36.0-rc.0)
+
+- [62fb984d](https://github.com/kubedb/redis/commit/62fb984dc) Prepare for release v0.36.0-rc.0 (#528)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.22.0-rc.0](https://github.com/kubedb/redis-coordinator/releases/tag/v0.22.0-rc.0)
+
+- [71f84047](https://github.com/kubedb/redis-coordinator/commit/71f84047) Prepare for release v0.22.0-rc.0 (#96)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.6.0-rc.0](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.6.0-rc.0)
+
+- [0abdc75](https://github.com/kubedb/redis-restic-plugin/commit/0abdc75) Prepare for release v0.6.0-rc.0 (#23)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.30.0-rc.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.30.0-rc.0)
+
+- [82431296](https://github.com/kubedb/replication-mode-detector/commit/82431296) Prepare for release v0.30.0-rc.0 (#261)
+- [397f06c4](https://github.com/kubedb/replication-mode-detector/commit/397f06c4) Add label for shard (#260)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.19.0-rc.0](https://github.com/kubedb/schema-manager/releases/tag/v0.19.0-rc.0)
+
+- [0b11c0ca](https://github.com/kubedb/schema-manager/commit/0b11c0ca) Prepare for release v0.19.0-rc.0 (#104)
+
+
+
+## [kubedb/singlestore](https://github.com/kubedb/singlestore)
+
+### [v0.0.6](https://github.com/kubedb/singlestore/releases/tag/v0.0.6)
+
+- [363401d](https://github.com/kubedb/singlestore/commit/363401d) Prepare for release v0.0.6 (#15)
+- [92ddddd](https://github.com/kubedb/singlestore/commit/92ddddd) Add monitoring support (#14)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.28.0-rc.0](https://github.com/kubedb/tests/releases/tag/v0.28.0-rc.0)
+
+- [79f0cad6](https://github.com/kubedb/tests/commit/79f0cad6) Prepare for release v0.28.0-rc.0 (#310)
+- [ed951ee1](https://github.com/kubedb/tests/commit/ed951ee1) MongoDB reprovision test (#309)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.19.0-rc.0](https://github.com/kubedb/ui-server/releases/tag/v0.19.0-rc.0)
+
+- [f7a7ee62](https://github.com/kubedb/ui-server/commit/f7a7ee62) Prepare for release v0.19.0-rc.0 (#113)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.19.0-rc.0](https://github.com/kubedb/webhook-server/releases/tag/v0.19.0-rc.0)
+
+- [c9031073](https://github.com/kubedb/webhook-server/commit/c9031073) Prepare for release v0.19.0-rc.0 (#97)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.3.9-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/86
Signed-off-by: 1gtm <1gtm@appscode.com>