### PR TITLE
Prepare for release v2025.10.17

### DIFF
--- a/docs/CHANGELOG-v2025.10.17.md
+++ b/docs/CHANGELOG-v2025.10.17.md
@@ -1,0 +1,679 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2025.10.17
+    name: Changelog-v2025.10.17
+    parent: welcome
+    weight: 20251017
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.10.17/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.10.17/
+---
+
+# KubeDB v2025.10.17 (2025-10-18)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.59.0](https://github.com/kubedb/apimachinery/releases/tag/v0.59.0)
+
+- [414bc215](https://github.com/kubedb/apimachinery/commit/414bc2151) Update deps
+- [e7a179ae](https://github.com/kubedb/apimachinery/commit/e7a179ae9) Cleaned up grpc extra code
+- [6cc4af81](https://github.com/kubedb/apimachinery/commit/6cc4af815) Revise redis acl spec (#1523)
+- [fbdf8aa7](https://github.com/kubedb/apimachinery/commit/fbdf8aa72) Add Monitoring In ClickHouse SetDefaults (#1525)
+- [c0a1dfe5](https://github.com/kubedb/apimachinery/commit/c0a1dfe58) Add Distributed MariaDB gRPC Utils (#1512)
+- [b9892459](https://github.com/kubedb/apimachinery/commit/b98924596) Add ClickHouse SetTLSDefaults (#1520)
+- [c072d874](https://github.com/kubedb/apimachinery/commit/c072d874e) Add Kafka Broker Rack API (#1514)
+- [14c6e6b7](https://github.com/kubedb/apimachinery/commit/14c6e6b7f) Defaulting for authSecret field (#1521)
+- [289a5cb7](https://github.com/kubedb/apimachinery/commit/289a5cb76) Add Redis Configure Auth (#1518)
+- [02c435b5](https://github.com/kubedb/apimachinery/commit/02c435b58) Use LocalObjectRef as auth secret (#1519)
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.44.0](https://github.com/kubedb/autoscaler/releases/tag/v0.44.0)
+
+- [2c20574d](https://github.com/kubedb/autoscaler/commit/2c20574d) Prepare for release v0.44.0 (#261)
+- [741ffd0c](https://github.com/kubedb/autoscaler/commit/741ffd0c) Add Distributed MariaDB Support (#259)
+- [205e745e](https://github.com/kubedb/autoscaler/commit/205e745e) Add ClickHouse (#260)
+
+
+
+## [kubedb/cassandra](https://github.com/kubedb/cassandra)
+
+### [v0.12.0](https://github.com/kubedb/cassandra/releases/tag/v0.12.0)
+
+- [d26b8805](https://github.com/kubedb/cassandra/commit/d26b8805) Prepare for release v0.12.0 (#50)
+- [f5aa7b01](https://github.com/kubedb/cassandra/commit/f5aa7b01) Update secret type (#49)
+- [ba08206c](https://github.com/kubedb/cassandra/commit/ba08206c) Test against k8s 1.34 (#48)
+
+
+
+## [kubedb/cassandra-medusa-plugin](https://github.com/kubedb/cassandra-medusa-plugin)
+
+### [v0.6.0](https://github.com/kubedb/cassandra-medusa-plugin/releases/tag/v0.6.0)
+
+- [481a899](https://github.com/kubedb/cassandra-medusa-plugin/commit/481a899) Prepare for release v0.6.0 (#12)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.59.0](https://github.com/kubedb/cli/releases/tag/v0.59.0)
+
+- [1b87111e](https://github.com/kubedb/cli/commit/1b87111e5) Prepare for release v0.59.0 (#803)
+
+
+
+## [kubedb/clickhouse](https://github.com/kubedb/clickhouse)
+
+### [v0.14.0](https://github.com/kubedb/clickhouse/releases/tag/v0.14.0)
+
+- [b019bf16](https://github.com/kubedb/clickhouse/commit/b019bf16) Prepare for release v0.14.0 (#70)
+- [387ee641](https://github.com/kubedb/clickhouse/commit/387ee641) Add user provided Init Script (#68)
+- [7f16fa47](https://github.com/kubedb/clickhouse/commit/7f16fa47) Add secret Annotation  (#66)
+
+
+
+## [kubedb/crd-manager](https://github.com/kubedb/crd-manager)
+
+### [v0.14.0](https://github.com/kubedb/crd-manager/releases/tag/v0.14.0)
+
+
+
+
+## [kubedb/dashboard-restic-plugin](https://github.com/kubedb/dashboard-restic-plugin)
+
+### [v0.17.0](https://github.com/kubedb/dashboard-restic-plugin/releases/tag/v0.17.0)
+
+- [9c938da](https://github.com/kubedb/dashboard-restic-plugin/commit/9c938da) Prepare for release v0.17.0 (#47)
+
+
+
+## [kubedb/db-client-go](https://github.com/kubedb/db-client-go)
+
+### [v0.14.0](https://github.com/kubedb/db-client-go/releases/tag/v0.14.0)
+
+- [20801110](https://github.com/kubedb/db-client-go/commit/20801110) Prepare for release v0.14.0 (#196)
+- [5a22d695](https://github.com/kubedb/db-client-go/commit/5a22d695) changes for es 9.1 version (#195)
+
+
+
+## [kubedb/druid](https://github.com/kubedb/druid)
+
+### [v0.14.0](https://github.com/kubedb/druid/releases/tag/v0.14.0)
+
+- [19e02546](https://github.com/kubedb/druid/commit/19e02546) Prepare for release v0.14.0 (#101)
+- [0a72e448](https://github.com/kubedb/druid/commit/0a72e448) Use LocalObjectRef as auth secret (#100)
+- [3aeb1e7b](https://github.com/kubedb/druid/commit/3aeb1e7b) Test against k8s 1.34 (#99)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.59.0](https://github.com/kubedb/elasticsearch/releases/tag/v0.59.0)
+
+- [bf4e772f](https://github.com/kubedb/elasticsearch/commit/bf4e772ff) Prepare for release v0.59.0 (#777)
+- [58b6388f](https://github.com/kubedb/elasticsearch/commit/58b6388fb) update secret type to TypedLocalObjectReference (#776)
+- [5a5e54f3](https://github.com/kubedb/elasticsearch/commit/5a5e54f30) Test against k8s 1.34 (#775)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.22.0](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.22.0)
+
+- [8eb741d5](https://github.com/kubedb/elasticsearch-restic-plugin/commit/8eb741d5) Prepare for release v0.22.0 (#71)
+
+
+
+## [kubedb/ferretdb](https://github.com/kubedb/ferretdb)
+
+### [v0.14.0](https://github.com/kubedb/ferretdb/releases/tag/v0.14.0)
+
+- [1569bbf0](https://github.com/kubedb/ferretdb/commit/1569bbf0) Prepare for release v0.14.0 (#87)
+- [8ca0a015](https://github.com/kubedb/ferretdb/commit/8ca0a015) Update secret type (#86)
+- [c543b719](https://github.com/kubedb/ferretdb/commit/c543b719) Test against k8s 1.34 (#85)
+
+
+
+## [kubedb/gitops](https://github.com/kubedb/gitops)
+
+### [v0.7.0](https://github.com/kubedb/gitops/releases/tag/v0.7.0)
+
+- [1c538254](https://github.com/kubedb/gitops/commit/1c538254) Prepare for release v0.7.0 (#27)
+- [f9026477](https://github.com/kubedb/gitops/commit/f9026477) Update SecretReference Api Change (#26)
+- [48ae7392](https://github.com/kubedb/gitops/commit/48ae7392) Test against k8s 1.34 (#25)
+
+
+
+## [kubedb/hazelcast](https://github.com/kubedb/hazelcast)
+
+### [v0.5.0](https://github.com/kubedb/hazelcast/releases/tag/v0.5.0)
+
+- [3be5850b](https://github.com/kubedb/hazelcast/commit/3be5850b) Prepare for release v0.5.0 (#15)
+- [b9e90272](https://github.com/kubedb/hazelcast/commit/b9e90272) enterprise rest enable (#14)
+- [e82548c1](https://github.com/kubedb/hazelcast/commit/e82548c1) Test against k8s 1.34 (#13)
+
+
+
+## [kubedb/ignite](https://github.com/kubedb/ignite)
+
+### [v0.6.0](https://github.com/kubedb/ignite/releases/tag/v0.6.0)
+
+- [3d0e22bf](https://github.com/kubedb/ignite/commit/3d0e22bf) Prepare for release v0.6.0 (#23)
+- [57319cfb](https://github.com/kubedb/ignite/commit/57319cfb) Update secret type to TypedLocalObjectReference (#22)
+- [e7447f1c](https://github.com/kubedb/ignite/commit/e7447f1c) Test against k8s 1.34 (#21)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2025.10.17](https://github.com/kubedb/installer/releases/tag/v2025.10.17)
+
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.30.0](https://github.com/kubedb/kafka/releases/tag/v0.30.0)
+
+- [19c34d52](https://github.com/kubedb/kafka/commit/19c34d52) Prepare for release v0.30.0 (#164)
+- [33d2eaff](https://github.com/kubedb/kafka/commit/33d2eaff) Add kafka rack (#163)
+- [13b29001](https://github.com/kubedb/kafka/commit/13b29001) Test against k8s 1.34 (#162)
+
+
+
+## [kubedb/kibana](https://github.com/kubedb/kibana)
+
+### [v0.35.0](https://github.com/kubedb/kibana/releases/tag/v0.35.0)
+
+- [8fd82617](https://github.com/kubedb/kibana/commit/8fd82617) Prepare for release v0.35.0 (#159)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.22.0](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.22.0)
+
+- [d0f73542](https://github.com/kubedb/kubedb-manifest-plugin/commit/d0f73542) Prepare for release v0.22.0 (#103)
+
+
+
+## [kubedb/kubedb-verifier](https://github.com/kubedb/kubedb-verifier)
+
+### [v0.10.0](https://github.com/kubedb/kubedb-verifier/releases/tag/v0.10.0)
+
+- [e52f395a](https://github.com/kubedb/kubedb-verifier/commit/e52f395a) Prepare for release v0.10.0 (#25)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.43.0](https://github.com/kubedb/mariadb/releases/tag/v0.43.0)
+
+- [e829b572](https://github.com/kubedb/mariadb/commit/e829b5725) Prepare for release v0.43.0 (#352)
+- [56624f27](https://github.com/kubedb/mariadb/commit/56624f276) Add Physical Base Backup Support (#295)
+- [9d900340](https://github.com/kubedb/mariadb/commit/9d900340a) Add PodMetrics Get Perimission (#351)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.19.0](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.19.0)
+
+- [2102109a](https://github.com/kubedb/mariadb-archiver/commit/2102109a) Prepare for release v0.19.0 (#59)
+- [dd809009](https://github.com/kubedb/mariadb-archiver/commit/dd809009) Add Physical Base Backup Support (#32)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.39.0](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.39.0)
+
+- [c76ee61d](https://github.com/kubedb/mariadb-coordinator/commit/c76ee61d) Prepare for release v0.39.0 (#152)
+- [42cb515a](https://github.com/kubedb/mariadb-coordinator/commit/42cb515a) Add Get PodMetrics to gRPC API (#151)
+
+
+
+## [kubedb/mariadb-csi-snapshotter-plugin](https://github.com/kubedb/mariadb-csi-snapshotter-plugin)
+
+### [v0.19.0](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/releases/tag/v0.19.0)
+
+- [db46623b](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/db46623b) Prepare for release v0.19.0 (#55)
+- [66f0373e](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/66f0373e) Fix VolumeSnapshot Kind not Found Issue (#54)
+
+
+
+## [kubedb/mariadb-restic-plugin](https://github.com/kubedb/mariadb-restic-plugin)
+
+### [v0.17.0](https://github.com/kubedb/mariadb-restic-plugin/releases/tag/v0.17.0)
+
+- [d906ca7](https://github.com/kubedb/mariadb-restic-plugin/commit/d906ca7) Prepare for release v0.17.0 (#55)
+- [39e4050](https://github.com/kubedb/mariadb-restic-plugin/commit/39e4050) Add Physical Base Backup Support (#31)
+- [5935501](https://github.com/kubedb/mariadb-restic-plugin/commit/5935501) Stop 'cmd-nsc' container after backup done (#54)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.52.0](https://github.com/kubedb/memcached/releases/tag/v0.52.0)
+
+- [fd7ae301](https://github.com/kubedb/memcached/commit/fd7ae3016) Prepare for release v0.52.0 (#511)
+- [5089ddb5](https://github.com/kubedb/memcached/commit/5089ddb58) Ensure auth secret before petset and fix health check condition update (#507)
+- [69ffb550](https://github.com/kubedb/memcached/commit/69ffb5502) Update secret type to TypedLocalObjectReference (#510)
+- [b1b9752c](https://github.com/kubedb/memcached/commit/b1b9752ce) Test against k8s 1.34 (#509)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.52.0](https://github.com/kubedb/mongodb/releases/tag/v0.52.0)
+
+- [2022597d](https://github.com/kubedb/mongodb/commit/2022597d4) Prepare for release v0.52.0 (#720)
+- [1cfa8ff4](https://github.com/kubedb/mongodb/commit/1cfa8ff49) Remove VSAPI dependency; import from kubestash (#719)
+- [942dee48](https://github.com/kubedb/mongodb/commit/942dee488) Update for local obj reference (#718)
+- [c47ba613](https://github.com/kubedb/mongodb/commit/c47ba6138) Test against k8s 1.34 (#717)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.20.0](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.20.0)
+
+- [7370838b](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/7370838b) Prepare for release v0.20.0 (#59)
+- [4bf89909](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/4bf89909) Remove VSAPI dependency (#58)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.22.0](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.22.0)
+
+- [ab761664](https://github.com/kubedb/mongodb-restic-plugin/commit/ab761664) Prepare for release v0.22.0 (#92)
+
+
+
+## [kubedb/mssql-coordinator](https://github.com/kubedb/mssql-coordinator)
+
+### [v0.14.0](https://github.com/kubedb/mssql-coordinator/releases/tag/v0.14.0)
+
+- [105a2fc5](https://github.com/kubedb/mssql-coordinator/commit/105a2fc5) Prepare for release v0.14.0 (#44)
+
+
+
+## [kubedb/mssqlserver](https://github.com/kubedb/mssqlserver)
+
+### [v0.14.0](https://github.com/kubedb/mssqlserver/releases/tag/v0.14.0)
+
+- [7ead4162](https://github.com/kubedb/mssqlserver/commit/7ead4162) Prepare for release v0.14.0 (#92)
+- [5a1110cd](https://github.com/kubedb/mssqlserver/commit/5a1110cd) Update secret type to TypedLocalObjectReference (#91)
+- [713b0075](https://github.com/kubedb/mssqlserver/commit/713b0075) Test against k8s 1.34 (#90)
+
+
+
+## [kubedb/mssqlserver-archiver](https://github.com/kubedb/mssqlserver-archiver)
+
+### [v0.13.0](https://github.com/kubedb/mssqlserver-archiver/releases/tag/v0.13.0)
+
+
+
+
+## [kubedb/mssqlserver-walg-plugin](https://github.com/kubedb/mssqlserver-walg-plugin)
+
+### [v0.13.0](https://github.com/kubedb/mssqlserver-walg-plugin/releases/tag/v0.13.0)
+
+- [638bf26](https://github.com/kubedb/mssqlserver-walg-plugin/commit/638bf26) Prepare for release v0.13.0 (#34)
+- [2342c2e](https://github.com/kubedb/mssqlserver-walg-plugin/commit/2342c2e) Make s3 path style to true for s3 compatible storage
+- [4c09999](https://github.com/kubedb/mssqlserver-walg-plugin/commit/4c09999) Add caCertPath to walg envs
+- [ab7ea53](https://github.com/kubedb/mssqlserver-walg-plugin/commit/ab7ea53) make s3 path style to true
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.52.0](https://github.com/kubedb/mysql/releases/tag/v0.52.0)
+
+- [9e17f785](https://github.com/kubedb/mysql/commit/9e17f7857) Prepare for release v0.52.0 (#702)
+- [1873a00c](https://github.com/kubedb/mysql/commit/1873a00c5) Update secret type to TypedLocalObjectReference (#701)
+- [34c78926](https://github.com/kubedb/mysql/commit/34c789267) Test against k8s 1.34 (#700)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.20.0](https://github.com/kubedb/mysql-archiver/releases/tag/v0.20.0)
+
+- [cba87352](https://github.com/kubedb/mysql-archiver/commit/cba87352) Prepare for release v0.20.0 (#67)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.37.0](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.37.0)
+
+- [83a2eb80](https://github.com/kubedb/mysql-coordinator/commit/83a2eb80) Prepare for release v0.37.0 (#151)
+
+
+
+## [kubedb/mysql-csi-snapshotter-plugin](https://github.com/kubedb/mysql-csi-snapshotter-plugin)
+
+### [v0.20.0](https://github.com/kubedb/mysql-csi-snapshotter-plugin/releases/tag/v0.20.0)
+
+- [5afd0844](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/5afd0844) Prepare for release v0.20.0 (#55)
+- [c9e1be64](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/c9e1be64) Fix VolumeSnapshot Kind not Found (#54)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.22.0](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.22.0)
+
+- [200d560](https://github.com/kubedb/mysql-restic-plugin/commit/200d560) Prepare for release v0.22.0 (#82)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.37.0](https://github.com/kubedb/mysql-router-init/releases/tag/v0.37.0)
+
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.46.0](https://github.com/kubedb/ops-manager/releases/tag/v0.46.0)
+
+- [0780580b](https://github.com/kubedb/ops-manager/commit/0780580ba) Prepare for release v0.46.0 (#798)
+- [a15f3446](https://github.com/kubedb/ops-manager/commit/a15f34465) Update ACL configuration For Redis API changes  (#796)
+- [12a09397](https://github.com/kubedb/ops-manager/commit/12a09397e) "MariaDB Distributed" Shift gRPC proto to Apimachinery (#793)
+- [f26ed3b3](https://github.com/kubedb/ops-manager/commit/f26ed3b33) Add ClickHouse Recommendation (#795)
+- [1c0c8f73](https://github.com/kubedb/ops-manager/commit/1c0c8f73e) Update for local obj reference (#797)
+
+
+
+## [kubedb/oracle](https://github.com/kubedb/oracle)
+
+### [v0.5.0](https://github.com/kubedb/oracle/releases/tag/v0.5.0)
+
+- [cc7cfbae](https://github.com/kubedb/oracle/commit/cc7cfbae) Prepare for release v0.5.0 (#15)
+- [1557f281](https://github.com/kubedb/oracle/commit/1557f281) Update Secret Type (#14)
+- [b4c5a88b](https://github.com/kubedb/oracle/commit/b4c5a88b) Test against k8s 1.34 (#13)
+
+
+
+## [kubedb/oracle-coordinator](https://github.com/kubedb/oracle-coordinator)
+
+### [v0.5.0](https://github.com/kubedb/oracle-coordinator/releases/tag/v0.5.0)
+
+- [ce4557a](https://github.com/kubedb/oracle-coordinator/commit/ce4557a) Prepare for release v0.5.0 (#10)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.46.0](https://github.com/kubedb/percona-xtradb/releases/tag/v0.46.0)
+
+- [acf28f1e](https://github.com/kubedb/percona-xtradb/commit/acf28f1ef) Prepare for release v0.46.0 (#419)
+- [b4029c1c](https://github.com/kubedb/percona-xtradb/commit/b4029c1cb) Update Secret type to TypedLocalObjectReference (#418)
+- [ba94e68c](https://github.com/kubedb/percona-xtradb/commit/ba94e68c5) Test against k8s 1.34 (#417)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.32.0](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.32.0)
+
+- [b76e45a2](https://github.com/kubedb/percona-xtradb-coordinator/commit/b76e45a2) Prepare for release v0.32.0 (#102)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.43.0](https://github.com/kubedb/pg-coordinator/releases/tag/v0.43.0)
+
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.46.0](https://github.com/kubedb/pgbouncer/releases/tag/v0.46.0)
+
+
+
+
+## [kubedb/pgpool](https://github.com/kubedb/pgpool)
+
+### [v0.14.0](https://github.com/kubedb/pgpool/releases/tag/v0.14.0)
+
+- [b7e64eec](https://github.com/kubedb/pgpool/commit/b7e64eec) Prepare for release v0.14.0 (#86)
+- [1426bc67](https://github.com/kubedb/pgpool/commit/1426bc67) Updated Secret Reference (#85)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.59.0](https://github.com/kubedb/postgres/releases/tag/v0.59.0)
+
+- [4a48d93d](https://github.com/kubedb/postgres/commit/4a48d93d2) Prepare for release v0.59.0 (#835)
+- [29f79005](https://github.com/kubedb/postgres/commit/29f790059) Change Postgre Write Check Code for Minimizing LSN Movement (#834)
+- [78218c9a](https://github.com/kubedb/postgres/commit/78218c9a0) Use LocalObjectRef as auth secret (#833)
+- [0592bc32](https://github.com/kubedb/postgres/commit/0592bc329) Test against k8s 1.34 (#832)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.20.0](https://github.com/kubedb/postgres-archiver/releases/tag/v0.20.0)
+
+- [8e4b5556](https://github.com/kubedb/postgres-archiver/commit/8e4b5556) Prepare for release v0.20.0 (#68)
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.20.0](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.20.0)
+
+- [165fcc3b](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/165fcc3b) Prepare for release v0.20.0 (#65)
+- [a72b28ad](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/a72b28ad) Fix VolumeSnapshot Kind not Found Issue (#64)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.22.0](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.22.0)
+
+- [04c0e84](https://github.com/kubedb/postgres-restic-plugin/commit/04c0e84) Prepare for release v0.22.0 (#79)
+
+
+
+## [kubedb/provider-aws](https://github.com/kubedb/provider-aws)
+
+### [v0.20.0](https://github.com/kubedb/provider-aws/releases/tag/v0.20.0)
+
+
+
+
+## [kubedb/provider-azure](https://github.com/kubedb/provider-azure)
+
+### [v0.20.0](https://github.com/kubedb/provider-azure/releases/tag/v0.20.0)
+
+
+
+
+## [kubedb/provider-gcp](https://github.com/kubedb/provider-gcp)
+
+### [v0.20.0](https://github.com/kubedb/provider-gcp/releases/tag/v0.20.0)
+
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.59.0](https://github.com/kubedb/provisioner/releases/tag/v0.59.0)
+
+- [dd40254d](https://github.com/kubedb/provisioner/commit/dd40254d9) Prepare for release v0.59.0 (#166)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.46.0](https://github.com/kubedb/proxysql/releases/tag/v0.46.0)
+
+- [d5bcb8b0](https://github.com/kubedb/proxysql/commit/d5bcb8b0c) Prepare for release v0.46.0 (#405)
+- [b38a92ad](https://github.com/kubedb/proxysql/commit/b38a92ad3) Update secret type to TypedLocalObjectReference (#404)
+- [1d76e745](https://github.com/kubedb/proxysql/commit/1d76e745d) Test against k8s 1.34 (#403)
+
+
+
+## [kubedb/rabbitmq](https://github.com/kubedb/rabbitmq)
+
+### [v0.14.0](https://github.com/kubedb/rabbitmq/releases/tag/v0.14.0)
+
+- [9ca998d9](https://github.com/kubedb/rabbitmq/commit/9ca998d9) Prepare for release v0.14.0 (#99)
+- [35f07ead](https://github.com/kubedb/rabbitmq/commit/35f07ead) update secret type to TypedLocalObjectReference (#98)
+- [3ce6a4f1](https://github.com/kubedb/rabbitmq/commit/3ce6a4f1) Test against k8s 1.34 (#97)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.52.0](https://github.com/kubedb/redis/releases/tag/v0.52.0)
+
+- [317956d4](https://github.com/kubedb/redis/commit/317956d4a) Prepare for release v0.52.0 (#608)
+- [04abe883](https://github.com/kubedb/redis/commit/04abe8832) Add new secret ref And Revise ACL (#607)
+- [f60be213](https://github.com/kubedb/redis/commit/f60be2137) Add Configure Auth and Change Secret Reference (#606)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.38.0](https://github.com/kubedb/redis-coordinator/releases/tag/v0.38.0)
+
+- [bae104c0](https://github.com/kubedb/redis-coordinator/commit/bae104c0) Prepare for release v0.38.0 (#135)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.22.0](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.22.0)
+
+- [722d80f](https://github.com/kubedb/redis-restic-plugin/commit/722d80f) Prepare for release v0.22.0 (#74)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.46.0](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.46.0)
+
+- [d23f1424](https://github.com/kubedb/replication-mode-detector/commit/d23f1424) Prepare for release v0.46.0 (#299)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.35.0](https://github.com/kubedb/schema-manager/releases/tag/v0.35.0)
+
+- [06227ca4](https://github.com/kubedb/schema-manager/commit/06227ca4) Prepare for release v0.35.0 (#146)
+
+
+
+## [kubedb/singlestore](https://github.com/kubedb/singlestore)
+
+### [v0.14.0](https://github.com/kubedb/singlestore/releases/tag/v0.14.0)
+
+- [c2d2f697](https://github.com/kubedb/singlestore/commit/c2d2f697) Prepare for release v0.14.0 (#85)
+- [925a9e63](https://github.com/kubedb/singlestore/commit/925a9e63) Update secret type (#84)
+- [ddf3430c](https://github.com/kubedb/singlestore/commit/ddf3430c) Test against k8s 1.34 (#83)
+
+
+
+## [kubedb/singlestore-coordinator](https://github.com/kubedb/singlestore-coordinator)
+
+### [v0.14.0](https://github.com/kubedb/singlestore-coordinator/releases/tag/v0.14.0)
+
+- [4138aa1](https://github.com/kubedb/singlestore-coordinator/commit/4138aa1) Prepare for release v0.14.0 (#49)
+
+
+
+## [kubedb/singlestore-restic-plugin](https://github.com/kubedb/singlestore-restic-plugin)
+
+### [v0.17.0](https://github.com/kubedb/singlestore-restic-plugin/releases/tag/v0.17.0)
+
+- [117395a](https://github.com/kubedb/singlestore-restic-plugin/commit/117395a) Prepare for release v0.17.0 (#53)
+
+
+
+## [kubedb/solr](https://github.com/kubedb/solr)
+
+### [v0.14.0](https://github.com/kubedb/solr/releases/tag/v0.14.0)
+
+- [0aaa1ab7](https://github.com/kubedb/solr/commit/0aaa1ab7) Prepare for release v0.14.0 (#99)
+- [710306af](https://github.com/kubedb/solr/commit/710306af) Update secret type (#98)
+- [f6a1455d](https://github.com/kubedb/solr/commit/f6a1455d) Add shardconfig flag (#84)
+- [378308db](https://github.com/kubedb/solr/commit/378308db) Test against k8s 1.34 (#97)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.44.0](https://github.com/kubedb/tests/releases/tag/v0.44.0)
+
+- [47b8059c](https://github.com/kubedb/tests/commit/47b8059c) Prepare for release v0.44.0 (#486)
+- [9b0071e4](https://github.com/kubedb/tests/commit/9b0071e4) MySQL Rotate Authentication (#485)
+- [0d4e3bcc](https://github.com/kubedb/tests/commit/0d4e3bcc) Log Reduce for All Tests (#469)
+- [761dd390](https://github.com/kubedb/tests/commit/761dd390) MySQL Restic Backup-Restore CI (#477)
+- [ed974836](https://github.com/kubedb/tests/commit/ed974836) MSSQLServer Arbiter Node (#482)
+- [99b6a972](https://github.com/kubedb/tests/commit/99b6a972) Add MSSQL AutoScale (#470)
+- [9fb77603](https://github.com/kubedb/tests/commit/9fb77603) Test against k8s 1.34 (#479)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.35.0](https://github.com/kubedb/ui-server/releases/tag/v0.35.0)
+
+- [8ca638a2](https://github.com/kubedb/ui-server/commit/8ca638a2) Prepare for release v0.35.0 (#173)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.35.0](https://github.com/kubedb/webhook-server/releases/tag/v0.35.0)
+
+
+
+
+## [kubedb/xtrabackup-restic-plugin](https://github.com/kubedb/xtrabackup-restic-plugin)
+
+### [v0.8.0](https://github.com/kubedb/xtrabackup-restic-plugin/releases/tag/v0.8.0)
+
+- [4da8a68](https://github.com/kubedb/xtrabackup-restic-plugin/commit/4da8a68) Prepare for release v0.8.0 (#21)
+
+
+
+## [kubedb/zookeeper](https://github.com/kubedb/zookeeper)
+
+### [v0.14.0](https://github.com/kubedb/zookeeper/releases/tag/v0.14.0)
+
+- [438119f0](https://github.com/kubedb/zookeeper/commit/438119f0) Prepare for release v0.14.0 (#89)
+- [4a404486](https://github.com/kubedb/zookeeper/commit/4a404486) Update secret type to TypedLocalObjectReference (#88)
+- [5bbfc66f](https://github.com/kubedb/zookeeper/commit/5bbfc66f) Test against k8s 1.34 (#87)
+
+
+
+## [kubedb/zookeeper-restic-plugin](https://github.com/kubedb/zookeeper-restic-plugin)
+
+### [v0.15.0](https://github.com/kubedb/zookeeper-restic-plugin/releases/tag/v0.15.0)
+
+- [780e5b4](https://github.com/kubedb/zookeeper-restic-plugin/commit/780e5b4) Prepare for release v0.15.0 (#43)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2025.10.17
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/119
Signed-off-by: 1gtm <1gtm@appscode.com>