### PR TITLE
Prepare for release v2024.8.14-rc.3

### DIFF
--- a/docs/CHANGELOG-v2024.8.14-rc.3.md
+++ b/docs/CHANGELOG-v2024.8.14-rc.3.md
@@ -1,0 +1,593 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2024.8.14-rc.3
+    name: Changelog-v2024.8.14-rc.3
+    parent: welcome
+    weight: 20240814
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.8.14-rc.3/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.8.14-rc.3/
+---
+
+# KubeDB v2024.8.14-rc.3 (2024-08-15)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.47.0-rc.3](https://github.com/kubedb/apimachinery/releases/tag/v0.47.0-rc.3)
+
+- [4b2e4872](https://github.com/kubedb/apimachinery/commit/4b2e48726) Add Halted API Field in ProxySQL and Pgbouncher (#1288)
+- [f7813626](https://github.com/kubedb/apimachinery/commit/f78136264) SingleStore Ops-Request API (#1287)
+- [b7bee768](https://github.com/kubedb/apimachinery/commit/b7bee7681) Test against k8s 1.31 (#1285)
+- [92ab030c](https://github.com/kubedb/apimachinery/commit/92ab030c5) Add DisabledProtocols API for RabbitMQ (#1282)
+- [83f69191](https://github.com/kubedb/apimachinery/commit/83f69191f) Add constants for RM additional plugins (#1280)
+- [beb194a1](https://github.com/kubedb/apimachinery/commit/beb194a15) Add Kafka `halted` field & some ops helpers (#1279)
+- [7334833b](https://github.com/kubedb/apimachinery/commit/7334833b5) Set the catagories correctly (#1277)
+- [ddbf74f3](https://github.com/kubedb/apimachinery/commit/ddbf74f33) Add missing opsRequests (#1276)
+- [6402035d](https://github.com/kubedb/apimachinery/commit/6402035de) Fix petset patch issue (#1275)
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.32.0-rc.3](https://github.com/kubedb/autoscaler/releases/tag/v0.32.0-rc.3)
+
+- [8b1eb269](https://github.com/kubedb/autoscaler/commit/8b1eb269) Prepare for release v0.32.0-rc.3 (#218)
+- [7c61bf9e](https://github.com/kubedb/autoscaler/commit/7c61bf9e) Implement autoscaling for pgbouncer (#214)
+- [0ce4541c](https://github.com/kubedb/autoscaler/commit/0ce4541c) Add Readinessgate Condition (#216)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.47.0-rc.3](https://github.com/kubedb/cli/releases/tag/v0.47.0-rc.3)
+
+- [39e448d9](https://github.com/kubedb/cli/commit/39e448d9) Prepare for release v0.47.0-rc.3 (#775)
+
+
+
+## [kubedb/clickhouse](https://github.com/kubedb/clickhouse)
+
+### [v0.2.0-rc.3](https://github.com/kubedb/clickhouse/releases/tag/v0.2.0-rc.3)
+
+- [e722214a](https://github.com/kubedb/clickhouse/commit/e722214a) Prepare for release v0.2.0-rc.3 (#14)
+- [d67b6596](https://github.com/kubedb/clickhouse/commit/d67b6596) Improve logs (#13)
+- [1a78915c](https://github.com/kubedb/clickhouse/commit/1a78915c) Update webhook server (#11)
+- [782c361e](https://github.com/kubedb/clickhouse/commit/782c361e) Fix unnecessary patch (#10)
+
+
+
+## [kubedb/crd-manager](https://github.com/kubedb/crd-manager)
+
+### [v0.2.0-rc.3](https://github.com/kubedb/crd-manager/releases/tag/v0.2.0-rc.3)
+
+
+
+
+## [kubedb/dashboard](https://github.com/kubedb/dashboard)
+
+### [v0.23.0-rc.3](https://github.com/kubedb/dashboard/releases/tag/v0.23.0-rc.3)
+
+- [838503eb](https://github.com/kubedb/dashboard/commit/838503eb) Prepare for release v0.23.0-rc.3 (#124)
+- [08560e23](https://github.com/kubedb/dashboard/commit/08560e23) Use serviceTemplate provided specs for primary svc (#122)
+
+
+
+## [kubedb/dashboard-restic-plugin](https://github.com/kubedb/dashboard-restic-plugin)
+
+### [v0.5.0-rc.3](https://github.com/kubedb/dashboard-restic-plugin/releases/tag/v0.5.0-rc.3)
+
+- [0d547b1](https://github.com/kubedb/dashboard-restic-plugin/commit/0d547b1) Prepare for release v0.5.0-rc.3 (#17)
+
+
+
+## [kubedb/db-client-go](https://github.com/kubedb/db-client-go)
+
+### [v0.2.0-rc.3](https://github.com/kubedb/db-client-go/releases/tag/v0.2.0-rc.3)
+
+- [b4a5b756](https://github.com/kubedb/db-client-go/commit/b4a5b756) Prepare for release v0.2.0-rc.3 (#131)
+- [f17f15a5](https://github.com/kubedb/db-client-go/commit/f17f15a5) Update log verbosity level (#127)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.47.0-rc.3](https://github.com/kubedb/elasticsearch/releases/tag/v0.47.0-rc.3)
+
+- [6e5a7875](https://github.com/kubedb/elasticsearch/commit/6e5a78758) Prepare for release v0.47.0-rc.3 (#731)
+- [14079024](https://github.com/kubedb/elasticsearch/commit/140790248) Refactor Elasticsearch webhook server (#729)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.10.0-rc.3](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.10.0-rc.3)
+
+- [e6aacd8](https://github.com/kubedb/elasticsearch-restic-plugin/commit/e6aacd8) Prepare for release v0.10.0-rc.3 (#39)
+
+
+
+## [kubedb/ferretdb](https://github.com/kubedb/ferretdb)
+
+### [v0.2.0-rc.3](https://github.com/kubedb/ferretdb/releases/tag/v0.2.0-rc.3)
+
+- [7c5d6d1c](https://github.com/kubedb/ferretdb/commit/7c5d6d1c) Prepare for release v0.2.0-rc.3 (#41)
+- [b6223cab](https://github.com/kubedb/ferretdb/commit/b6223cab) Test against k8s 1.31 (#39)
+- [933d5b0d](https://github.com/kubedb/ferretdb/commit/933d5b0d) update server (#37)
+- [a587c29d](https://github.com/kubedb/ferretdb/commit/a587c29d) pass context properly (#38)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2024.8.14-rc.3](https://github.com/kubedb/installer/releases/tag/v2024.8.14-rc.3)
+
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.18.0-rc.3](https://github.com/kubedb/kafka/releases/tag/v0.18.0-rc.3)
+
+- [61da1711](https://github.com/kubedb/kafka/commit/61da1711) Prepare for release v0.18.0-rc.3 (#104)
+- [0d676702](https://github.com/kubedb/kafka/commit/0d676702) Test against k8s 1.31 (#102)
+- [f826ea35](https://github.com/kubedb/kafka/commit/f826ea35) Update ReadinessGate Conditions and remove unncessary logs (#101)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.10.0-rc.3](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.10.0-rc.3)
+
+- [281d889](https://github.com/kubedb/kubedb-manifest-plugin/commit/281d889) Prepare for release v0.10.0-rc.3 (#63)
+- [5053a2b](https://github.com/kubedb/kubedb-manifest-plugin/commit/5053a2b) Implement MSSQLServer manifest backup and restore (#59)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.31.0-rc.3](https://github.com/kubedb/mariadb/releases/tag/v0.31.0-rc.3)
+
+- [211fad73](https://github.com/kubedb/mariadb/commit/211fad731) Prepare for release v0.31.0-rc.3 (#280)
+- [00d8723b](https://github.com/kubedb/mariadb/commit/00d8723bf) Test against k8s 1.31 (#278)
+- [c21a2238](https://github.com/kubedb/mariadb/commit/c21a22387) Mongodb Alike Archiver related changes, refactor webhook (#277)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.7.0-rc.3](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.7.0-rc.3)
+
+- [4b3a6003](https://github.com/kubedb/mariadb-archiver/commit/4b3a6003) Prepare for release v0.7.0-rc.3 (#26)
+- [c7230b61](https://github.com/kubedb/mariadb-archiver/commit/c7230b61) Remove SafeToBootstrapInGrastateFile from Archiver Backup (#25)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.27.0-rc.3](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.27.0-rc.3)
+
+- [53d96b8e](https://github.com/kubedb/mariadb-coordinator/commit/53d96b8e) Prepare for release v0.27.0-rc.3 (#125)
+- [b5384a99](https://github.com/kubedb/mariadb-coordinator/commit/b5384a99) Fix Archiver Restore Issue (#123)
+
+
+
+## [kubedb/mariadb-csi-snapshotter-plugin](https://github.com/kubedb/mariadb-csi-snapshotter-plugin)
+
+### [v0.7.0-rc.3](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/releases/tag/v0.7.0-rc.3)
+
+- [cdd76b1](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/cdd76b1) Prepare for release v0.7.0-rc.3 (#28)
+
+
+
+## [kubedb/mariadb-restic-plugin](https://github.com/kubedb/mariadb-restic-plugin)
+
+### [v0.5.0-rc.3](https://github.com/kubedb/mariadb-restic-plugin/releases/tag/v0.5.0-rc.3)
+
+- [21c1331](https://github.com/kubedb/mariadb-restic-plugin/commit/21c1331) Prepare for release v0.5.0-rc.3 (#21)
+- [4d22fb4](https://github.com/kubedb/mariadb-restic-plugin/commit/4d22fb4) Wait for ready condition instead Provisioned condition (#19)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.40.0-rc.3](https://github.com/kubedb/memcached/releases/tag/v0.40.0-rc.3)
+
+- [1a3ed68b](https://github.com/kubedb/memcached/commit/1a3ed68b8) Prepare for release v0.40.0-rc.3 (#462)
+- [93626b1a](https://github.com/kubedb/memcached/commit/93626b1ab) Fix DeletionPolicy Halt (#461)
+- [7ddfc3eb](https://github.com/kubedb/memcached/commit/7ddfc3eb1) Test against k8s 1.31 (#459)
+- [c5a4d6a8](https://github.com/kubedb/memcached/commit/c5a4d6a85) Refactor Memcached Webhook Server (#458)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.40.0-rc.3](https://github.com/kubedb/mongodb/releases/tag/v0.40.0-rc.3)
+
+- [490947fc](https://github.com/kubedb/mongodb/commit/490947fc6) Prepare for release v0.40.0-rc.3 (#647)
+- [9308c2fd](https://github.com/kubedb/mongodb/commit/9308c2fd3) Test against k8s 1.31 (#645)
+- [ec0fe7fe](https://github.com/kubedb/mongodb/commit/ec0fe7feb) Refactor MongoDB webhook server (#644)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.8.0-rc.3](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.8.0-rc.3)
+
+- [4fd050d](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/4fd050d) Prepare for release v0.8.0-rc.3 (#33)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.10.0-rc.3](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.10.0-rc.3)
+
+- [5bedb88](https://github.com/kubedb/mongodb-restic-plugin/commit/5bedb88) Prepare for release v0.10.0-rc.3 (#57)
+- [82148eb](https://github.com/kubedb/mongodb-restic-plugin/commit/82148eb) Fix issues of MongoDB 5.x+ and 6.x+ TLS (#55)
+
+
+
+## [kubedb/mssql-coordinator](https://github.com/kubedb/mssql-coordinator)
+
+### [v0.2.0-rc.3](https://github.com/kubedb/mssql-coordinator/releases/tag/v0.2.0-rc.3)
+
+- [2bbe790a](https://github.com/kubedb/mssql-coordinator/commit/2bbe790a) Prepare for release v0.2.0-rc.3 (#14)
+
+
+
+## [kubedb/mssqlserver](https://github.com/kubedb/mssqlserver)
+
+### [v0.2.0-rc.3](https://github.com/kubedb/mssqlserver/releases/tag/v0.2.0-rc.3)
+
+- [5937734a](https://github.com/kubedb/mssqlserver/commit/5937734a) Prepare for release v0.2.0-rc.3 (#23)
+- [cc70bf74](https://github.com/kubedb/mssqlserver/commit/cc70bf74) Add MSSQL Server Monitoring Support (#11)
+- [00f23687](https://github.com/kubedb/mssqlserver/commit/00f23687) Add PITR backup and restore support by using WAlG (#20)
+
+
+
+## [kubedb/mssqlserver-archiver](https://github.com/kubedb/mssqlserver-archiver)
+
+### [v0.1.0-rc.3](https://github.com/kubedb/mssqlserver-archiver/releases/tag/v0.1.0-rc.3)
+
+- [7c867e6](https://github.com/kubedb/mssqlserver-archiver/commit/7c867e6) Prepare for release v0.1.0-rc.3 (#2)
+
+
+
+## [kubedb/mssqlserver-walg-plugin](https://github.com/kubedb/mssqlserver-walg-plugin)
+
+### [v0.1.0-rc.3](https://github.com/kubedb/mssqlserver-walg-plugin/releases/tag/v0.1.0-rc.3)
+
+- [47b5046](https://github.com/kubedb/mssqlserver-walg-plugin/commit/47b5046) Prepare for release v0.1.0-rc.3 (#4)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.40.0-rc.3](https://github.com/kubedb/mysql/releases/tag/v0.40.0-rc.3)
+
+- [715b4713](https://github.com/kubedb/mysql/commit/715b4713d) Prepare for release v0.40.0-rc.3 (#636)
+- [46d5c62c](https://github.com/kubedb/mysql/commit/46d5c62ce) Test against k8s 1.31 (#634)
+- [42a90ae7](https://github.com/kubedb/mysql/commit/42a90ae77) Refactor MySQL Webhook Server (#633)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.8.0-rc.3](https://github.com/kubedb/mysql-archiver/releases/tag/v0.8.0-rc.3)
+
+- [2d439cb5](https://github.com/kubedb/mysql-archiver/commit/2d439cb5) Prepare for release v0.8.0-rc.3 (#39)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.25.0-rc.3](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.25.0-rc.3)
+
+- [486d06e4](https://github.com/kubedb/mysql-coordinator/commit/486d06e4) Prepare for release v0.25.0-rc.3 (#121)
+
+
+
+## [kubedb/mysql-csi-snapshotter-plugin](https://github.com/kubedb/mysql-csi-snapshotter-plugin)
+
+### [v0.8.0-rc.3](https://github.com/kubedb/mysql-csi-snapshotter-plugin/releases/tag/v0.8.0-rc.3)
+
+- [6136a15](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/6136a15) Prepare for release v0.8.0-rc.3 (#26)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.10.0-rc.3](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.10.0-rc.3)
+
+- [79412f1](https://github.com/kubedb/mysql-restic-plugin/commit/79412f1) Prepare for release v0.10.0-rc.3 (#50)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.25.0-rc.3](https://github.com/kubedb/mysql-router-init/releases/tag/v0.25.0-rc.3)
+
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.34.0-rc.3](https://github.com/kubedb/ops-manager/releases/tag/v0.34.0-rc.3)
+
+- [483ae746](https://github.com/kubedb/ops-manager/commit/483ae746e) Prepare for release v0.34.0-rc.3 (#623)
+- [24cb3616](https://github.com/kubedb/ops-manager/commit/24cb3616b) Fix reconfigure ops request for postgres (#615)
+- [f39cc6be](https://github.com/kubedb/ops-manager/commit/f39cc6be4) SingleStore VersionUpdate, Reconfigure TLS, Horizontal Scale Ops-Request (#622)
+- [909661fe](https://github.com/kubedb/ops-manager/commit/909661fea) Test against k8s 1.31 (#620)
+- [0c8104dc](https://github.com/kubedb/ops-manager/commit/0c8104dca) Add exporter container in vertical scaling (#619)
+- [efd37edd](https://github.com/kubedb/ops-manager/commit/efd37edd9) Add readiness gate condition before webhook server starts (#617)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.34.0-rc.3](https://github.com/kubedb/percona-xtradb/releases/tag/v0.34.0-rc.3)
+
+- [43b7e218](https://github.com/kubedb/percona-xtradb/commit/43b7e2180) Prepare for release v0.34.0-rc.3 (#378)
+- [99a0cb4b](https://github.com/kubedb/percona-xtradb/commit/99a0cb4b6) Test against k8s 1.31 (#376)
+- [bdb89e11](https://github.com/kubedb/percona-xtradb/commit/bdb89e115) Refactor Wekhook (#375)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.20.0-rc.3](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.20.0-rc.3)
+
+- [c15480fc](https://github.com/kubedb/percona-xtradb-coordinator/commit/c15480fc) Prepare for release v0.20.0-rc.3 (#79)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.31.0-rc.3](https://github.com/kubedb/pg-coordinator/releases/tag/v0.31.0-rc.3)
+
+- [6f7c70bc](https://github.com/kubedb/pg-coordinator/commit/6f7c70bc) Prepare for release v0.31.0-rc.3 (#171)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.34.0-rc.3](https://github.com/kubedb/pgbouncer/releases/tag/v0.34.0-rc.3)
+
+- [98209762](https://github.com/kubedb/pgbouncer/commit/98209762) Prepare for release v0.34.0-rc.3 (#343)
+- [c777b369](https://github.com/kubedb/pgbouncer/commit/c777b369) Use common DeletionPolicy
+- [2984f4f6](https://github.com/kubedb/pgbouncer/commit/2984f4f6) Test against k8s 1.31 (#341)
+- [fe1786b2](https://github.com/kubedb/pgbouncer/commit/fe1786b2) refactor webhook server (#340)
+
+
+
+## [kubedb/pgpool](https://github.com/kubedb/pgpool)
+
+### [v0.2.0-rc.3](https://github.com/kubedb/pgpool/releases/tag/v0.2.0-rc.3)
+
+- [8c6ad096](https://github.com/kubedb/pgpool/commit/8c6ad096) Prepare for release v0.2.0-rc.3 (#44)
+- [4763f499](https://github.com/kubedb/pgpool/commit/4763f499) Test against k8s 1.31 (#41)
+- [b21f97fc](https://github.com/kubedb/pgpool/commit/b21f97fc) Update webhook server (#40)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.47.0-rc.3](https://github.com/kubedb/postgres/releases/tag/v0.47.0-rc.3)
+
+- [3cce86fd](https://github.com/kubedb/postgres/commit/3cce86fd5) Prepare for release v0.47.0-rc.3 (#749)
+- [ae6fe1b9](https://github.com/kubedb/postgres/commit/ae6fe1b9b) Test against k8s 1.31 (#747)
+- [53972b4f](https://github.com/kubedb/postgres/commit/53972b4f6) Mongodb Alike Archiver related changes (#746)
+- [9c39791e](https://github.com/kubedb/postgres/commit/9c39791e3) Refactor Postgres With changes from Webhook-server (#745)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.8.0-rc.3](https://github.com/kubedb/postgres-archiver/releases/tag/v0.8.0-rc.3)
+
+- [60125c8e](https://github.com/kubedb/postgres-archiver/commit/60125c8e) Prepare for release v0.8.0-rc.3 (#37)
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.8.0-rc.3](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.8.0-rc.3)
+
+- [68f40d9](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/68f40d9) Prepare for release v0.8.0-rc.3 (#35)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.10.0-rc.3](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.10.0-rc.3)
+
+- [c1e0b54](https://github.com/kubedb/postgres-restic-plugin/commit/c1e0b54) Prepare for release v0.10.0-rc.3 (#44)
+- [28ee1da](https://github.com/kubedb/postgres-restic-plugin/commit/28ee1da) Wait for ready condition instead Provisioned condition (#42)
+
+
+
+## [kubedb/provider-aws](https://github.com/kubedb/provider-aws)
+
+### [v0.9.0-rc.3](https://github.com/kubedb/provider-aws/releases/tag/v0.9.0-rc.3)
+
+
+
+
+## [kubedb/provider-azure](https://github.com/kubedb/provider-azure)
+
+### [v0.9.0-rc.3](https://github.com/kubedb/provider-azure/releases/tag/v0.9.0-rc.3)
+
+
+
+
+## [kubedb/provider-gcp](https://github.com/kubedb/provider-gcp)
+
+### [v0.9.0-rc.3](https://github.com/kubedb/provider-gcp/releases/tag/v0.9.0-rc.3)
+
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.47.0-rc.3](https://github.com/kubedb/provisioner/releases/tag/v0.47.0-rc.3)
+
+- [4e8b6d9f](https://github.com/kubedb/provisioner/commit/4e8b6d9f7) Prepare for release v0.47.0-rc.3 (#110)
+- [305458e1](https://github.com/kubedb/provisioner/commit/305458e14) Update deps
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.34.0-rc.3](https://github.com/kubedb/proxysql/releases/tag/v0.34.0-rc.3)
+
+- [67116493](https://github.com/kubedb/proxysql/commit/671164930) Prepare for release v0.34.0-rc.3 (#356)
+- [331ad2ae](https://github.com/kubedb/proxysql/commit/331ad2ae1) Test against k8s 1.31 (#353)
+- [c378175f](https://github.com/kubedb/proxysql/commit/c378175f8) Webhook Server Refactor (#352)
+
+
+
+## [kubedb/rabbitmq](https://github.com/kubedb/rabbitmq)
+
+### [v0.2.0-rc.3](https://github.com/kubedb/rabbitmq/releases/tag/v0.2.0-rc.3)
+
+- [9e2d1b30](https://github.com/kubedb/rabbitmq/commit/9e2d1b30) Prepare for release v0.2.0-rc.3 (#42)
+- [ea18918d](https://github.com/kubedb/rabbitmq/commit/ea18918d) Update configurations and ports for DisableProtocol Support (#40)
+- [a8f7d00d](https://github.com/kubedb/rabbitmq/commit/a8f7d00d) Add protocol plugins configurations and refactor webhook server (#39)
+- [d0e559c6](https://github.com/kubedb/rabbitmq/commit/d0e559c6) Fix petset patch issue (#38)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.40.0-rc.3](https://github.com/kubedb/redis/releases/tag/v0.40.0-rc.3)
+
+- [8e1b8b60](https://github.com/kubedb/redis/commit/8e1b8b600) Prepare for release v0.40.0-rc.3 (#555)
+- [19c330c7](https://github.com/kubedb/redis/commit/19c330c78) Test against k8s 1.31 (#553)
+- [e28ec45c](https://github.com/kubedb/redis/commit/e28ec45ca) Update Redis Webhook Server (#551)
+- [89ab2ee1](https://github.com/kubedb/redis/commit/89ab2ee14) Remove Redis Petset Extra Enque (#552)
+- [0dd62824](https://github.com/kubedb/redis/commit/0dd628243) Fix webhook crash issue for sentinel (#550)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.26.0-rc.3](https://github.com/kubedb/redis-coordinator/releases/tag/v0.26.0-rc.3)
+
+- [de860a65](https://github.com/kubedb/redis-coordinator/commit/de860a65) Prepare for release v0.26.0-rc.3 (#110)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.10.0-rc.3](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.10.0-rc.3)
+
+- [201ed9f](https://github.com/kubedb/redis-restic-plugin/commit/201ed9f) Prepare for release v0.10.0-rc.3 (#42)
+- [5d6204e](https://github.com/kubedb/redis-restic-plugin/commit/5d6204e) Wait for Ready condition instead of Provisioned condition (#40)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.34.0-rc.3](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.34.0-rc.3)
+
+- [fcc68baf](https://github.com/kubedb/replication-mode-detector/commit/fcc68baf) Prepare for release v0.34.0-rc.3 (#276)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.23.0-rc.3](https://github.com/kubedb/schema-manager/releases/tag/v0.23.0-rc.3)
+
+- [10068069](https://github.com/kubedb/schema-manager/commit/10068069) Prepare for release v0.23.0-rc.3 (#119)
+
+
+
+## [kubedb/singlestore](https://github.com/kubedb/singlestore)
+
+### [v0.2.0-rc.3](https://github.com/kubedb/singlestore/releases/tag/v0.2.0-rc.3)
+
+- [be3ac6ae](https://github.com/kubedb/singlestore/commit/be3ac6ae) Prepare for release v0.2.0-rc.3 (#44)
+- [0ea16467](https://github.com/kubedb/singlestore/commit/0ea16467) Improve logs and Fix manager (#43)
+- [72322a75](https://github.com/kubedb/singlestore/commit/72322a75) Test against k8s 1.31 (#41)
+- [507dbe5a](https://github.com/kubedb/singlestore/commit/507dbe5a) Update Webhook Server (#40)
+
+
+
+## [kubedb/singlestore-coordinator](https://github.com/kubedb/singlestore-coordinator)
+
+### [v0.2.0-rc.3](https://github.com/kubedb/singlestore-coordinator/releases/tag/v0.2.0-rc.3)
+
+- [379e303](https://github.com/kubedb/singlestore-coordinator/commit/379e303) Prepare for release v0.2.0-rc.3 (#25)
+
+
+
+## [kubedb/singlestore-restic-plugin](https://github.com/kubedb/singlestore-restic-plugin)
+
+### [v0.5.0-rc.3](https://github.com/kubedb/singlestore-restic-plugin/releases/tag/v0.5.0-rc.3)
+
+- [99b5c46](https://github.com/kubedb/singlestore-restic-plugin/commit/99b5c46) Prepare for release v0.5.0-rc.3 (#21)
+
+
+
+## [kubedb/solr](https://github.com/kubedb/solr)
+
+### [v0.2.0-rc.3](https://github.com/kubedb/solr/releases/tag/v0.2.0-rc.3)
+
+- [5dcbfa1d](https://github.com/kubedb/solr/commit/5dcbfa1d) Prepare for release v0.2.0-rc.3 (#45)
+- [02eccb48](https://github.com/kubedb/solr/commit/02eccb48) Improve logs (#44)
+- [82a533c8](https://github.com/kubedb/solr/commit/82a533c8) Test against k8s 1.31 (#42)
+- [4e1ff74a](https://github.com/kubedb/solr/commit/4e1ff74a) Fix chroot issue to configure multiple solr cluster refering single zk (#41)
+- [86526192](https://github.com/kubedb/solr/commit/86526192) Fix petset patch issue (#40)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.32.0-rc.3](https://github.com/kubedb/tests/releases/tag/v0.32.0-rc.3)
+
+- [5f5d899c](https://github.com/kubedb/tests/commit/5f5d899c) Prepare for release v0.32.0-rc.3 (#349)
+- [746fba1f](https://github.com/kubedb/tests/commit/746fba1f) Add Memcached e2e Tests (#346)
+- [7647c955](https://github.com/kubedb/tests/commit/7647c955) Fix Redis Tests (#345)
+- [cd54a2b7](https://github.com/kubedb/tests/commit/cd54a2b7) Add Redis Initialization Script (#342)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.23.0-rc.3](https://github.com/kubedb/ui-server/releases/tag/v0.23.0-rc.3)
+
+- [717efd76](https://github.com/kubedb/ui-server/commit/717efd76) Prepare for release v0.23.0-rc.3 (#127)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.23.0-rc.3](https://github.com/kubedb/webhook-server/releases/tag/v0.23.0-rc.3)
+
+
+
+
+## [kubedb/zookeeper](https://github.com/kubedb/zookeeper)
+
+### [v0.2.0-rc.3](https://github.com/kubedb/zookeeper/releases/tag/v0.2.0-rc.3)
+
+- [3c7a8b4d](https://github.com/kubedb/zookeeper/commit/3c7a8b4d) Prepare for release v0.2.0-rc.3 (#37)
+- [6d9f2a50](https://github.com/kubedb/zookeeper/commit/6d9f2a50) Improve logging and fix manager (#36)
+
+
+
+## [kubedb/zookeeper-restic-plugin](https://github.com/kubedb/zookeeper-restic-plugin)
+
+### [v0.3.0-rc.3](https://github.com/kubedb/zookeeper-restic-plugin/releases/tag/v0.3.0-rc.3)
+
+- [0ef0eb0](https://github.com/kubedb/zookeeper-restic-plugin/commit/0ef0eb0) Prepare for release v0.3.0-rc.3 (#13)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.8.14-rc.3
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/96
Signed-off-by: 1gtm <1gtm@appscode.com>