### PR TITLE
Prepare for release v2024.11.18

### DIFF
--- a/docs/CHANGELOG-v2024.11.18.md
+++ b/docs/CHANGELOG-v2024.11.18.md
@@ -1,0 +1,787 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2024.11.18
+    name: Changelog-v2024.11.18
+    parent: welcome
+    weight: 20241118
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.11.18/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.11.18/
+---
+
+# KubeDB v2024.11.18 (2024-11-20)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.49.0](https://github.com/kubedb/apimachinery/releases/tag/v0.49.0)
+
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.34.0](https://github.com/kubedb/autoscaler/releases/tag/v0.34.0)
+
+- [a67ba7eb](https://github.com/kubedb/autoscaler/commit/a67ba7eb) Prepare for release v0.34.0 (#229)
+- [0e555ac9](https://github.com/kubedb/autoscaler/commit/0e555ac9) Prepare for release v0.34.0-rc.0 (#228)
+- [9a723b6e](https://github.com/kubedb/autoscaler/commit/9a723b6e) Add autoscaler for solr (#227)
+- [6fa6ac10](https://github.com/kubedb/autoscaler/commit/6fa6ac10) Use debian:12 base image (#226)
+- [7b4b559f](https://github.com/kubedb/autoscaler/commit/7b4b559f) Use debian:12 base image (#225)
+
+
+
+## [kubedb/cassandra](https://github.com/kubedb/cassandra)
+
+### [v0.2.0](https://github.com/kubedb/cassandra/releases/tag/v0.2.0)
+
+- [a22e35fe](https://github.com/kubedb/cassandra/commit/a22e35fe) Prepare for release v0.2.0 (#12)
+- [98f26f87](https://github.com/kubedb/cassandra/commit/98f26f87) Use kind v0.25.0 (#11)
+- [2a6da5c4](https://github.com/kubedb/cassandra/commit/2a6da5c4) Add ReconcileState struct to pass reconciling objects as parameter (#9)
+- [c8344e76](https://github.com/kubedb/cassandra/commit/c8344e76) Prepare for release v0.2.0-rc.0 (#10)
+- [49bea527](https://github.com/kubedb/cassandra/commit/49bea527) Fix Petset observedGeneration issue & Add Monitoring Support  (#7)
+- [08e51996](https://github.com/kubedb/cassandra/commit/08e51996) Use debian:12 base image (#8)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.49.0](https://github.com/kubedb/cli/releases/tag/v0.49.0)
+
+- [ce5dc68e](https://github.com/kubedb/cli/commit/ce5dc68e) Prepare for release v0.49.0 (#781)
+- [a10a51fa](https://github.com/kubedb/cli/commit/a10a51fa) Prepare for release v0.49.0-rc.0 (#780)
+
+
+
+## [kubedb/clickhouse](https://github.com/kubedb/clickhouse)
+
+### [v0.4.0](https://github.com/kubedb/clickhouse/releases/tag/v0.4.0)
+
+- [7b61f24f](https://github.com/kubedb/clickhouse/commit/7b61f24f) Prepare for release v0.4.0 (#26)
+- [4c83f38b](https://github.com/kubedb/clickhouse/commit/4c83f38b) Use kind v0.25.0 (#25)
+- [4710110d](https://github.com/kubedb/clickhouse/commit/4710110d) Add ReconcileState struct to pass reconciling objects as parameter (#23)
+- [c3e50828](https://github.com/kubedb/clickhouse/commit/c3e50828) Prepare for release v0.4.0-rc.0 (#24)
+- [8dd25781](https://github.com/kubedb/clickhouse/commit/8dd25781) Use debian:12 base image (#21)
+
+
+
+## [kubedb/crd-manager](https://github.com/kubedb/crd-manager)
+
+### [v0.4.0](https://github.com/kubedb/crd-manager/releases/tag/v0.4.0)
+
+- [de8bb2d1](https://github.com/kubedb/crd-manager/commit/de8bb2d1) Prepare for release v0.4.0 (#55)
+- [71f313ce](https://github.com/kubedb/crd-manager/commit/71f313ce) Prepare for release v0.4.0-rc.0 (#54)
+- [27c3d99b](https://github.com/kubedb/crd-manager/commit/27c3d99b) Use debian:12 base image (#53)
+- [f45b9afd](https://github.com/kubedb/crd-manager/commit/f45b9afd) Use debian:12 base image (#52)
+
+
+
+## [kubedb/dashboard-restic-plugin](https://github.com/kubedb/dashboard-restic-plugin)
+
+### [v0.7.0](https://github.com/kubedb/dashboard-restic-plugin/releases/tag/v0.7.0)
+
+- [75460de](https://github.com/kubedb/dashboard-restic-plugin/commit/75460de) Prepare for release v0.7.0 (#25)
+- [b3a729b](https://github.com/kubedb/dashboard-restic-plugin/commit/b3a729b) Use debian:12 base image (#24)
+- [7672ced](https://github.com/kubedb/dashboard-restic-plugin/commit/7672ced) Prepare for release v0.7.0-rc.0 (#23)
+- [504cae4](https://github.com/kubedb/dashboard-restic-plugin/commit/504cae4) Use debian:12 base image (#22)
+
+
+
+## [kubedb/db-client-go](https://github.com/kubedb/db-client-go)
+
+### [v0.4.0](https://github.com/kubedb/db-client-go/releases/tag/v0.4.0)
+
+- [1138af27](https://github.com/kubedb/db-client-go/commit/1138af27) Prepare for release v0.4.0 (#152)
+- [25a03892](https://github.com/kubedb/db-client-go/commit/25a03892) Add Support for Updating Druid Credential dynamically (#148)
+- [e5ed4c59](https://github.com/kubedb/db-client-go/commit/e5ed4c59) Use pointer clientTLS filed (#151)
+- [bc1b92c5](https://github.com/kubedb/db-client-go/commit/bc1b92c5) Prepare for release v0.4.0-rc.0 (#150)
+- [e8210401](https://github.com/kubedb/db-client-go/commit/e8210401) Update Cassandra/client.go (#143)
+- [8f470859](https://github.com/kubedb/db-client-go/commit/8f470859) adding tls for pgbouncer (#149)
+- [7e70d363](https://github.com/kubedb/db-client-go/commit/7e70d363) Fix druid auth name (#147)
+- [234b5778](https://github.com/kubedb/db-client-go/commit/234b5778) Update apimachinery Dependency (#146)
+- [8b8905b9](https://github.com/kubedb/db-client-go/commit/8b8905b9) Update deps & fix authsecret mutation (#145)
+- [db011c56](https://github.com/kubedb/db-client-go/commit/db011c56) Add TLS config to druid client (#139)
+- [fbbd601a](https://github.com/kubedb/db-client-go/commit/fbbd601a) Use debian:12 base image (#144)
+- [7b28debe](https://github.com/kubedb/db-client-go/commit/7b28debe) Add DeleteCollection method for Solr (#141)
+
+
+
+## [kubedb/druid](https://github.com/kubedb/druid)
+
+### [v0.4.0](https://github.com/kubedb/druid/releases/tag/v0.4.0)
+
+- [00c82ce5](https://github.com/kubedb/druid/commit/00c82ce5) Prepare for release v0.4.0 (#60)
+- [bbdc017f](https://github.com/kubedb/druid/commit/bbdc017f) Update RotateAuth Ops based changes (#58)
+- [a8ef93f3](https://github.com/kubedb/druid/commit/a8ef93f3) Use kind v0.25.0 (#59)
+- [fbfafa4c](https://github.com/kubedb/druid/commit/fbfafa4c) Update Structure of ReconcileState (#57)
+- [7826e04a](https://github.com/kubedb/druid/commit/7826e04a) Update dep (#56)
+- [3cb337c4](https://github.com/kubedb/druid/commit/3cb337c4) Add Druid ReconcileState as receiver from Reconcile (#54)
+- [73e2f14b](https://github.com/kubedb/druid/commit/73e2f14b) Prepare for release v0.4.0-rc.0 (#55)
+- [cb3fc57a](https://github.com/kubedb/druid/commit/cb3fc57a) Fix druid auth secret name (#52)
+- [20da2c3a](https://github.com/kubedb/druid/commit/20da2c3a) Add druid TLS (#45)
+- [9f72c688](https://github.com/kubedb/druid/commit/9f72c688) Use debian:12 base image (#51)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.49.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.49.0)
+
+- [32a036e1](https://github.com/kubedb/elasticsearch/commit/32a036e19) Prepare for release v0.49.0 (#740)
+- [a10a337e](https://github.com/kubedb/elasticsearch/commit/a10a337e3) Fix authsecret name and validator to configure rotateauth ops request (#739)
+- [d3aaacf3](https://github.com/kubedb/elasticsearch/commit/d3aaacf37) Prepare for release v0.49.0-rc.0 (#738)
+- [57de6b5e](https://github.com/kubedb/elasticsearch/commit/57de6b5e6) Fix local Webhook Registration (#737)
+- [494c5f03](https://github.com/kubedb/elasticsearch/commit/494c5f03b) Use debian:12 base image (#736)
+- [986f6f22](https://github.com/kubedb/elasticsearch/commit/986f6f224) Use debian:12 base image (#735)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.12.0](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.12.0)
+
+- [1d9e4a2](https://github.com/kubedb/elasticsearch-restic-plugin/commit/1d9e4a2) Prepare for release v0.12.0 (#48)
+- [dd617de](https://github.com/kubedb/elasticsearch-restic-plugin/commit/dd617de) Use debian:12 base image (#47)
+- [3e60416](https://github.com/kubedb/elasticsearch-restic-plugin/commit/3e60416) Prepare for release v0.12.0-rc.0 (#46)
+
+
+
+## [kubedb/ferretdb](https://github.com/kubedb/ferretdb)
+
+### [v0.4.0](https://github.com/kubedb/ferretdb/releases/tag/v0.4.0)
+
+- [c955d034](https://github.com/kubedb/ferretdb/commit/c955d034) Prepare for release v0.4.0 (#52)
+- [f79f7989](https://github.com/kubedb/ferretdb/commit/f79f7989) Update deps (#51)
+- [41f5baba](https://github.com/kubedb/ferretdb/commit/41f5baba) Add ReconcileState as receiver from Reconcile (#50)
+- [46e66e54](https://github.com/kubedb/ferretdb/commit/46e66e54) Prepare for release v0.4.0-rc.0 (#49)
+- [d6dbb82a](https://github.com/kubedb/ferretdb/commit/d6dbb82a) Update pg tp v1 (#47)
+- [498cf1e3](https://github.com/kubedb/ferretdb/commit/498cf1e3) Use debian:12 base image (#46)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2024.11.18](https://github.com/kubedb/installer/releases/tag/v2024.11.18)
+
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.20.0](https://github.com/kubedb/kafka/releases/tag/v0.20.0)
+
+- [cff9ac07](https://github.com/kubedb/kafka/commit/cff9ac07) Prepare for release v0.20.0 (#120)
+- [122c28db](https://github.com/kubedb/kafka/commit/122c28db) Use kind v0.25.0 (#119)
+- [03868d66](https://github.com/kubedb/kafka/commit/03868d66) Update annotations name with constants (#117)
+- [0cfb8df3](https://github.com/kubedb/kafka/commit/0cfb8df3) Update RotateAuth Ops based changes (#112)
+- [f767cdbf](https://github.com/kubedb/kafka/commit/f767cdbf) Add Kafka ReconcileState as receiver from Reconcile (#114)
+- [9a007bb4](https://github.com/kubedb/kafka/commit/9a007bb4) Install monitoring stuffs in the daily (#113)
+- [c80ff7a2](https://github.com/kubedb/kafka/commit/c80ff7a2) Prepare for release v0.20.0-rc.0 (#116)
+- [96e3de84](https://github.com/kubedb/kafka/commit/96e3de84) Prepare for release v0.42.0-rc.0
+- [6f702d94](https://github.com/kubedb/kafka/commit/6f702d94) Fix breaking helper functions (#115)
+- [7e43c33f](https://github.com/kubedb/kafka/commit/7e43c33f) Use debian:12 base image (#111)
+
+
+
+## [kubedb/kibana](https://github.com/kubedb/kibana)
+
+### [v0.25.0](https://github.com/kubedb/kibana/releases/tag/v0.25.0)
+
+- [f2a01a30](https://github.com/kubedb/kibana/commit/f2a01a30) Prepare for release v0.25.0 (#131)
+- [772026c0](https://github.com/kubedb/kibana/commit/772026c0) Prepare for release v0.25.0-rc.0 (#130)
+- [ffd6e402](https://github.com/kubedb/kibana/commit/ffd6e402) Use debian:12 base image (#129)
+- [0dc26c52](https://github.com/kubedb/kibana/commit/0dc26c52) Use debian:12 base image (#128)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.12.0](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.12.0)
+
+- [2dcc07c](https://github.com/kubedb/kubedb-manifest-plugin/commit/2dcc07c) Prepare for release v0.12.0 (#78)
+- [dce514e](https://github.com/kubedb/kubedb-manifest-plugin/commit/dce514e) Use debian:12 base image (#77)
+- [7021daa](https://github.com/kubedb/kubedb-manifest-plugin/commit/7021daa) Prepare for release v0.12.0-rc.0 (#76)
+- [bea1697](https://github.com/kubedb/kubedb-manifest-plugin/commit/bea1697) Use debian:12 base image (#75)
+- [dd34241](https://github.com/kubedb/kubedb-manifest-plugin/commit/dd34241) Add Manifest backup/restore support for redis (#74)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.33.0](https://github.com/kubedb/mariadb/releases/tag/v0.33.0)
+
+- [9435f6ee](https://github.com/kubedb/mariadb/commit/9435f6eec) Prepare for release v0.33.0 (#291)
+- [db75a3f5](https://github.com/kubedb/mariadb/commit/db75a3f5e) Add all required const for archiver (#289)
+- [b73a732a](https://github.com/kubedb/mariadb/commit/b73a732ad) Prepare for release v0.33.0-rc.0 (#290)
+- [bd9c114a](https://github.com/kubedb/mariadb/commit/bd9c114a4) Use debian:12 base image (#288)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.9.0](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.9.0)
+
+- [c645ef42](https://github.com/kubedb/mariadb-archiver/commit/c645ef42) Prepare for release v0.9.0 (#31)
+- [e661da41](https://github.com/kubedb/mariadb-archiver/commit/e661da41) Add all required const for archiver (#29)
+- [8498c843](https://github.com/kubedb/mariadb-archiver/commit/8498c843) Prepare for release v0.9.0-rc.0 (#30)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.29.0](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.29.0)
+
+- [eae4bd98](https://github.com/kubedb/mariadb-coordinator/commit/eae4bd98) Prepare for release v0.29.0 (#130)
+- [f1a7ed08](https://github.com/kubedb/mariadb-coordinator/commit/f1a7ed08) Prepare for release v0.29.0-rc.0 (#129)
+- [896d4206](https://github.com/kubedb/mariadb-coordinator/commit/896d4206) Use debian:12 base image (#128)
+
+
+
+## [kubedb/mariadb-csi-snapshotter-plugin](https://github.com/kubedb/mariadb-csi-snapshotter-plugin)
+
+### [v0.9.0](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/releases/tag/v0.9.0)
+
+- [3096d80](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/3096d80) Prepare for release v0.9.0 (#34)
+- [92594f3](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/92594f3) Prepare for release v0.9.0-rc.0 (#33)
+- [cdc664f](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/cdc664f) Use debian:12 base image (#32)
+
+
+
+## [kubedb/mariadb-restic-plugin](https://github.com/kubedb/mariadb-restic-plugin)
+
+### [v0.7.0](https://github.com/kubedb/mariadb-restic-plugin/releases/tag/v0.7.0)
+
+- [bf019c5](https://github.com/kubedb/mariadb-restic-plugin/commit/bf019c5) Prepare for release v0.7.0 (#30)
+- [8583fb5](https://github.com/kubedb/mariadb-restic-plugin/commit/8583fb5) Use debian:12 base image (#29)
+- [d9af547](https://github.com/kubedb/mariadb-restic-plugin/commit/d9af547) Prepare for release v0.7.0-rc.0 (#28)
+- [610dab6](https://github.com/kubedb/mariadb-restic-plugin/commit/610dab6) Add external databases backup/restore support (#27)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.42.0](https://github.com/kubedb/memcached/releases/tag/v0.42.0)
+
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.42.0](https://github.com/kubedb/mongodb/releases/tag/v0.42.0)
+
+- [92b2774e](https://github.com/kubedb/mongodb/commit/92b2774e6) Prepare for release v0.42.0 (#666)
+- [520bbe55](https://github.com/kubedb/mongodb/commit/520bbe55a) Add `basic-auth-active-from` annotation in auth secret (#665)
+- [df91f37e](https://github.com/kubedb/mongodb/commit/df91f37e3) Prepare for release v0.42.0-rc.0 (#664)
+- [decf3281](https://github.com/kubedb/mongodb/commit/decf32819) Fix MongoDBArchiver for Minio TLS backend  (#659)
+- [d1b57cfe](https://github.com/kubedb/mongodb/commit/d1b57cfe0) Use debian:12 base image (#663)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.10.0](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.10.0)
+
+- [a1eefb7](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/a1eefb7) Prepare for release v0.10.0 (#39)
+- [c84b8c0](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/c84b8c0) Prepare for release v0.10.0-rc.0 (#38)
+- [bca72d6](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/bca72d6) Use debian:12 base image (#37)
+- [780554d](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/780554d) Use debian:12 base image (#36)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.12.0](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.12.0)
+
+- [b1f1881](https://github.com/kubedb/mongodb-restic-plugin/commit/b1f1881) Prepare for release v0.12.0 (#70)
+- [1eb3fe7](https://github.com/kubedb/mongodb-restic-plugin/commit/1eb3fe7) Add support for MongoDB version 8.0.0 (#67)
+- [09ee7f4](https://github.com/kubedb/mongodb-restic-plugin/commit/09ee7f4) Use debian:12 base image (#69)
+- [3f6d291](https://github.com/kubedb/mongodb-restic-plugin/commit/3f6d291) Prepare for release v0.12.0-rc.0 (#68)
+
+
+
+## [kubedb/mssql-coordinator](https://github.com/kubedb/mssql-coordinator)
+
+### [v0.4.0](https://github.com/kubedb/mssql-coordinator/releases/tag/v0.4.0)
+
+- [9e567ec3](https://github.com/kubedb/mssql-coordinator/commit/9e567ec3) Prepare for release v0.4.0 (#21)
+- [ae1c7c69](https://github.com/kubedb/mssql-coordinator/commit/ae1c7c69) Prepare for release v0.4.0-rc.0 (#20)
+- [395372a7](https://github.com/kubedb/mssql-coordinator/commit/395372a7) Check AG Database exists before resume, clean LSN string (#18)
+- [505f0d8e](https://github.com/kubedb/mssql-coordinator/commit/505f0d8e) Use debian:12 base image (#19)
+
+
+
+## [kubedb/mssqlserver](https://github.com/kubedb/mssqlserver)
+
+### [v0.4.0](https://github.com/kubedb/mssqlserver/releases/tag/v0.4.0)
+
+- [034c2045](https://github.com/kubedb/mssqlserver/commit/034c2045) Prepare for release v0.4.0 (#40)
+- [239a842f](https://github.com/kubedb/mssqlserver/commit/239a842f) Add Reconfigure TLS changes (#38)
+- [244921e8](https://github.com/kubedb/mssqlserver/commit/244921e8) Use kind v0.25.0 (#39)
+- [e7609913](https://github.com/kubedb/mssqlserver/commit/e7609913) Add ReconcileState struct as reconcile methods receiver (#36)
+- [b43a0b19](https://github.com/kubedb/mssqlserver/commit/b43a0b19) Prepare for release v0.4.0-rc.0 (#37)
+- [69c1a4de](https://github.com/kubedb/mssqlserver/commit/69c1a4de) Use debian:12 base image (#35)
+- [c243e70b](https://github.com/kubedb/mssqlserver/commit/c243e70b) Add some fixes: Validate user envs  (#33)
+- [39de8531](https://github.com/kubedb/mssqlserver/commit/39de8531) Skip creating extra initial backup session for pitr (#34)
+
+
+
+## [kubedb/mssqlserver-archiver](https://github.com/kubedb/mssqlserver-archiver)
+
+### [v0.3.0](https://github.com/kubedb/mssqlserver-archiver/releases/tag/v0.3.0)
+
+- [6e67fd4](https://github.com/kubedb/mssqlserver-archiver/commit/6e67fd4) Remove matrix build
+- [8ab2080](https://github.com/kubedb/mssqlserver-archiver/commit/8ab2080) Use debian:12 base image (#4)
+
+
+
+## [kubedb/mssqlserver-walg-plugin](https://github.com/kubedb/mssqlserver-walg-plugin)
+
+### [v0.3.0](https://github.com/kubedb/mssqlserver-walg-plugin/releases/tag/v0.3.0)
+
+- [2364689](https://github.com/kubedb/mssqlserver-walg-plugin/commit/2364689) Prepare for release v0.3.0 (#10)
+- [e05e217](https://github.com/kubedb/mssqlserver-walg-plugin/commit/e05e217) Prepare for release v0.3.0-rc.0 (#9)
+- [4a9db7b](https://github.com/kubedb/mssqlserver-walg-plugin/commit/4a9db7b) Use debian:12 base image (#8)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.42.0](https://github.com/kubedb/mysql/releases/tag/v0.42.0)
+
+- [a32968b9](https://github.com/kubedb/mysql/commit/a32968b9c) Prepare for release v0.42.0 (#651)
+- [de193669](https://github.com/kubedb/mysql/commit/de1936692) Add Multi Primary Mode Support for V8.4.2 (#650)
+- [1ab34fa2](https://github.com/kubedb/mysql/commit/1ab34fa2e) Prepare for release v0.42.0-rc.0 (#649)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.10.0](https://github.com/kubedb/mysql-archiver/releases/tag/v0.10.0)
+
+- [120c9ffc](https://github.com/kubedb/mysql-archiver/commit/120c9ffc) Prepare for release v0.10.0 (#44)
+- [beb27b22](https://github.com/kubedb/mysql-archiver/commit/beb27b22) Prepare for release v0.10.0-rc.0 (#43)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.27.0](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.27.0)
+
+- [31e0281e](https://github.com/kubedb/mysql-coordinator/commit/31e0281e) Prepare for release v0.27.0 (#128)
+- [81d40c27](https://github.com/kubedb/mysql-coordinator/commit/81d40c27) Prepare for release v0.27.0-rc.0 (#127)
+
+
+
+## [kubedb/mysql-csi-snapshotter-plugin](https://github.com/kubedb/mysql-csi-snapshotter-plugin)
+
+### [v0.10.0](https://github.com/kubedb/mysql-csi-snapshotter-plugin/releases/tag/v0.10.0)
+
+- [8fcb3eb](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/8fcb3eb) Prepare for release v0.10.0 (#34)
+- [be7cf34](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/be7cf34) Prepare for release v0.10.0-rc.0 (#33)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.12.0](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.12.0)
+
+- [e08ce0c](https://github.com/kubedb/mysql-restic-plugin/commit/e08ce0c) Prepare for release v0.12.0 (#62)
+- [54c8bc8](https://github.com/kubedb/mysql-restic-plugin/commit/54c8bc8) Use debian:12 base image (#60)
+- [310725e](https://github.com/kubedb/mysql-restic-plugin/commit/310725e) Prepare for release v0.12.0-rc.0 (#59)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.27.0](https://github.com/kubedb/mysql-router-init/releases/tag/v0.27.0)
+
+- [a0ee1f6](https://github.com/kubedb/mysql-router-init/commit/a0ee1f6) Use debian:12 base image (#47)
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.36.0](https://github.com/kubedb/ops-manager/releases/tag/v0.36.0)
+
+- [8777963d](https://github.com/kubedb/ops-manager/commit/8777963df) Prepare for release v0.36.0 (#672)
+- [6c406557](https://github.com/kubedb/ops-manager/commit/6c4065573) Add rotateauth ops request for elasticsearch (#671)
+- [c2e7bdc2](https://github.com/kubedb/ops-manager/commit/c2e7bdc23) Restart For PgBouncer (#651)
+- [e0357528](https://github.com/kubedb/ops-manager/commit/e03575284) Add rotateauth ops request for solr (#670)
+- [9480d0dd](https://github.com/kubedb/ops-manager/commit/9480d0ddc) Add Druid Rotate-Auth OpsRequest (#653)
+- [26d26e0f](https://github.com/kubedb/ops-manager/commit/26d26e0f5) Add RotateAuth support for MongoDBOpsRequest (#664)
+- [4ab4f623](https://github.com/kubedb/ops-manager/commit/4ab4f6233) Add mssqlserver ops request reconfigure tls (#652)
+- [482ced11](https://github.com/kubedb/ops-manager/commit/482ced11d) Add Rotate Auth Secret Support for Postgres and fix arbiter spec (#669)
+- [a35a08e5](https://github.com/kubedb/ops-manager/commit/a35a08e5a) Add Memcached TLS and OpsRequest Reconfigure TLS (#654)
+- [fe04070b](https://github.com/kubedb/ops-manager/commit/fe04070b4) Update Pgpool operator reconcile struct changes (#668)
+- [29edd77d](https://github.com/kubedb/ops-manager/commit/29edd77d5) Update SingleStore for ReconcilerState Change (#666)
+- [53a7941a](https://github.com/kubedb/ops-manager/commit/53a7941a2) Fix Keystore Secret reference for Kafka ReconfigureTLS (#663)
+- [b01a8869](https://github.com/kubedb/ops-manager/commit/b01a88698) Add Validator for Druid Ops-Requests (#665)
+- [8275c2a5](https://github.com/kubedb/ops-manager/commit/8275c2a51) Updates for Druid ReconcileState Structure (#667)
+- [545bd0c0](https://github.com/kubedb/ops-manager/commit/545bd0c08) Add Kafka Rotate Auth Ops Request (#644)
+- [5bc565e4](https://github.com/kubedb/ops-manager/commit/5bc565e4a) Sync ReconcileState changes for RabbitMQ (#658)
+- [fb456387](https://github.com/kubedb/ops-manager/commit/fb456387c) Add MSSQLServer Reconfigure Ops request (#634)
+- [03af4451](https://github.com/kubedb/ops-manager/commit/03af4451a) Update Zookeeper for Reconcile Changes (#662)
+- [7ab6c269](https://github.com/kubedb/ops-manager/commit/7ab6c2694) Fix Druid ReconcileState Changes (#661)
+- [250cd5c2](https://github.com/kubedb/ops-manager/commit/250cd5c22) Update FerretDB operator reconcile struct changes (#655)
+- [0b0ad7cd](https://github.com/kubedb/ops-manager/commit/0b0ad7cdf) Add ReconcilerState changes in solr (#659)
+- [f0ac65c8](https://github.com/kubedb/ops-manager/commit/f0ac65c84) Fix Kafka ReconcileState Changes (#657)
+- [370b9f98](https://github.com/kubedb/ops-manager/commit/370b9f98f) Fix Fastspeed standalone postgres db upgrade issue (#648)
+- [eb4dfe2f](https://github.com/kubedb/ops-manager/commit/eb4dfe2fe) Prepare for release v0.36.0-rc.0 (#656)
+- [a03bb54e](https://github.com/kubedb/ops-manager/commit/a03bb54e3) Update all db deps
+- [6b0cf17f](https://github.com/kubedb/ops-manager/commit/6b0cf17fa) Fix recommendation (#642)
+- [1b049295](https://github.com/kubedb/ops-manager/commit/1b0492953) Add support for Druid TLS and Ops-Requests (#629)
+- [e72ae41d](https://github.com/kubedb/ops-manager/commit/e72ae41dc) Fix reconfigure tls mg patch issue (#650)
+- [5d328f00](https://github.com/kubedb/ops-manager/commit/5d328f00b) Use debian:12 base image (#647)
+- [1f32a6cf](https://github.com/kubedb/ops-manager/commit/1f32a6cf0) Use debian:12 base image (#646)
+- [3d69bbcc](https://github.com/kubedb/ops-manager/commit/3d69bbcc7) Update zk deps (#645)
+- [c71245eb](https://github.com/kubedb/ops-manager/commit/c71245eb4) Add TLS for ZooKeeper (#640)
+- [0624ed34](https://github.com/kubedb/ops-manager/commit/0624ed346) Update deps (#643)
+- [0c2abc62](https://github.com/kubedb/ops-manager/commit/0c2abc62f) Fix Ops Request Reconfiguration and Version Update (#641)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.36.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.36.0)
+
+- [c32a5a7b](https://github.com/kubedb/percona-xtradb/commit/c32a5a7bf) Prepare for release v0.36.0 (#384)
+- [de5d228a](https://github.com/kubedb/percona-xtradb/commit/de5d228ac) Prepare for release v0.36.0-rc.0 (#383)
+- [23f321d4](https://github.com/kubedb/percona-xtradb/commit/23f321d42) Use debian:12 base image (#382)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.22.0](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.22.0)
+
+- [00f8797c](https://github.com/kubedb/percona-xtradb-coordinator/commit/00f8797c) Prepare for release v0.22.0 (#84)
+- [23075738](https://github.com/kubedb/percona-xtradb-coordinator/commit/23075738) Prepare for release v0.22.0-rc.0 (#83)
+- [86853e65](https://github.com/kubedb/percona-xtradb-coordinator/commit/86853e65) Use debian:12 base image (#82)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.33.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.33.0)
+
+- [5fc9ab78](https://github.com/kubedb/pg-coordinator/commit/5fc9ab78) Prepare for release v0.33.0 (#177)
+- [f8d96212](https://github.com/kubedb/pg-coordinator/commit/f8d96212) Prepare for release v0.33.0-rc.0 (#176)
+- [0e372546](https://github.com/kubedb/pg-coordinator/commit/0e372546) Add PITR modes support (#175)
+- [87ab3dfe](https://github.com/kubedb/pg-coordinator/commit/87ab3dfe) Use debian:12 base image (#174)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.36.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.36.0)
+
+- [34d3b17f](https://github.com/kubedb/pgbouncer/commit/34d3b17f) Prepare for release v0.36.0 (#351)
+- [5b075c85](https://github.com/kubedb/pgbouncer/commit/5b075c85) Prepare for release v0.36.0-rc.0 (#350)
+- [5780e16a](https://github.com/kubedb/pgbouncer/commit/5780e16a) Use debian:12 base image (#348)
+
+
+
+## [kubedb/pgpool](https://github.com/kubedb/pgpool)
+
+### [v0.4.0](https://github.com/kubedb/pgpool/releases/tag/v0.4.0)
+
+- [3d42bf8c](https://github.com/kubedb/pgpool/commit/3d42bf8c) Prepare for release v0.4.0 (#53)
+- [5e4336fe](https://github.com/kubedb/pgpool/commit/5e4336fe) Reconciler state (#52)
+- [e2bfcc3a](https://github.com/kubedb/pgpool/commit/e2bfcc3a) Update dep (#51)
+- [5422557f](https://github.com/kubedb/pgpool/commit/5422557f) Prepare for release v0.4.0-rc.0 (#50)
+- [b1e214ca](https://github.com/kubedb/pgpool/commit/b1e214ca) Use debian:12 base image (#49)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.49.0](https://github.com/kubedb/postgres/releases/tag/v0.49.0)
+
+- [51becf1b](https://github.com/kubedb/postgres/commit/51becf1bb) Prepare for release v0.49.0 (#770)
+- [0fee8ec5](https://github.com/kubedb/postgres/commit/0fee8ec5c) Fix arbiter spec on odd replicas and support for rotate auth secret with activeFrom api (#766)
+- [990c6130](https://github.com/kubedb/postgres/commit/990c6130e) Use separate steps for Autoscaler, Healthchecker, Customization profile in Daily testing (#767)
+- [887ad3de](https://github.com/kubedb/postgres/commit/887ad3dee) Fix RunAsGroup (#768)
+- [cda07c6c](https://github.com/kubedb/postgres/commit/cda07c6ca) Fix daily CI name
+- [a40ef294](https://github.com/kubedb/postgres/commit/a40ef2949) Add Exporters test prerequisites in Daily CI (#765)
+- [a8a62aea](https://github.com/kubedb/postgres/commit/a8a62aea3) Prepare for release v0.49.0-rc.0 (#764)
+- [c39cd034](https://github.com/kubedb/postgres/commit/c39cd034f) Fix cross region restore issue (#763)
+- [be0d9cba](https://github.com/kubedb/postgres/commit/be0d9cba1) Use debian:12 base image (#761)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.10.0](https://github.com/kubedb/postgres-archiver/releases/tag/v0.10.0)
+
+- [03d67011](https://github.com/kubedb/postgres-archiver/commit/03d67011) Prepare for release v0.10.0 (#42)
+- [9fa2492a](https://github.com/kubedb/postgres-archiver/commit/9fa2492a) Prepare for release v0.10.0-rc.0 (#41)
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.10.0](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.10.0)
+
+- [08fe128](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/08fe128) Prepare for release v0.10.0 (#42)
+- [a48321d](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/a48321d) Prepare for release v0.10.0-rc.0 (#41)
+- [1571bab](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/1571bab) Use debian:12 base image (#40)
+- [7393bf4](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/7393bf4) Use debian:12 base image (#39)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.12.0](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.12.0)
+
+- [b71f30a](https://github.com/kubedb/postgres-restic-plugin/commit/b71f30a) Prepare for release v0.12.0 (#57)
+- [77b0c1b](https://github.com/kubedb/postgres-restic-plugin/commit/77b0c1b) Use debian:12 base image (#56)
+- [f744dce](https://github.com/kubedb/postgres-restic-plugin/commit/f744dce) Prepare for release v0.12.0-rc.0 (#55)
+
+
+
+## [kubedb/provider-aws](https://github.com/kubedb/provider-aws)
+
+### [v0.11.0](https://github.com/kubedb/provider-aws/releases/tag/v0.11.0)
+
+
+
+
+## [kubedb/provider-azure](https://github.com/kubedb/provider-azure)
+
+### [v0.11.0](https://github.com/kubedb/provider-azure/releases/tag/v0.11.0)
+
+
+
+
+## [kubedb/provider-gcp](https://github.com/kubedb/provider-gcp)
+
+### [v0.11.0](https://github.com/kubedb/provider-gcp/releases/tag/v0.11.0)
+
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.49.0](https://github.com/kubedb/provisioner/releases/tag/v0.49.0)
+
+- [3e2cb353](https://github.com/kubedb/provisioner/commit/3e2cb3538) Prepare for release v0.49.0 (#122)
+- [1fec3354](https://github.com/kubedb/provisioner/commit/1fec33545) Prepare for release v0.49.0-rc.0 (#121)
+- [ad392149](https://github.com/kubedb/provisioner/commit/ad392149a) Update all db deps
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.36.0](https://github.com/kubedb/proxysql/releases/tag/v0.36.0)
+
+- [195ba40d](https://github.com/kubedb/proxysql/commit/195ba40da) Prepare for release v0.36.0 (#366)
+- [bce09dcf](https://github.com/kubedb/proxysql/commit/bce09dcfe) Use kind v0.25.0 (#365)
+- [a6c29b60](https://github.com/kubedb/proxysql/commit/a6c29b60b) Prepare for release v0.36.0-rc.0 (#364)
+- [ad781b1e](https://github.com/kubedb/proxysql/commit/ad781b1ec) Use debian:12 base image (#362)
+
+
+
+## [kubedb/rabbitmq](https://github.com/kubedb/rabbitmq)
+
+### [v0.4.0](https://github.com/kubedb/rabbitmq/releases/tag/v0.4.0)
+
+- [9115622a](https://github.com/kubedb/rabbitmq/commit/9115622a) Prepare for release v0.4.0 (#54)
+- [0b692417](https://github.com/kubedb/rabbitmq/commit/0b692417) Use kind v0.25.0 (#53)
+- [0209b44a](https://github.com/kubedb/rabbitmq/commit/0209b44a) Add ReconcileState as receiver from Reconcile (#52)
+- [3eabf7e9](https://github.com/kubedb/rabbitmq/commit/3eabf7e9) Prepare for release v0.4.0-rc.0 (#51)
+- [bb92e142](https://github.com/kubedb/rabbitmq/commit/bb92e142) Revert "Add ReconcileState struct as reconcile methods receiver (#50)"
+- [208e2ebc](https://github.com/kubedb/rabbitmq/commit/208e2ebc) Add ReconcileState struct as reconcile methods receiver (#50)
+- [c62f41c0](https://github.com/kubedb/rabbitmq/commit/c62f41c0) Use debian:12 base image (#49)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.42.0](https://github.com/kubedb/redis/releases/tag/v0.42.0)
+
+- [67b02743](https://github.com/kubedb/redis/commit/67b027437) Prepare for release v0.42.0 (#565)
+- [1869d651](https://github.com/kubedb/redis/commit/1869d6514) Prepare for release v0.42.0-rc.0 (#564)
+- [60db928f](https://github.com/kubedb/redis/commit/60db928f4) Use debian:12 base image (#563)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.28.0](https://github.com/kubedb/redis-coordinator/releases/tag/v0.28.0)
+
+- [c1a3dfa7](https://github.com/kubedb/redis-coordinator/commit/c1a3dfa7) Prepare for release v0.28.0 (#115)
+- [9bbeb8af](https://github.com/kubedb/redis-coordinator/commit/9bbeb8af) Prepare for release v0.28.0-rc.0 (#114)
+- [81465dcd](https://github.com/kubedb/redis-coordinator/commit/81465dcd) Use debian:12 base image (#113)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.12.0](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.12.0)
+
+- [1354aef](https://github.com/kubedb/redis-restic-plugin/commit/1354aef) Prepare for release v0.12.0 (#52)
+- [5d370f4](https://github.com/kubedb/redis-restic-plugin/commit/5d370f4) Use debian:12 base image (#51)
+- [ce0f2c5](https://github.com/kubedb/redis-restic-plugin/commit/ce0f2c5) Prepare for release v0.12.0-rc.0 (#50)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.36.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.36.0)
+
+- [a7aa00b6](https://github.com/kubedb/replication-mode-detector/commit/a7aa00b6) Prepare for release v0.36.0 (#281)
+- [637b35b0](https://github.com/kubedb/replication-mode-detector/commit/637b35b0) Prepare for release v0.36.0-rc.0 (#280)
+- [002dffe1](https://github.com/kubedb/replication-mode-detector/commit/002dffe1) Use debian:12 base image (#279)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.25.0](https://github.com/kubedb/schema-manager/releases/tag/v0.25.0)
+
+- [86824c75](https://github.com/kubedb/schema-manager/commit/86824c75) Prepare for release v0.25.0 (#125)
+- [b96dc475](https://github.com/kubedb/schema-manager/commit/b96dc475) Prepare for release v0.25.0-rc.0 (#124)
+- [6b295a6b](https://github.com/kubedb/schema-manager/commit/6b295a6b) Use debian:12 base image (#123)
+- [095be7c6](https://github.com/kubedb/schema-manager/commit/095be7c6) Use debian:12 base image (#122)
+
+
+
+## [kubedb/singlestore](https://github.com/kubedb/singlestore)
+
+### [v0.4.0](https://github.com/kubedb/singlestore/releases/tag/v0.4.0)
+
+- [6882b6b0](https://github.com/kubedb/singlestore/commit/6882b6b0) Prepare for release v0.4.0 (#52)
+- [f240110a](https://github.com/kubedb/singlestore/commit/f240110a) Add ReconcileState struct to pass reconciling objects as parameter (#49)
+- [c77349d7](https://github.com/kubedb/singlestore/commit/c77349d7) Update dep (#51)
+- [143ac48c](https://github.com/kubedb/singlestore/commit/143ac48c) Prepare for release v0.4.0-rc.0 (#50)
+- [c6d41c61](https://github.com/kubedb/singlestore/commit/c6d41c61) Use debian:12 base image (#48)
+
+
+
+## [kubedb/singlestore-coordinator](https://github.com/kubedb/singlestore-coordinator)
+
+### [v0.4.0](https://github.com/kubedb/singlestore-coordinator/releases/tag/v0.4.0)
+
+- [abb99f4](https://github.com/kubedb/singlestore-coordinator/commit/abb99f4) Prepare for release v0.4.0 (#30)
+- [2c8c88b](https://github.com/kubedb/singlestore-coordinator/commit/2c8c88b) Prepare for release v0.4.0-rc.0 (#29)
+- [6414517](https://github.com/kubedb/singlestore-coordinator/commit/6414517) Use debian:12 base image (#28)
+
+
+
+## [kubedb/singlestore-restic-plugin](https://github.com/kubedb/singlestore-restic-plugin)
+
+### [v0.7.0](https://github.com/kubedb/singlestore-restic-plugin/releases/tag/v0.7.0)
+
+- [60f3c5a](https://github.com/kubedb/singlestore-restic-plugin/commit/60f3c5a) Prepare for release v0.7.0 (#29)
+- [4fa6223](https://github.com/kubedb/singlestore-restic-plugin/commit/4fa6223) Use debian:12 base image (#28)
+- [fe8a465](https://github.com/kubedb/singlestore-restic-plugin/commit/fe8a465) Prepare for release v0.7.0-rc.0 (#27)
+
+
+
+## [kubedb/solr](https://github.com/kubedb/solr)
+
+### [v0.4.0](https://github.com/kubedb/solr/releases/tag/v0.4.0)
+
+- [ec8d69d6](https://github.com/kubedb/solr/commit/ec8d69d6) Prepare for release v0.4.0 (#59)
+- [9e1bbf8f](https://github.com/kubedb/solr/commit/9e1bbf8f) Update authconfig secret to implement rotateauth ops request (#58)
+- [0e3da42b](https://github.com/kubedb/solr/commit/0e3da42b) Update dep (#57)
+- [9203993c](https://github.com/kubedb/solr/commit/9203993c) Add Solr ReconcileState as receiver from Reconcile (#56)
+- [b337c65c](https://github.com/kubedb/solr/commit/b337c65c) Prepare for release v0.4.0-rc.0 (#55)
+- [71366144](https://github.com/kubedb/solr/commit/71366144) Revert "Add ReconcileState struct to pass reconciling objects as parameter (#54)"
+- [ca96f684](https://github.com/kubedb/solr/commit/ca96f684) Add ReconcileState struct to pass reconciling objects as parameter (#54)
+- [ef5fecdb](https://github.com/kubedb/solr/commit/ef5fecdb) Update deps & fix authsecret mutation (#53)
+- [c5fb9263](https://github.com/kubedb/solr/commit/c5fb9263) Use debian:12 base image (#52)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.34.0](https://github.com/kubedb/tests/releases/tag/v0.34.0)
+
+- [34b0b93f](https://github.com/kubedb/tests/commit/34b0b93f) Prepare for release v0.34.0 (#413)
+- [95f5d160](https://github.com/kubedb/tests/commit/95f5d160) Update Solr and MSSQL api (#412)
+- [5f40689f](https://github.com/kubedb/tests/commit/5f40689f) Exclude autoscaler,healthchecker,customizations from PG Provisioner test (#404)
+- [80fb6025](https://github.com/kubedb/tests/commit/80fb6025) Fix Resource's name (#389)
+- [d56b0310](https://github.com/kubedb/tests/commit/d56b0310) Add mysql backup-restore test using kubestash (#344)
+- [82a5166b](https://github.com/kubedb/tests/commit/82a5166b) Add Health Check test for Druid, PgBouncer, mysql innodb (#399)
+- [a203fd39](https://github.com/kubedb/tests/commit/a203fd39) fix linter issue for release v0.34.0-rc.0 (#402)
+- [ec82963a](https://github.com/kubedb/tests/commit/ec82963a) Prepare for release v0.34.0-rc.0 (#401)
+- [ddfac099](https://github.com/kubedb/tests/commit/ddfac099) Add Health Check Test (#329)
+- [cfb52cc6](https://github.com/kubedb/tests/commit/cfb52cc6) Add Druid Restart Test (#397)
+- [69f18704](https://github.com/kubedb/tests/commit/69f18704) Add Druid  AutoScaling Test (#396)
+- [d846af1b](https://github.com/kubedb/tests/commit/d846af1b) Add Postgres AutoScaling Tests (#364)
+- [d67c3869](https://github.com/kubedb/tests/commit/d67c3869) Kubestash Backup-Restore Test for Postgres (#388)
+- [4eafce8f](https://github.com/kubedb/tests/commit/4eafce8f) Add Pgpool metrics exporter tests (#377)
+- [eaa4499a](https://github.com/kubedb/tests/commit/eaa4499a) Add Postgres metrics exporter tests (#368)
+- [564d1cde](https://github.com/kubedb/tests/commit/564d1cde) Add Pgbouncer metrics exporter test (#385)
+- [4ffa3df4](https://github.com/kubedb/tests/commit/4ffa3df4) Add Solr metrics exporter test (#390)
+- [4183f879](https://github.com/kubedb/tests/commit/4183f879) working well (#381)
+- [a3eb7976](https://github.com/kubedb/tests/commit/a3eb7976) Use debian:12 base image (#392)
+- [ec4d737f](https://github.com/kubedb/tests/commit/ec4d737f) Add zookeeper metrics exporter test (#391)
+- [be48f627](https://github.com/kubedb/tests/commit/be48f627) Add ops manager to CI (#386)
+- [fa41180f](https://github.com/kubedb/tests/commit/fa41180f) remove branch from checkout (#380)
+- [ac4d8455](https://github.com/kubedb/tests/commit/ac4d8455) Remove extra print (#384)
+- [b26e740e](https://github.com/kubedb/tests/commit/b26e740e) Add ElasticSearch metrics exporter tests (#373)
+- [f15066fb](https://github.com/kubedb/tests/commit/f15066fb) Add Singlestore metrics exporter tests (#378)
+- [f5765a67](https://github.com/kubedb/tests/commit/f5765a67) mysql exporter unfocus (#382)
+- [a873ff4a](https://github.com/kubedb/tests/commit/a873ff4a) Add Perconaxtradb metrics exporter tests (#375)
+- [dc7c42c9](https://github.com/kubedb/tests/commit/dc7c42c9) Add MySQL metrics exporter tests  (#371)
+- [46189f39](https://github.com/kubedb/tests/commit/46189f39) Add MariaDB metrics exporter tests (#366)
+- [4b4fa18d](https://github.com/kubedb/tests/commit/4b4fa18d) Add PGBouncer update-version, reconfiguration, custom-config and auto-scaling test (#372)
+- [fe911856](https://github.com/kubedb/tests/commit/fe911856) Add kubestash-Backupstorage Phase (#374)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.25.0](https://github.com/kubedb/ui-server/releases/tag/v0.25.0)
+
+- [e6c5e7d8](https://github.com/kubedb/ui-server/commit/e6c5e7d8) Prepare for release v0.25.0 (#139)
+- [ee26c6b4](https://github.com/kubedb/ui-server/commit/ee26c6b4) Prepare for release v0.25.0-rc.0 (#138)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.25.0](https://github.com/kubedb/webhook-server/releases/tag/v0.25.0)
+
+- [4e27b4e3](https://github.com/kubedb/webhook-server/commit/4e27b4e3) Prepare for release v0.25.0 (#136)
+- [781984da](https://github.com/kubedb/webhook-server/commit/781984da) Prepare for release v0.25.0-rc.0 (#135)
+- [fa8b1b2f](https://github.com/kubedb/webhook-server/commit/fa8b1b2f) Use debian:12 base image (#134)
+
+
+
+## [kubedb/zookeeper](https://github.com/kubedb/zookeeper)
+
+### [v0.4.0](https://github.com/kubedb/zookeeper/releases/tag/v0.4.0)
+
+- [7de2e276](https://github.com/kubedb/zookeeper/commit/7de2e276) Prepare for release v0.4.0 (#51)
+- [4fdb8ff7](https://github.com/kubedb/zookeeper/commit/4fdb8ff7) Use kind v0.25.0 (#50)
+- [627161bf](https://github.com/kubedb/zookeeper/commit/627161bf) Fix Resource Name Change (#48)
+- [6b1ce481](https://github.com/kubedb/zookeeper/commit/6b1ce481) Update dep (#49)
+- [8aed4ed2](https://github.com/kubedb/zookeeper/commit/8aed4ed2) Add ReconcileState as receiver from Reconcile (#47)
+- [258b140f](https://github.com/kubedb/zookeeper/commit/258b140f) Prepare for release v0.4.0-rc.0 (#46)
+- [04989850](https://github.com/kubedb/zookeeper/commit/04989850) Fix Auth-Secret Name (#45)
+- [108a5495](https://github.com/kubedb/zookeeper/commit/108a5495) Use debian:12 base image (#44)
+- [f275c44a](https://github.com/kubedb/zookeeper/commit/f275c44a) Add TLS for ZooKeeper (#42)
+
+
+
+## [kubedb/zookeeper-restic-plugin](https://github.com/kubedb/zookeeper-restic-plugin)
+
+### [v0.5.0](https://github.com/kubedb/zookeeper-restic-plugin/releases/tag/v0.5.0)
+
+- [fff6c0a](https://github.com/kubedb/zookeeper-restic-plugin/commit/fff6c0a) Prepare for release v0.5.0 (#21)
+- [eba9823](https://github.com/kubedb/zookeeper-restic-plugin/commit/eba9823) Use debian:12 base image (#20)
+- [18c68cd](https://github.com/kubedb/zookeeper-restic-plugin/commit/18c68cd) Prepare for release v0.5.0-rc.0 (#19)
+- [e5240ed](https://github.com/kubedb/zookeeper-restic-plugin/commit/e5240ed) Use debian:12 base image (#18)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.11.18
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/101
Signed-off-by: 1gtm <1gtm@appscode.com>