### PR TITLE
Prepare for release v2025.3.20-rc.1

### DIFF
--- a/docs/CHANGELOG-v2025.3.20-rc.1.md
+++ b/docs/CHANGELOG-v2025.3.20-rc.1.md
@@ -1,0 +1,649 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2025.3.20-rc.1
+    name: Changelog-v2025.3.20-rc.1
+    parent: welcome
+    weight: 20250320
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.3.20-rc.1/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.3.20-rc.1/
+---
+
+# KubeDB v2025.3.20-rc.1 (2025-03-20)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.53.0-rc.1](https://github.com/kubedb/apimachinery/releases/tag/v0.53.0-rc.1)
+
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.37.0-rc.1](https://github.com/kubedb/autoscaler/releases/tag/v0.37.0-rc.1)
+
+- [9f61207e](https://github.com/kubedb/autoscaler/commit/9f61207e) Prepare for release v0.37.0-rc.1 (#242)
+- [02c7d33b](https://github.com/kubedb/autoscaler/commit/02c7d33b) Implement new-style webhook; Update to k8s v32 (#241)
+- [34248ff9](https://github.com/kubedb/autoscaler/commit/34248ff9) Prepare for release v0.37.0 (#240)
+- [e05a087b](https://github.com/kubedb/autoscaler/commit/e05a087b) Use Go 1.24 (#239)
+
+
+
+## [kubedb/cassandra](https://github.com/kubedb/cassandra)
+
+### [v0.6.0-rc.1](https://github.com/kubedb/cassandra/releases/tag/v0.6.0-rc.1)
+
+- [9288c65b](https://github.com/kubedb/cassandra/commit/9288c65b) Prepare for release v0.6.0-rc.1 (#30)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.53.0-rc.1](https://github.com/kubedb/cli/releases/tag/v0.53.0-rc.1)
+
+- [3085c9cd](https://github.com/kubedb/cli/commit/3085c9cdd) Prepare for release v0.53.0-rc.1 (#793)
+
+
+
+## [kubedb/clickhouse](https://github.com/kubedb/clickhouse)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/clickhouse/releases/tag/v0.8.0-rc.1)
+
+- [db836fa8](https://github.com/kubedb/clickhouse/commit/db836fa8) Prepare for release v0.8.0-rc.1 (#45)
+
+
+
+## [kubedb/crd-manager](https://github.com/kubedb/crd-manager)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/crd-manager/releases/tag/v0.8.0-rc.1)
+
+- [e5b58c7d](https://github.com/kubedb/crd-manager/commit/e5b58c7d) Prepare for release v0.8.0-rc.1 (#69)
+- [e3384a94](https://github.com/kubedb/crd-manager/commit/e3384a94) Add gitops CRDs (#70)
+
+
+
+## [kubedb/dashboard-restic-plugin](https://github.com/kubedb/dashboard-restic-plugin)
+
+### [v0.11.0-rc.1](https://github.com/kubedb/dashboard-restic-plugin/releases/tag/v0.11.0-rc.1)
+
+- [e30202c](https://github.com/kubedb/dashboard-restic-plugin/commit/e30202c) Prepare for release v0.11.0-rc.1 (#36)
+
+
+
+## [kubedb/db-client-go](https://github.com/kubedb/db-client-go)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/db-client-go/releases/tag/v0.8.0-rc.1)
+
+- [ca0ff72d](https://github.com/kubedb/db-client-go/commit/ca0ff72d) Prepare for release v0.8.0-rc.1 (#168)
+
+
+
+## [kubedb/druid](https://github.com/kubedb/druid)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/druid/releases/tag/v0.8.0-rc.1)
+
+- [795a8bb0](https://github.com/kubedb/druid/commit/795a8bb0) Prepare for release v0.8.0-rc.1 (#80)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.53.0-rc.1](https://github.com/kubedb/elasticsearch/releases/tag/v0.53.0-rc.1)
+
+- [b5e9c2e5](https://github.com/kubedb/elasticsearch/commit/b5e9c2e5b) Prepare for release v0.53.0-rc.1 (#761)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.16.0-rc.1)
+
+- [1e2569f5](https://github.com/kubedb/elasticsearch-restic-plugin/commit/1e2569f5) Prepare for release v0.16.0-rc.1 (#60)
+- [dd7dd4b8](https://github.com/kubedb/elasticsearch-restic-plugin/commit/dd7dd4b8) Prepare for release v0.15.0 (#59)
+- [9e05f686](https://github.com/kubedb/elasticsearch-restic-plugin/commit/9e05f686) Use Go 1.24 (#58)
+
+
+
+## [kubedb/ferretdb](https://github.com/kubedb/ferretdb)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/ferretdb/releases/tag/v0.8.0-rc.1)
+
+- [5e59d781](https://github.com/kubedb/ferretdb/commit/5e59d781) Prepare for release v0.8.0-rc.1 (#69)
+
+
+
+## [kubedb/gitops](https://github.com/kubedb/gitops)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/gitops/releases/tag/v0.1.0-rc.1)
+
+- [b9208aa9](https://github.com/kubedb/gitops/commit/b9208aa9) Prepare for release v0.1.0-rc.1 (#9)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2025.3.20-rc.1](https://github.com/kubedb/installer/releases/tag/v2025.3.20-rc.1)
+
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.24.0-rc.1](https://github.com/kubedb/kafka/releases/tag/v0.24.0-rc.1)
+
+- [9f2b6c69](https://github.com/kubedb/kafka/commit/9f2b6c69) Prepare for release v0.24.0-rc.1 (#146)
+- [e8195ac4](https://github.com/kubedb/kafka/commit/e8195ac4) Update webhook dependency (#145)
+- [1714ea67](https://github.com/kubedb/kafka/commit/1714ea67) Add Kafka Operator Shading Support (#144)
+- [a5d76b95](https://github.com/kubedb/kafka/commit/a5d76b95) Setup new webhook style; Update to k8s v1.32 (#143)
+- [bb875226](https://github.com/kubedb/kafka/commit/bb875226) Install ace-user-roles; Run tests twice a week (#142)
+- [5760f6ef](https://github.com/kubedb/kafka/commit/5760f6ef) Prepare for release v0.23.0 (#141)
+- [cecd7700](https://github.com/kubedb/kafka/commit/cecd7700) Test against k8s 1.32 (#140)
+- [77970b06](https://github.com/kubedb/kafka/commit/77970b06) Use Go 1.24 (#139)
+- [e63d1571](https://github.com/kubedb/kafka/commit/e63d1571) Report namespace info with billing event (#138)
+- [256409b5](https://github.com/kubedb/kafka/commit/256409b5) Show the reason for not satifying license restriction (#137)
+- [5d530b62](https://github.com/kubedb/kafka/commit/5d530b62) Use testrig
+
+
+
+## [kubedb/kibana](https://github.com/kubedb/kibana)
+
+### [v0.29.0-rc.1](https://github.com/kubedb/kibana/releases/tag/v0.29.0-rc.1)
+
+- [2ca1a410](https://github.com/kubedb/kibana/commit/2ca1a410) Prepare for release v0.29.0-rc.1 (#147)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.16.0-rc.1)
+
+- [8dbc92d0](https://github.com/kubedb/kubedb-manifest-plugin/commit/8dbc92d0) Prepare for release v0.16.0-rc.1 (#91)
+- [01b12a7a](https://github.com/kubedb/kubedb-manifest-plugin/commit/01b12a7a) Prepare for release v0.15.0 (#90)
+- [891e1ea9](https://github.com/kubedb/kubedb-manifest-plugin/commit/891e1ea9) Use Go 1.24 (#89)
+
+
+
+## [kubedb/kubedb-verifier](https://github.com/kubedb/kubedb-verifier)
+
+### [v0.4.0-rc.1](https://github.com/kubedb/kubedb-verifier/releases/tag/v0.4.0-rc.1)
+
+- [cb903bb](https://github.com/kubedb/kubedb-verifier/commit/cb903bb) Prepare for release v0.4.0-rc.1 (#16)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.37.0-rc.1](https://github.com/kubedb/mariadb/releases/tag/v0.37.0-rc.1)
+
+- [f6bad15c](https://github.com/kubedb/mariadb/commit/f6bad15c0) Prepare for release v0.37.0-rc.1 (#323)
+- [12653892](https://github.com/kubedb/mariadb/commit/126538929) Restructure admission webhook (#322)
+- [c858218f](https://github.com/kubedb/mariadb/commit/c858218f2) Run Maxscale as Non Root User (#321)
+- [9aaa179a](https://github.com/kubedb/mariadb/commit/9aaa179ad) Add MaxScale Cluster Support (#318)
+- [84f8d44c](https://github.com/kubedb/mariadb/commit/84f8d44c8) Update IRSA annotations (#320)
+- [510aeb7a](https://github.com/kubedb/mariadb/commit/510aeb7a8) ShardConfiguration, Install ace-user-roles, Run tests twice a week,  (#316)
+- [b4fc4ddc](https://github.com/kubedb/mariadb/commit/b4fc4ddc7) Update to k8s v32 (#319)
+- [08554f66](https://github.com/kubedb/mariadb/commit/08554f660) Add MariaDB Replication Support (#303)
+- [e2212de1](https://github.com/kubedb/mariadb/commit/e2212de15) Lower Sidekick Default Resource (#315)
+- [5aae329e](https://github.com/kubedb/mariadb/commit/5aae329ea) Prepare for release v0.36.0 (#314)
+- [2102f599](https://github.com/kubedb/mariadb/commit/2102f5992) Test against k8s 1.32 (#313)
+- [c48e29b6](https://github.com/kubedb/mariadb/commit/c48e29b67) Use Go 1.24 (#312)
+- [c2df3bc9](https://github.com/kubedb/mariadb/commit/c2df3bc9b) Report namespace info with billing event (#311)
+- [d72a123c](https://github.com/kubedb/mariadb/commit/d72a123ca) Show the reason for not satifying license restriction (#310)
+- [d586b568](https://github.com/kubedb/mariadb/commit/d586b5689) Use testrig
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.13.0-rc.1](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.13.0-rc.1)
+
+- [ea393fb4](https://github.com/kubedb/mariadb-archiver/commit/ea393fb4) Prepare for release v0.13.0-rc.1 (#46)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.33.0-rc.1](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.33.0-rc.1)
+
+- [fe289242](https://github.com/kubedb/mariadb-coordinator/commit/fe289242) Prepare for release v0.33.0-rc.1 (#140)
+- [a19d30bf](https://github.com/kubedb/mariadb-coordinator/commit/a19d30bf) Add Support for MariaDB Replication (#134)
+- [24eeb621](https://github.com/kubedb/mariadb-coordinator/commit/24eeb621) Prepare for release v0.32.0 (#139)
+- [a8c8f873](https://github.com/kubedb/mariadb-coordinator/commit/a8c8f873) Use Go 1.24 (#138)
+
+
+
+## [kubedb/mariadb-restic-plugin](https://github.com/kubedb/mariadb-restic-plugin)
+
+### [v0.11.0-rc.1](https://github.com/kubedb/mariadb-restic-plugin/releases/tag/v0.11.0-rc.1)
+
+- [d525ec1](https://github.com/kubedb/mariadb-restic-plugin/commit/d525ec1) Prepare for release v0.11.0-rc.1 (#43)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.46.0-rc.1](https://github.com/kubedb/memcached/releases/tag/v0.46.0-rc.1)
+
+- [ca7ab019](https://github.com/kubedb/memcached/commit/ca7ab0190) Prepare for release v0.46.0-rc.1 (#494)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.46.0-rc.1](https://github.com/kubedb/mongodb/releases/tag/v0.46.0-rc.1)
+
+- [6da8b44f](https://github.com/kubedb/mongodb/commit/6da8b44fd) Prepare for release v0.46.0-rc.1 (#698)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.14.0-rc.1)
+
+- [f23ef219](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/f23ef219) Prepare for release v0.14.0-rc.1 (#48)
+- [d5b6acbe](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/d5b6acbe) Prepare for release v0.13.0 (#47)
+- [feff5cc7](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/feff5cc7) Use Go 1.24 (#46)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.16.0-rc.1)
+
+- [849d2e4](https://github.com/kubedb/mongodb-restic-plugin/commit/849d2e4) Prepare for release v0.16.0-rc.1 (#81)
+- [9afda5c](https://github.com/kubedb/mongodb-restic-plugin/commit/9afda5c) Prepare for release v0.15.0 (#80)
+- [6f5b57b](https://github.com/kubedb/mongodb-restic-plugin/commit/6f5b57b) Use Go 1.24 (#79)
+
+
+
+## [kubedb/mssql-coordinator](https://github.com/kubedb/mssql-coordinator)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/mssql-coordinator/releases/tag/v0.8.0-rc.1)
+
+- [d2e1774a](https://github.com/kubedb/mssql-coordinator/commit/d2e1774a) Prepare for release v0.8.0-rc.1 (#33)
+
+
+
+## [kubedb/mssqlserver](https://github.com/kubedb/mssqlserver)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/mssqlserver/releases/tag/v0.8.0-rc.1)
+
+- [9798e329](https://github.com/kubedb/mssqlserver/commit/9798e329) Prepare for release v0.8.0-rc.1 (#73)
+
+
+
+## [kubedb/mssqlserver-archiver](https://github.com/kubedb/mssqlserver-archiver)
+
+### [v0.7.0-rc.1](https://github.com/kubedb/mssqlserver-archiver/releases/tag/v0.7.0-rc.1)
+
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.46.0-rc.1](https://github.com/kubedb/mysql/releases/tag/v0.46.0-rc.1)
+
+- [7d3e6468](https://github.com/kubedb/mysql/commit/7d3e64685) Prepare for release v0.46.0-rc.1 (#678)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/mysql-archiver/releases/tag/v0.14.0-rc.1)
+
+- [ffeaa873](https://github.com/kubedb/mysql-archiver/commit/ffeaa873) Prepare for release v0.14.0-rc.1 (#56)
+- [39107a7b](https://github.com/kubedb/mysql-archiver/commit/39107a7b) Prepare for release v0.13.0 (#55)
+- [ef00cd3b](https://github.com/kubedb/mysql-archiver/commit/ef00cd3b) Use Go 1.24 (#54)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.31.0-rc.1](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.31.0-rc.1)
+
+- [d4bc9ecb](https://github.com/kubedb/mysql-coordinator/commit/d4bc9ecb) Prepare for release v0.31.0-rc.1 (#139)
+
+
+
+## [kubedb/mysql-csi-snapshotter-plugin](https://github.com/kubedb/mysql-csi-snapshotter-plugin)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/mysql-csi-snapshotter-plugin/releases/tag/v0.14.0-rc.1)
+
+- [1215a3d1](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/1215a3d1) Prepare for release v0.14.0-rc.1 (#44)
+- [1511498e](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/1511498e) Prepare for release v0.13.0 (#43)
+- [d1c7f1b1](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/d1c7f1b1) Use Go 1.24 (#42)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.16.0-rc.1)
+
+- [a1a92a6](https://github.com/kubedb/mysql-restic-plugin/commit/a1a92a6) Prepare for release v0.16.0-rc.1 (#71)
+- [a19fa28](https://github.com/kubedb/mysql-restic-plugin/commit/a19fa28) Prepare for release v0.15.0 (#70)
+- [78dcba1](https://github.com/kubedb/mysql-restic-plugin/commit/78dcba1) Use Go 1.24 (#69)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.31.0-rc.1](https://github.com/kubedb/mysql-router-init/releases/tag/v0.31.0-rc.1)
+
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.39.0-rc.1](https://github.com/kubedb/ops-manager/releases/tag/v0.39.0-rc.1)
+
+- [2933d1ce](https://github.com/kubedb/ops-manager/commit/2933d1cef) Prepare for release v0.39.0-rc.1 (#719)
+- [ce00c939](https://github.com/kubedb/ops-manager/commit/ce00c9392) Move all ops valiadators to apimachinery (#718)
+- [9a963c89](https://github.com/kubedb/ops-manager/commit/9a963c896) Update db machineProfiles from ops annotation (#717)
+- [a28a1df8](https://github.com/kubedb/ops-manager/commit/a28a1df8f) FerretDB replication support (#716)
+- [416df7a5](https://github.com/kubedb/ops-manager/commit/416df7a57) Add MariaDB Replication Support (#706)
+- [c9f66bff](https://github.com/kubedb/ops-manager/commit/c9f66bffd) Update to k8s v0.32 (#715)
+- [491e4de0](https://github.com/kubedb/ops-manager/commit/491e4de03) Fix existing rotateauth getting getting ignored when TLS enabled (#713)
+- [429376f1](https://github.com/kubedb/ops-manager/commit/429376f16) Prepare for release v0.39.0 (#712)
+- [2db83b1f](https://github.com/kubedb/ops-manager/commit/2db83b1f7) Add PgOps ReconnectStandby, ForceFailover, SetRaftKeyPair (#709)
+- [d2921d29](https://github.com/kubedb/ops-manager/commit/d2921d296) Test against k8s 1.32 (#711)
+- [3c5e484b](https://github.com/kubedb/ops-manager/commit/3c5e484be) Use Go 1.24 (#710)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.40.0-rc.1](https://github.com/kubedb/percona-xtradb/releases/tag/v0.40.0-rc.1)
+
+- [b9354d4d](https://github.com/kubedb/percona-xtradb/commit/b9354d4d7) Prepare for release v0.40.0-rc.1 (#404)
+- [3cfd53c5](https://github.com/kubedb/percona-xtradb/commit/3cfd53c55) Restructure admission webhook (#403)
+- [d6174a69](https://github.com/kubedb/percona-xtradb/commit/d6174a69c) Add operator-sharding; Install ace-user-roles (#401)
+- [fd5c0af1](https://github.com/kubedb/percona-xtradb/commit/fd5c0af1f) Update to k8s v32 (#402)
+- [04e2466a](https://github.com/kubedb/percona-xtradb/commit/04e2466a3) Prepare for release v0.39.0 (#400)
+- [29cda551](https://github.com/kubedb/percona-xtradb/commit/29cda5511) Test against k8s 1.32 (#399)
+- [45ce72c7](https://github.com/kubedb/percona-xtradb/commit/45ce72c71) Use Go 1.24 (#398)
+- [672219b8](https://github.com/kubedb/percona-xtradb/commit/672219b81) Report namespace info with billing event (#397)
+- [2370ef83](https://github.com/kubedb/percona-xtradb/commit/2370ef834) Wait for PVC restoration by stash (#396)
+- [01e39d5f](https://github.com/kubedb/percona-xtradb/commit/01e39d5fe) Show the reason for not satifying license restriction (#395)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.26.0-rc.1](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.26.0-rc.1)
+
+- [20479694](https://github.com/kubedb/percona-xtradb-coordinator/commit/20479694) Prepare for release v0.26.0-rc.1 (#93)
+- [5dfc6dd5](https://github.com/kubedb/percona-xtradb-coordinator/commit/5dfc6dd5) Prepare for release v0.25.0 (#92)
+- [52e1530a](https://github.com/kubedb/percona-xtradb-coordinator/commit/52e1530a) Use Go 1.24 (#91)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.37.0-rc.1](https://github.com/kubedb/pg-coordinator/releases/tag/v0.37.0-rc.1)
+
+- [f676b187](https://github.com/kubedb/pg-coordinator/commit/f676b187) Prepare for release v0.37.0-rc.1 (#195)
+- [7655688f](https://github.com/kubedb/pg-coordinator/commit/7655688f) Set Raft Role Correctly (#194)
+- [7542383e](https://github.com/kubedb/pg-coordinator/commit/7542383e) Do Checkpoint on primary before running pg_rewind (#193)
+- [421d91d6](https://github.com/kubedb/pg-coordinator/commit/421d91d6) Prepare for release v0.36.0 (#192)
+- [1488a1d9](https://github.com/kubedb/pg-coordinator/commit/1488a1d9) Fix a bug for force failover (#191)
+- [b04c16fd](https://github.com/kubedb/pg-coordinator/commit/b04c16fd) Use Go 1.24 (#190)
+- [35382941](https://github.com/kubedb/pg-coordinator/commit/35382941) Reduce API Server Load by Adding Wait Interval When DB Is In Not Ready State (#189)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.40.0-rc.1](https://github.com/kubedb/pgbouncer/releases/tag/v0.40.0-rc.1)
+
+- [45eac53c](https://github.com/kubedb/pgbouncer/commit/45eac53c) Prepare for release v0.40.0-rc.1 (#368)
+
+
+
+## [kubedb/pgpool](https://github.com/kubedb/pgpool)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/pgpool/releases/tag/v0.8.0-rc.1)
+
+- [23eb8dbb](https://github.com/kubedb/pgpool/commit/23eb8dbb) Prepare for release v0.8.0-rc.1 (#71)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.53.0-rc.1](https://github.com/kubedb/postgres/releases/tag/v0.53.0-rc.1)
+
+- [79de1743](https://github.com/kubedb/postgres/commit/79de17436) Prepare for release v0.53.0-rc.1 (#806)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/postgres-archiver/releases/tag/v0.14.0-rc.1)
+
+- [96f5fde6](https://github.com/kubedb/postgres-archiver/commit/96f5fde6) Prepare for release v0.14.0-rc.1 (#58)
+- [c40544c2](https://github.com/kubedb/postgres-archiver/commit/c40544c2) Prepare for release v0.13.0 (#57)
+- [4cc8a8e7](https://github.com/kubedb/postgres-archiver/commit/4cc8a8e7) Use Go 1.24 (#56)
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.14.0-rc.1)
+
+- [c910645a](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/c910645a) Prepare for release v0.14.0-rc.1 (#54)
+- [63ba8c91](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/63ba8c91) Prepare for release v0.13.0 (#53)
+- [c4b928f2](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/c4b928f2) Use Go 1.24 (#52)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.16.0-rc.1)
+
+- [a047ea7](https://github.com/kubedb/postgres-restic-plugin/commit/a047ea7) Prepare for release v0.16.0-rc.1 (#68)
+- [4219198](https://github.com/kubedb/postgres-restic-plugin/commit/4219198) Prepare for release v0.15.0 (#67)
+- [3773695](https://github.com/kubedb/postgres-restic-plugin/commit/3773695) Use Go 1.24 (#66)
+
+
+
+## [kubedb/provider-aws](https://github.com/kubedb/provider-aws)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/provider-aws/releases/tag/v0.14.0-rc.1)
+
+
+
+
+## [kubedb/provider-azure](https://github.com/kubedb/provider-azure)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/provider-azure/releases/tag/v0.14.0-rc.1)
+
+
+
+
+## [kubedb/provider-gcp](https://github.com/kubedb/provider-gcp)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/provider-gcp/releases/tag/v0.14.0-rc.1)
+
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.53.0-rc.1](https://github.com/kubedb/provisioner/releases/tag/v0.53.0-rc.1)
+
+- [f3804631](https://github.com/kubedb/provisioner/commit/f38046310) Prepare for release v0.53.0-rc.1 (#144)
+- [c2f93ed2](https://github.com/kubedb/provisioner/commit/c2f93ed2c) Add Sharding Ability To Provisioner (#140)
+- [4a037775](https://github.com/kubedb/provisioner/commit/4a037775a) Update to k8s v0.32 (#141)
+- [511ae726](https://github.com/kubedb/provisioner/commit/511ae7263) Set default resources on the walg container
+- [1649d46c](https://github.com/kubedb/provisioner/commit/1649d46cd) Prepare for release v0.52.0 (#139)
+- [2aa0d9cf](https://github.com/kubedb/provisioner/commit/2aa0d9cfa) Add stash scheme
+- [f7815d07](https://github.com/kubedb/provisioner/commit/f7815d079) Test against k8s 1.32 (#138)
+- [c98910cd](https://github.com/kubedb/provisioner/commit/c98910cd8) Use Go 1.24 (#137)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.40.0-rc.1](https://github.com/kubedb/proxysql/releases/tag/v0.40.0-rc.1)
+
+- [7f5bb28a](https://github.com/kubedb/proxysql/commit/7f5bb28aa) Prepare for release v0.40.0-rc.1 (#389)
+
+
+
+## [kubedb/rabbitmq](https://github.com/kubedb/rabbitmq)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/rabbitmq/releases/tag/v0.8.0-rc.1)
+
+- [74769b6b](https://github.com/kubedb/rabbitmq/commit/74769b6b) Prepare for release v0.8.0-rc.1 (#79)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.46.0-rc.1](https://github.com/kubedb/redis/releases/tag/v0.46.0-rc.1)
+
+- [0385fa3c](https://github.com/kubedb/redis/commit/0385fa3cc) Prepare for release v0.46.0-rc.1 (#589)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.32.0-rc.1](https://github.com/kubedb/redis-coordinator/releases/tag/v0.32.0-rc.1)
+
+- [0b85ddde](https://github.com/kubedb/redis-coordinator/commit/0b85ddde) Prepare for release v0.32.0-rc.1 (#125)
+- [ad30d0f4](https://github.com/kubedb/redis-coordinator/commit/ad30d0f4) Prepare for release v0.31.0 (#123)
+- [ba9e3036](https://github.com/kubedb/redis-coordinator/commit/ba9e3036) Use Go 1.24 (#122)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.16.0-rc.1)
+
+- [a535e54](https://github.com/kubedb/redis-restic-plugin/commit/a535e54) Prepare for release v0.16.0-rc.1 (#63)
+- [84059cf](https://github.com/kubedb/redis-restic-plugin/commit/84059cf) Prepare for release v0.15.0 (#62)
+- [1ef930f](https://github.com/kubedb/redis-restic-plugin/commit/1ef930f) Use Go 1.24 (#61)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.40.0-rc.1](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.40.0-rc.1)
+
+- [e7943024](https://github.com/kubedb/replication-mode-detector/commit/e7943024) Prepare for release v0.40.0-rc.1 (#290)
+- [feb3420a](https://github.com/kubedb/replication-mode-detector/commit/feb3420a) Prepare for release v0.39.0 (#289)
+- [b42c020d](https://github.com/kubedb/replication-mode-detector/commit/b42c020d) Use Go 1.24 (#288)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.29.0-rc.1](https://github.com/kubedb/schema-manager/releases/tag/v0.29.0-rc.1)
+
+- [b7094850](https://github.com/kubedb/schema-manager/commit/b7094850) Prepare for release v0.29.0-rc.1 (#136)
+
+
+
+## [kubedb/singlestore](https://github.com/kubedb/singlestore)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/singlestore/releases/tag/v0.8.0-rc.1)
+
+- [0272fc4d](https://github.com/kubedb/singlestore/commit/0272fc4d) Prepare for release v0.8.0-rc.1 (#68)
+
+
+
+## [kubedb/singlestore-coordinator](https://github.com/kubedb/singlestore-coordinator)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/singlestore-coordinator/releases/tag/v0.8.0-rc.1)
+
+- [821d775](https://github.com/kubedb/singlestore-coordinator/commit/821d775) Prepare for release v0.8.0-rc.1 (#40)
+
+
+
+## [kubedb/singlestore-restic-plugin](https://github.com/kubedb/singlestore-restic-plugin)
+
+### [v0.11.0-rc.1](https://github.com/kubedb/singlestore-restic-plugin/releases/tag/v0.11.0-rc.1)
+
+- [ae4805f](https://github.com/kubedb/singlestore-restic-plugin/commit/ae4805f) Prepare for release v0.11.0-rc.1 (#40)
+
+
+
+## [kubedb/solr](https://github.com/kubedb/solr)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/solr/releases/tag/v0.8.0-rc.1)
+
+- [a2f3abd6](https://github.com/kubedb/solr/commit/a2f3abd6) Prepare for release v0.8.0-rc.1 (#79)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.38.0-rc.1](https://github.com/kubedb/tests/releases/tag/v0.38.0-rc.1)
+
+- [065abf8a](https://github.com/kubedb/tests/commit/065abf8a) Prepare for release v0.38.0-rc.1 (#451)
+- [d3aec073](https://github.com/kubedb/tests/commit/d3aec073) Update go.mod with k8s v0.32.2 (#449)
+- [7181a2ab](https://github.com/kubedb/tests/commit/7181a2ab) Fix MongoDB restic backup CI (#438)
+- [8780cccd](https://github.com/kubedb/tests/commit/8780cccd) MongoDB Test Profile Divide (#442)
+- [1576dbf8](https://github.com/kubedb/tests/commit/1576dbf8) rabbitmq test log fix (#445)
+- [86e04cc1](https://github.com/kubedb/tests/commit/86e04cc1) Test against k8s 1.32 (#444)
+- [ac643c07](https://github.com/kubedb/tests/commit/ac643c07) Add Postgres CI (restic-backup) (#434)
+- [f165f126](https://github.com/kubedb/tests/commit/f165f126) Prepare for release v0.37.0 (#443)
+- [3b5fada0](https://github.com/kubedb/tests/commit/3b5fada0) Test against k8s 1.32 (#441)
+- [892d8c3d](https://github.com/kubedb/tests/commit/892d8c3d) Use Go 1.24 (#440)
+- [0b3ececa](https://github.com/kubedb/tests/commit/0b3ececa) fix backupstorage, release v2025.2.10 (#439)
+- [0bfee605](https://github.com/kubedb/tests/commit/0bfee605) fix mongo package (#435)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.29.0-rc.1](https://github.com/kubedb/ui-server/releases/tag/v0.29.0-rc.1)
+
+- [683a6c9d](https://github.com/kubedb/ui-server/commit/683a6c9d) Prepare for release v0.29.0-rc.1 (#156)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.29.0-rc.1](https://github.com/kubedb/webhook-server/releases/tag/v0.29.0-rc.1)
+
+- [32299e12](https://github.com/kubedb/webhook-server/commit/32299e12) Prepare for release v0.29.0-rc.1 (#149)
+- [a18927dc](https://github.com/kubedb/webhook-server/commit/a18927dc) Remove old-db & ops-manager deps for webhooks (#148)
+- [4eab5c8e](https://github.com/kubedb/webhook-server/commit/4eab5c8e) Rewrite webhook calls; Update to k8s v32 (#147)
+- [6f2040e4](https://github.com/kubedb/webhook-server/commit/6f2040e4) Prepare for release v0.28.0 (#146)
+- [b96f329a](https://github.com/kubedb/webhook-server/commit/b96f329a) Test against k8s 1.32 (#145)
+- [5285151d](https://github.com/kubedb/webhook-server/commit/5285151d) Use Go 1.24 (#144)
+
+
+
+## [kubedb/xtrabackup-restic-plugin](https://github.com/kubedb/xtrabackup-restic-plugin)
+
+### [v0.2.0-rc.1](https://github.com/kubedb/xtrabackup-restic-plugin/releases/tag/v0.2.0-rc.1)
+
+- [0e1c903](https://github.com/kubedb/xtrabackup-restic-plugin/commit/0e1c903) Prepare for release v0.2.0-rc.1 (#10)
+
+
+
+## [kubedb/zookeeper](https://github.com/kubedb/zookeeper)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/zookeeper/releases/tag/v0.8.0-rc.1)
+
+- [66198a06](https://github.com/kubedb/zookeeper/commit/66198a06) Prepare for release v0.8.0-rc.1 (#70)
+
+
+
+## [kubedb/zookeeper-restic-plugin](https://github.com/kubedb/zookeeper-restic-plugin)
+
+### [v0.9.0-rc.1](https://github.com/kubedb/zookeeper-restic-plugin/releases/tag/v0.9.0-rc.1)
+
+- [3d99e28](https://github.com/kubedb/zookeeper-restic-plugin/commit/3d99e28) Prepare for release v0.9.0-rc.1 (#32)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2025.3.20-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/110
Signed-off-by: 1gtm <1gtm@appscode.com>