### PR TITLE
Prepare for release v2025.1.9

### DIFF
--- a/docs/CHANGELOG-v2025.1.9.md
+++ b/docs/CHANGELOG-v2025.1.9.md
@@ -1,0 +1,628 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2025.1.9
+    name: Changelog-v2025.1.9
+    parent: welcome
+    weight: 20250109
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.1.9/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.1.9/
+---
+
+# KubeDB v2025.1.9 (2025-01-09)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.51.0](https://github.com/kubedb/apimachinery/releases/tag/v0.51.0)
+
+- [9d755176](https://github.com/kubedb/apimachinery/commit/9d7551766) Update deps
+- [ad765a4c](https://github.com/kubedb/apimachinery/commit/ad765a4c3) Update for release KubeStash@v2025.1.9 (#1379)
+- [d2f3f115](https://github.com/kubedb/apimachinery/commit/d2f3f115f) Print license expiration timestamp
+- [cb004556](https://github.com/kubedb/apimachinery/commit/cb0045560) Fix patching
+- [20781652](https://github.com/kubedb/apimachinery/commit/207816521) Update github action modules (#1376)
+- [bb87939a](https://github.com/kubedb/apimachinery/commit/bb87939ac) Update github action modules (#1375)
+- [08b21d02](https://github.com/kubedb/apimachinery/commit/08b21d025) Update github action modules (#1374)
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.36.0](https://github.com/kubedb/autoscaler/releases/tag/v0.36.0)
+
+- [cae9cabe](https://github.com/kubedb/autoscaler/commit/cae9cabe) Prepare for release v0.36.0 (#234)
+- [f627082e](https://github.com/kubedb/autoscaler/commit/f627082e) Update github action modules (#233)
+
+
+
+## [kubedb/cassandra](https://github.com/kubedb/cassandra)
+
+### [v0.4.0](https://github.com/kubedb/cassandra/releases/tag/v0.4.0)
+
+- [9f593cba](https://github.com/kubedb/cassandra/commit/9f593cba) Prepare for release v0.4.0 (#15)
+- [b8e55c8a](https://github.com/kubedb/cassandra/commit/b8e55c8a) Update github action modules (#14)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.51.0](https://github.com/kubedb/cli/releases/tag/v0.51.0)
+
+- [c7e3ab8a](https://github.com/kubedb/cli/commit/c7e3ab8a) Prepare for release v0.51.0 (#785)
+- [b8861821](https://github.com/kubedb/cli/commit/b8861821) Update github action modules (#784)
+- [d69c5d99](https://github.com/kubedb/cli/commit/d69c5d99) Update github action modules (#783)
+
+
+
+## [kubedb/clickhouse](https://github.com/kubedb/clickhouse)
+
+### [v0.6.0](https://github.com/kubedb/clickhouse/releases/tag/v0.6.0)
+
+- [b6468d41](https://github.com/kubedb/clickhouse/commit/b6468d41) Prepare for release v0.6.0 (#29)
+- [a9efd726](https://github.com/kubedb/clickhouse/commit/a9efd726) Update github action modules (#28)
+
+
+
+## [kubedb/crd-manager](https://github.com/kubedb/crd-manager)
+
+### [v0.6.0](https://github.com/kubedb/crd-manager/releases/tag/v0.6.0)
+
+- [ce83843a](https://github.com/kubedb/crd-manager/commit/ce83843a) Prepare for release v0.6.0 (#59)
+- [31d35f51](https://github.com/kubedb/crd-manager/commit/31d35f51) Update github action modules (#58)
+
+
+
+## [kubedb/dashboard-restic-plugin](https://github.com/kubedb/dashboard-restic-plugin)
+
+### [v0.9.0](https://github.com/kubedb/dashboard-restic-plugin/releases/tag/v0.9.0)
+
+- [c3ab76d](https://github.com/kubedb/dashboard-restic-plugin/commit/c3ab76d) Prepare for release v0.9.0 (#28)
+- [8dc7721](https://github.com/kubedb/dashboard-restic-plugin/commit/8dc7721) Update github action modules (#27)
+
+
+
+## [kubedb/db-client-go](https://github.com/kubedb/db-client-go)
+
+### [v0.6.0](https://github.com/kubedb/db-client-go/releases/tag/v0.6.0)
+
+- [3866811f](https://github.com/kubedb/db-client-go/commit/3866811f) Prepare for release v0.6.0 (#157)
+- [aa26ffc7](https://github.com/kubedb/db-client-go/commit/aa26ffc7) Update github action modules (#156)
+- [681e7075](https://github.com/kubedb/db-client-go/commit/681e7075) Update github action modules (#155)
+
+
+
+## [kubedb/druid](https://github.com/kubedb/druid)
+
+### [v0.6.0](https://github.com/kubedb/druid/releases/tag/v0.6.0)
+
+- [9fbabd31](https://github.com/kubedb/druid/commit/9fbabd31) Prepare for release v0.6.0 (#66)
+- [57e41476](https://github.com/kubedb/druid/commit/57e41476) Update github action modules (#65)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.51.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.51.0)
+
+- [b7e8c024](https://github.com/kubedb/elasticsearch/commit/b7e8c0249) Prepare for release v0.51.0 (#746)
+- [e08b8e60](https://github.com/kubedb/elasticsearch/commit/e08b8e603) Update github action modules (#745)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.14.0](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.14.0)
+
+- [51e627d9](https://github.com/kubedb/elasticsearch-restic-plugin/commit/51e627d9) Prepare for release v0.14.0 (#52)
+- [3c9437f2](https://github.com/kubedb/elasticsearch-restic-plugin/commit/3c9437f2) Update github action modules (#51)
+
+
+
+## [kubedb/ferretdb](https://github.com/kubedb/ferretdb)
+
+### [v0.6.0](https://github.com/kubedb/ferretdb/releases/tag/v0.6.0)
+
+- [5b2c092e](https://github.com/kubedb/ferretdb/commit/5b2c092e) Prepare for release v0.6.0 (#56)
+- [f7e85570](https://github.com/kubedb/ferretdb/commit/f7e85570) Update github action modules (#55)
+- [d48f5be9](https://github.com/kubedb/ferretdb/commit/d48f5be9) Update github action modules (#54)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2025.1.9](https://github.com/kubedb/installer/releases/tag/v2025.1.9)
+
+- [ed4734a9](https://github.com/kubedb/installer/commit/ed4734a9) Prepare for release v2025.1.9 (#1497)
+- [24c19b90](https://github.com/kubedb/installer/commit/24c19b90) Fix es update constraints (#1501)
+- [d27e29c6](https://github.com/kubedb/installer/commit/d27e29c6) added updateConstrain for pgbouncer (#1500)
+- [911e9985](https://github.com/kubedb/installer/commit/911e9985) Update constraints for MariaDB (#1499)
+- [2716657d](https://github.com/kubedb/installer/commit/2716657d) Update constraints for mongodb (#1495)
+- [3bb62f22](https://github.com/kubedb/installer/commit/3bb62f22) Generate version update matrix (#1498)
+- [1893caed](https://github.com/kubedb/installer/commit/1893caed) Update deps
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.22.0](https://github.com/kubedb/kafka/releases/tag/v0.22.0)
+
+- [8c19ca3e](https://github.com/kubedb/kafka/commit/8c19ca3e) Prepare for release v0.22.0 (#131)
+- [f67701ca](https://github.com/kubedb/kafka/commit/f67701ca) Update github action modules (#129)
+
+
+
+## [kubedb/kibana](https://github.com/kubedb/kibana)
+
+### [v0.27.0](https://github.com/kubedb/kibana/releases/tag/v0.27.0)
+
+- [0352d8be](https://github.com/kubedb/kibana/commit/0352d8be) Prepare for release v0.27.0 (#134)
+- [8a4fa19e](https://github.com/kubedb/kibana/commit/8a4fa19e) Update github action modules (#133)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.14.0](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.14.0)
+
+- [462aeed](https://github.com/kubedb/kubedb-manifest-plugin/commit/462aeed) Prepare for release v0.14.0 (#83)
+- [2012ca0](https://github.com/kubedb/kubedb-manifest-plugin/commit/2012ca0) Update github action modules (#82)
+
+
+
+## [kubedb/kubedb-verifier](https://github.com/kubedb/kubedb-verifier)
+
+### [v0.2.0](https://github.com/kubedb/kubedb-verifier/releases/tag/v0.2.0)
+
+- [eb92631](https://github.com/kubedb/kubedb-verifier/commit/eb92631) Prepare for release v0.2.0 (#9)
+- [996460e](https://github.com/kubedb/kubedb-verifier/commit/996460e) Update github action modules (#8)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.35.0](https://github.com/kubedb/mariadb/releases/tag/v0.35.0)
+
+- [458e99dc](https://github.com/kubedb/mariadb/commit/458e99dc2) Prepare for release v0.35.0 (#301)
+- [b0e88a50](https://github.com/kubedb/mariadb/commit/b0e88a502) Update github action modules (#300)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.11.0](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.11.0)
+
+- [cf07e426](https://github.com/kubedb/mariadb-archiver/commit/cf07e426) Prepare for release v0.11.0 (#38)
+- [00efc652](https://github.com/kubedb/mariadb-archiver/commit/00efc652) Update github action modules (#37)
+- [b2152c04](https://github.com/kubedb/mariadb-archiver/commit/b2152c04) Update github action modules (#36)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.31.0](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.31.0)
+
+- [520b9d50](https://github.com/kubedb/mariadb-coordinator/commit/520b9d50) Prepare for release v0.31.0 (#133)
+- [a1fa7e06](https://github.com/kubedb/mariadb-coordinator/commit/a1fa7e06) Update github action modules (#132)
+
+
+
+## [kubedb/mariadb-csi-snapshotter-plugin](https://github.com/kubedb/mariadb-csi-snapshotter-plugin)
+
+### [v0.11.0](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/releases/tag/v0.11.0)
+
+- [58e6245](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/58e6245) Prepare for release v0.11.0 (#37)
+- [0efce43](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/0efce43) Update github action modules (#36)
+
+
+
+## [kubedb/mariadb-restic-plugin](https://github.com/kubedb/mariadb-restic-plugin)
+
+### [v0.9.0](https://github.com/kubedb/mariadb-restic-plugin/releases/tag/v0.9.0)
+
+- [f277695](https://github.com/kubedb/mariadb-restic-plugin/commit/f277695) Prepare for release v0.9.0 (#34)
+- [78fb004](https://github.com/kubedb/mariadb-restic-plugin/commit/78fb004) Update github action modules (#33)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.44.0](https://github.com/kubedb/memcached/releases/tag/v0.44.0)
+
+- [a8cb071c](https://github.com/kubedb/memcached/commit/a8cb071ca) Prepare for release v0.44.0 (#478)
+- [916ec545](https://github.com/kubedb/memcached/commit/916ec5455) Update github action modules (#477)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.44.0](https://github.com/kubedb/mongodb/releases/tag/v0.44.0)
+
+- [a298af18](https://github.com/kubedb/mongodb/commit/a298af18c) Prepare for release v0.44.0 (#676)
+- [4e7f9233](https://github.com/kubedb/mongodb/commit/4e7f9233b) Update github action modules (#675)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.12.0](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.12.0)
+
+- [672ca95](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/672ca95) Prepare for release v0.12.0 (#42)
+- [de8dc7b](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/de8dc7b) Update github action modules (#41)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.14.0](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.14.0)
+
+- [a572332](https://github.com/kubedb/mongodb-restic-plugin/commit/a572332) Prepare for release v0.14.0 (#74)
+- [b42f1b1](https://github.com/kubedb/mongodb-restic-plugin/commit/b42f1b1) Update github action modules (#73)
+
+
+
+## [kubedb/mssql-coordinator](https://github.com/kubedb/mssql-coordinator)
+
+### [v0.6.0](https://github.com/kubedb/mssql-coordinator/releases/tag/v0.6.0)
+
+- [a0b1ab4b](https://github.com/kubedb/mssql-coordinator/commit/a0b1ab4b) Prepare for release v0.6.0 (#26)
+- [30171f67](https://github.com/kubedb/mssql-coordinator/commit/30171f67) Update github action modules (#25)
+
+
+
+## [kubedb/mssqlserver](https://github.com/kubedb/mssqlserver)
+
+### [v0.6.0](https://github.com/kubedb/mssqlserver/releases/tag/v0.6.0)
+
+- [06e3e47b](https://github.com/kubedb/mssqlserver/commit/06e3e47b) Prepare for release v0.6.0 (#52)
+- [90a154a5](https://github.com/kubedb/mssqlserver/commit/90a154a5) Update github action modules (#51)
+
+
+
+## [kubedb/mssqlserver-archiver](https://github.com/kubedb/mssqlserver-archiver)
+
+### [v0.5.0](https://github.com/kubedb/mssqlserver-archiver/releases/tag/v0.5.0)
+
+- [01de86c](https://github.com/kubedb/mssqlserver-archiver/commit/01de86c) Update github action modules (#8)
+
+
+
+## [kubedb/mssqlserver-walg-plugin](https://github.com/kubedb/mssqlserver-walg-plugin)
+
+### [v0.5.0](https://github.com/kubedb/mssqlserver-walg-plugin/releases/tag/v0.5.0)
+
+- [ab5e490](https://github.com/kubedb/mssqlserver-walg-plugin/commit/ab5e490) Prepare for release v0.5.0 (#15)
+- [b63c5e0](https://github.com/kubedb/mssqlserver-walg-plugin/commit/b63c5e0) Update github action modules (#14)
+- [bd69aed](https://github.com/kubedb/mssqlserver-walg-plugin/commit/bd69aed) Update github action modules (#12)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.44.0](https://github.com/kubedb/mysql/releases/tag/v0.44.0)
+
+- [9ee5640a](https://github.com/kubedb/mysql/commit/9ee5640a2) Prepare for release v0.44.0 (#660)
+- [b0429276](https://github.com/kubedb/mysql/commit/b04292766) Update github action modules (#658)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.12.0](https://github.com/kubedb/mysql-archiver/releases/tag/v0.12.0)
+
+- [0fab1a47](https://github.com/kubedb/mysql-archiver/commit/0fab1a47) Prepare for release v0.12.0 (#50)
+- [715640b1](https://github.com/kubedb/mysql-archiver/commit/715640b1) Update github action modules (#48)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.29.0](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.29.0)
+
+- [70436079](https://github.com/kubedb/mysql-coordinator/commit/70436079) Prepare for release v0.29.0 (#131)
+- [ae4a76f4](https://github.com/kubedb/mysql-coordinator/commit/ae4a76f4) Update github action modules (#130)
+
+
+
+## [kubedb/mysql-csi-snapshotter-plugin](https://github.com/kubedb/mysql-csi-snapshotter-plugin)
+
+### [v0.12.0](https://github.com/kubedb/mysql-csi-snapshotter-plugin/releases/tag/v0.12.0)
+
+- [3c5d2f7](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/3c5d2f7) Prepare for release v0.12.0 (#38)
+- [1f60220](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/1f60220) Update github action modules (#37)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.14.0](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.14.0)
+
+- [032f02a](https://github.com/kubedb/mysql-restic-plugin/commit/032f02a) Prepare for release v0.14.0 (#65)
+- [ce376f3](https://github.com/kubedb/mysql-restic-plugin/commit/ce376f3) Update github action modules (#64)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.29.0](https://github.com/kubedb/mysql-router-init/releases/tag/v0.29.0)
+
+- [05a92e2](https://github.com/kubedb/mysql-router-init/commit/05a92e2) Update github action modules (#48)
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.38.0](https://github.com/kubedb/ops-manager/releases/tag/v0.38.0)
+
+- [7333aed1](https://github.com/kubedb/ops-manager/commit/7333aed13) Prepare for release v0.38.0 (#699)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.38.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.38.0)
+
+- [4c003572](https://github.com/kubedb/percona-xtradb/commit/4c0035725) Prepare for release v0.38.0 (#391)
+- [dc2d9715](https://github.com/kubedb/percona-xtradb/commit/dc2d9715b) Update github action modules (#390)
+- [68e6689f](https://github.com/kubedb/percona-xtradb/commit/68e6689fe) Update github action modules (#388)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.24.0](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.24.0)
+
+- [7b378bbd](https://github.com/kubedb/percona-xtradb-coordinator/commit/7b378bbd) Prepare for release v0.24.0 (#87)
+- [0952931d](https://github.com/kubedb/percona-xtradb-coordinator/commit/0952931d) Update github action modules (#86)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.35.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.35.0)
+
+- [fd03be43](https://github.com/kubedb/pg-coordinator/commit/fd03be43) Prepare for release v0.35.0 (#183)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.38.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.38.0)
+
+- [fa9b2dad](https://github.com/kubedb/pgbouncer/commit/fa9b2dad) Prepare for release v0.38.0 (#355)
+- [03a67630](https://github.com/kubedb/pgbouncer/commit/03a67630) Update github action modules (#354)
+
+
+
+## [kubedb/pgpool](https://github.com/kubedb/pgpool)
+
+### [v0.6.0](https://github.com/kubedb/pgpool/releases/tag/v0.6.0)
+
+- [c029f5e1](https://github.com/kubedb/pgpool/commit/c029f5e1) Prepare for release v0.6.0 (#57)
+- [2ae35af8](https://github.com/kubedb/pgpool/commit/2ae35af8) Update github action modules (#55)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.51.0](https://github.com/kubedb/postgres/releases/tag/v0.51.0)
+
+- [0ac15c2c](https://github.com/kubedb/postgres/commit/0ac15c2c3) Prepare for release v0.51.0 (#781)
+- [7187f979](https://github.com/kubedb/postgres/commit/7187f9794) Update github action modules (#779)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.12.0](https://github.com/kubedb/postgres-archiver/releases/tag/v0.12.0)
+
+- [ebcaeedd](https://github.com/kubedb/postgres-archiver/commit/ebcaeedd) Prepare for release v0.12.0 (#51)
+- [7ffc8f22](https://github.com/kubedb/postgres-archiver/commit/7ffc8f22) Update github action modules (#49)
+- [e71fc319](https://github.com/kubedb/postgres-archiver/commit/e71fc319) Update github action modules (#47)
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.12.0](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.12.0)
+
+- [a812501](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/a812501) Prepare for release v0.12.0 (#48)
+- [4a6acc9](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/4a6acc9) Update github action modules (#47)
+- [3a568ff](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/3a568ff) Update github action modules (#45)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.14.0](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.14.0)
+
+- [1e06dda](https://github.com/kubedb/postgres-restic-plugin/commit/1e06dda) Prepare for release v0.14.0 (#61)
+
+
+
+## [kubedb/provider-aws](https://github.com/kubedb/provider-aws)
+
+### [v0.13.0](https://github.com/kubedb/provider-aws/releases/tag/v0.13.0)
+
+
+
+
+## [kubedb/provider-azure](https://github.com/kubedb/provider-azure)
+
+### [v0.13.0](https://github.com/kubedb/provider-azure/releases/tag/v0.13.0)
+
+
+
+
+## [kubedb/provider-gcp](https://github.com/kubedb/provider-gcp)
+
+### [v0.13.0](https://github.com/kubedb/provider-gcp/releases/tag/v0.13.0)
+
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.51.0](https://github.com/kubedb/provisioner/releases/tag/v0.51.0)
+
+- [39000c34](https://github.com/kubedb/provisioner/commit/39000c342) Prepare for release v0.51.0 (#131)
+- [d75d6279](https://github.com/kubedb/provisioner/commit/d75d6279c) Update github action modules (#130)
+- [0e96443f](https://github.com/kubedb/provisioner/commit/0e96443f1) Update github action modules (#128)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.38.0](https://github.com/kubedb/proxysql/releases/tag/v0.38.0)
+
+- [ab482443](https://github.com/kubedb/proxysql/commit/ab4824432) Prepare for release v0.38.0 (#371)
+- [52add947](https://github.com/kubedb/proxysql/commit/52add9471) Update github action modules (#370)
+
+
+
+## [kubedb/rabbitmq](https://github.com/kubedb/rabbitmq)
+
+### [v0.6.0](https://github.com/kubedb/rabbitmq/releases/tag/v0.6.0)
+
+- [95d560ff](https://github.com/kubedb/rabbitmq/commit/95d560ff) Prepare for release v0.6.0 (#62)
+- [c62683d7](https://github.com/kubedb/rabbitmq/commit/c62683d7) Update github action modules (#61)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.44.0](https://github.com/kubedb/redis/releases/tag/v0.44.0)
+
+- [0535751e](https://github.com/kubedb/redis/commit/0535751ee) Prepare for release v0.44.0 (#570)
+- [f26cefc6](https://github.com/kubedb/redis/commit/f26cefc62) Update github action modules (#569)
+- [262dfd9c](https://github.com/kubedb/redis/commit/262dfd9c7) Update github action modules (#567)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.30.0](https://github.com/kubedb/redis-coordinator/releases/tag/v0.30.0)
+
+- [e7ccd8c3](https://github.com/kubedb/redis-coordinator/commit/e7ccd8c3) Prepare for release v0.30.0 (#118)
+- [27299223](https://github.com/kubedb/redis-coordinator/commit/27299223) Update github action modules (#117)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.14.0](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.14.0)
+
+- [b1c1602](https://github.com/kubedb/redis-restic-plugin/commit/b1c1602) Prepare for release v0.14.0 (#55)
+- [0f212e7](https://github.com/kubedb/redis-restic-plugin/commit/0f212e7) Update github action modules (#54)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.38.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.38.0)
+
+- [1525e27b](https://github.com/kubedb/replication-mode-detector/commit/1525e27b) Prepare for release v0.38.0 (#284)
+- [9c437e88](https://github.com/kubedb/replication-mode-detector/commit/9c437e88) Update github action modules (#283)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.27.0](https://github.com/kubedb/schema-manager/releases/tag/v0.27.0)
+
+- [70ae7333](https://github.com/kubedb/schema-manager/commit/70ae7333) Prepare for release v0.27.0 (#128)
+- [6927781a](https://github.com/kubedb/schema-manager/commit/6927781a) Update github action modules (#127)
+
+
+
+## [kubedb/singlestore](https://github.com/kubedb/singlestore)
+
+### [v0.6.0](https://github.com/kubedb/singlestore/releases/tag/v0.6.0)
+
+- [e6c6c715](https://github.com/kubedb/singlestore/commit/e6c6c715) Prepare for release v0.6.0 (#56)
+- [6157e138](https://github.com/kubedb/singlestore/commit/6157e138) Update github action modules (#55)
+
+
+
+## [kubedb/singlestore-coordinator](https://github.com/kubedb/singlestore-coordinator)
+
+### [v0.6.0](https://github.com/kubedb/singlestore-coordinator/releases/tag/v0.6.0)
+
+- [a8ed8aa](https://github.com/kubedb/singlestore-coordinator/commit/a8ed8aa) Prepare for release v0.6.0 (#33)
+- [63f46cc](https://github.com/kubedb/singlestore-coordinator/commit/63f46cc) Update github action modules (#32)
+
+
+
+## [kubedb/singlestore-restic-plugin](https://github.com/kubedb/singlestore-restic-plugin)
+
+### [v0.9.0](https://github.com/kubedb/singlestore-restic-plugin/releases/tag/v0.9.0)
+
+- [df7eb0e](https://github.com/kubedb/singlestore-restic-plugin/commit/df7eb0e) Prepare for release v0.9.0 (#32)
+- [5d8845b](https://github.com/kubedb/singlestore-restic-plugin/commit/5d8845b) Update github action modules (#31)
+
+
+
+## [kubedb/solr](https://github.com/kubedb/solr)
+
+### [v0.6.0](https://github.com/kubedb/solr/releases/tag/v0.6.0)
+
+- [2cc22dac](https://github.com/kubedb/solr/commit/2cc22dac) Prepare for release v0.6.0 (#63)
+- [9430ec64](https://github.com/kubedb/solr/commit/9430ec64) Update github action modules (#62)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.36.0](https://github.com/kubedb/tests/releases/tag/v0.36.0)
+
+- [5ce809da](https://github.com/kubedb/tests/commit/5ce809da) Prepare for release v0.36.0 (#430)
+- [7ab26162](https://github.com/kubedb/tests/commit/7ab26162) Add Rotate OpsRequest Test (#420)
+- [9245b237](https://github.com/kubedb/tests/commit/9245b237) Update github action modules (#426)
+- [7964d1d0](https://github.com/kubedb/tests/commit/7964d1d0) Add Druid horizontal scaling (#406)
+- [a12a2c0d](https://github.com/kubedb/tests/commit/a12a2c0d) Add Druid Vertical Scaling and Volume Expantion tests (#400)
+- [c050d1e0](https://github.com/kubedb/tests/commit/c050d1e0) Remove kafka from appendtocleanuplist (#425)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.27.0](https://github.com/kubedb/ui-server/releases/tag/v0.27.0)
+
+- [ce0daab1](https://github.com/kubedb/ui-server/commit/ce0daab1) Prepare for release v0.27.0 (#144)
+- [7a873c0d](https://github.com/kubedb/ui-server/commit/7a873c0d) Update github action modules (#143)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.27.0](https://github.com/kubedb/webhook-server/releases/tag/v0.27.0)
+
+- [d9703947](https://github.com/kubedb/webhook-server/commit/d9703947) Prepare for release v0.27.0 (#140)
+- [d5ebf56c](https://github.com/kubedb/webhook-server/commit/d5ebf56c) Update github action modules (#139)
+
+
+
+## [kubedb/zookeeper](https://github.com/kubedb/zookeeper)
+
+### [v0.6.0](https://github.com/kubedb/zookeeper/releases/tag/v0.6.0)
+
+- [21eeb4cd](https://github.com/kubedb/zookeeper/commit/21eeb4cd) Prepare for release v0.6.0 (#54)
+- [6a1412ed](https://github.com/kubedb/zookeeper/commit/6a1412ed) Update github action modules (#53)
+
+
+
+## [kubedb/zookeeper-restic-plugin](https://github.com/kubedb/zookeeper-restic-plugin)
+
+### [v0.7.0](https://github.com/kubedb/zookeeper-restic-plugin/releases/tag/v0.7.0)
+
+- [d8afbeb](https://github.com/kubedb/zookeeper-restic-plugin/commit/d8afbeb) Prepare for release v0.7.0 (#24)
+- [1599f4b](https://github.com/kubedb/zookeeper-restic-plugin/commit/1599f4b) Update github action modules (#23)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2025.1.9
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/105
Signed-off-by: 1gtm <1gtm@appscode.com>