### PR TITLE
Prepare for release v2025.12.31-rc.1

### DIFF
--- a/docs/CHANGELOG-v2025.12.31-rc.1.md
+++ b/docs/CHANGELOG-v2025.12.31-rc.1.md
@@ -1,0 +1,894 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2025.12.31-rc.1
+    name: Changelog-v2025.12.31-rc.1
+    parent: welcome
+    weight: 20251231
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.12.31-rc.1/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.12.31-rc.1/
+---
+
+# KubeDB v2025.12.31-rc.1 (2026-01-01)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.60.0-rc.1](https://github.com/kubedb/apimachinery/releases/tag/v0.60.0-rc.1)
+
+- [3fb97b25](https://github.com/kubedb/apimachinery/commit/3fb97b259) Use k8s 1.34 client go libs (#1560)
+- [eb03debc](https://github.com/kubedb/apimachinery/commit/eb03debc7) Add DatabaseInfo api (#1557)
+- [72d44c38](https://github.com/kubedb/apimachinery/commit/72d44c386) Update deps
+- [d30d72e0](https://github.com/kubedb/apimachinery/commit/d30d72e0f) Test against k8s 1.35 (#1554)
+- [da3e069f](https://github.com/kubedb/apimachinery/commit/da3e069f8) Update deps
+- [7086a4bd](https://github.com/kubedb/apimachinery/commit/7086a4bd8) Add "EndOfLife" field in catalogs (#1553)
+- [5cfded61](https://github.com/kubedb/apimachinery/commit/5cfded61a) Update deps
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.45.0-rc.1](https://github.com/kubedb/autoscaler/releases/tag/v0.45.0-rc.1)
+
+- [37b3c020](https://github.com/kubedb/autoscaler/commit/37b3c020) Prepare for release v0.45.0-rc.1 (#272)
+- [e7f4287d](https://github.com/kubedb/autoscaler/commit/e7f4287d) Use k8s 1.34 client libs (#271)
+- [138b469c](https://github.com/kubedb/autoscaler/commit/138b469c) Fix makefile indentation (#270)
+- [cffebd62](https://github.com/kubedb/autoscaler/commit/cffebd62) Publish Image for Redhat software certification (#269)
+
+
+
+## [kubedb/cassandra](https://github.com/kubedb/cassandra)
+
+### [v0.13.0-rc.1](https://github.com/kubedb/cassandra/releases/tag/v0.13.0-rc.1)
+
+- [04f224cf](https://github.com/kubedb/cassandra/commit/04f224cf) Prepare for release v0.13.0-rc.1 (#56)
+- [8bd54c7a](https://github.com/kubedb/cassandra/commit/8bd54c7a) Use k8s 1.34 client libs (#55)
+- [00e147f5](https://github.com/kubedb/cassandra/commit/00e147f5) Test against k8s 1.35 (#54)
+
+
+
+## [kubedb/cassandra-medusa-plugin](https://github.com/kubedb/cassandra-medusa-plugin)
+
+### [v0.7.0-rc.1](https://github.com/kubedb/cassandra-medusa-plugin/releases/tag/v0.7.0-rc.1)
+
+- [804c9f62](https://github.com/kubedb/cassandra-medusa-plugin/commit/804c9f62) Prepare for release v0.7.0-rc.1 (#19)
+- [7dfbd231](https://github.com/kubedb/cassandra-medusa-plugin/commit/7dfbd231) Use k8s 1.34 client libs (#18)
+- [7db29d99](https://github.com/kubedb/cassandra-medusa-plugin/commit/7db29d99) Fix makefile indentation (#17)
+- [0ca8af6d](https://github.com/kubedb/cassandra-medusa-plugin/commit/0ca8af6d) Publish Image for Redhat software certification (#16)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.60.0-rc.1](https://github.com/kubedb/cli/releases/tag/v0.60.0-rc.1)
+
+- [691493f2](https://github.com/kubedb/cli/commit/691493f27) Prepare for release v0.60.0-rc.1 (#809)
+- [f3e2ac0a](https://github.com/kubedb/cli/commit/f3e2ac0aa) Use k8s 1.34 client libs (#808)
+
+
+
+## [kubedb/clickhouse](https://github.com/kubedb/clickhouse)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/clickhouse/releases/tag/v0.15.0-rc.1)
+
+- [9c394a8f](https://github.com/kubedb/clickhouse/commit/9c394a8f) Prepare for release v0.15.0-rc.1 (#78)
+- [e482f9ab](https://github.com/kubedb/clickhouse/commit/e482f9ab) Use k8s 1.34 client libs (#77)
+- [918b772c](https://github.com/kubedb/clickhouse/commit/918b772c) Test against k8s 1.35 (#75)
+
+
+
+## [kubedb/crd-manager](https://github.com/kubedb/crd-manager)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/crd-manager/releases/tag/v0.15.0-rc.1)
+
+- [09f8c382](https://github.com/kubedb/crd-manager/commit/09f8c382) Prepare for release v0.15.0-rc.1 (#105)
+- [02225ed0](https://github.com/kubedb/crd-manager/commit/02225ed0) Use k8s 1.34 client libs (#104)
+- [8565968f](https://github.com/kubedb/crd-manager/commit/8565968f) Fix makefile indentation (#103)
+- [370e88f2](https://github.com/kubedb/crd-manager/commit/370e88f2) Publish Image for Redhat software certification (#102)
+
+
+
+## [kubedb/dashboard-restic-plugin](https://github.com/kubedb/dashboard-restic-plugin)
+
+### [v0.18.0-rc.1](https://github.com/kubedb/dashboard-restic-plugin/releases/tag/v0.18.0-rc.1)
+
+- [334a35e](https://github.com/kubedb/dashboard-restic-plugin/commit/334a35e) Prepare for release v0.18.0-rc.1 (#55)
+- [51ae5d7](https://github.com/kubedb/dashboard-restic-plugin/commit/51ae5d7) Use k8s 1.34 client libs (#54)
+- [901091a](https://github.com/kubedb/dashboard-restic-plugin/commit/901091a) Fix makefile indentation (#53)
+- [a5bafae](https://github.com/kubedb/dashboard-restic-plugin/commit/a5bafae) Publish Image for Redhat software certification (#52)
+
+
+
+## [kubedb/db-client-go](https://github.com/kubedb/db-client-go)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/db-client-go/releases/tag/v0.15.0-rc.1)
+
+- [3f74e4df](https://github.com/kubedb/db-client-go/commit/3f74e4df) Prepare for release v0.15.0-rc.1 (#215)
+- [d7814284](https://github.com/kubedb/db-client-go/commit/d7814284) Update vulnerable deps (#214)
+- [cf25883f](https://github.com/kubedb/db-client-go/commit/cf25883f) Use k8s 1.34 client libs (#213)
+- [17120b90](https://github.com/kubedb/db-client-go/commit/17120b90) Update deps
+
+
+
+## [kubedb/db2](https://github.com/kubedb/db2)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/db2/releases/tag/v0.1.0-rc.1)
+
+- [e64f6a2f](https://github.com/kubedb/db2/commit/e64f6a2f) Prepare for release v0.1.0-rc.1 (#7)
+- [46dfb4fb](https://github.com/kubedb/db2/commit/46dfb4fb) Use k8s 1.34 client libs (#5)
+
+
+
+## [kubedb/db2-coordinator](https://github.com/kubedb/db2-coordinator)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/db2-coordinator/releases/tag/v0.1.0-rc.1)
+
+- [60183db](https://github.com/kubedb/db2-coordinator/commit/60183db) Use k8s 1.34 client libs (#5)
+- [e16ce63](https://github.com/kubedb/db2-coordinator/commit/e16ce63) Fix makefile indentation (#4)
+- [2fcb2a3](https://github.com/kubedb/db2-coordinator/commit/2fcb2a3) Publish Image for Redhat software certification (#3)
+
+
+
+## [kubedb/druid](https://github.com/kubedb/druid)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/druid/releases/tag/v0.15.0-rc.1)
+
+- [08fa3cc6](https://github.com/kubedb/druid/commit/08fa3cc6) Prepare for release v0.15.0-rc.1 (#109)
+- [d0d33608](https://github.com/kubedb/druid/commit/d0d33608) Use k8s 1.34 client libs (#108)
+- [d9ada989](https://github.com/kubedb/druid/commit/d9ada989) Test against k8s 1.35 (#106)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.60.0-rc.1](https://github.com/kubedb/elasticsearch/releases/tag/v0.60.0-rc.1)
+
+- [1c7a0371](https://github.com/kubedb/elasticsearch/commit/1c7a0371f) Prepare for release v0.60.0-rc.1 (#784)
+- [119a44ab](https://github.com/kubedb/elasticsearch/commit/119a44abc) Use k8s 1.34 client libs (#783)
+- [d686d92a](https://github.com/kubedb/elasticsearch/commit/d686d92a3) Test against k8s 1.35 (#781)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.23.0-rc.1](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.23.0-rc.1)
+
+- [94598fe3](https://github.com/kubedb/elasticsearch-restic-plugin/commit/94598fe3) Prepare for release v0.23.0-rc.1 (#78)
+- [fb7521bd](https://github.com/kubedb/elasticsearch-restic-plugin/commit/fb7521bd) Fix makefile indentation (#77)
+- [ce5dfcea](https://github.com/kubedb/elasticsearch-restic-plugin/commit/ce5dfcea) Publish Image for Redhat software certification (#76)
+
+
+
+## [kubedb/ferretdb](https://github.com/kubedb/ferretdb)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/ferretdb/releases/tag/v0.15.0-rc.1)
+
+- [5ef0a4a1](https://github.com/kubedb/ferretdb/commit/5ef0a4a1) Prepare for release v0.15.0-rc.1 (#96)
+- [8e07c378](https://github.com/kubedb/ferretdb/commit/8e07c378) Use k8s 1.34 client libs (#95)
+- [8e5d5e72](https://github.com/kubedb/ferretdb/commit/8e5d5e72) Test against k8s 1.35 (#94)
+
+
+
+## [kubedb/gitops](https://github.com/kubedb/gitops)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/gitops/releases/tag/v0.8.0-rc.1)
+
+- [bd6e94c4](https://github.com/kubedb/gitops/commit/bd6e94c4) Prepare for release v0.8.0-rc.1 (#35)
+- [2b260a9d](https://github.com/kubedb/gitops/commit/2b260a9d) Use k8s 1.34 client libs (#34)
+- [119edc0b](https://github.com/kubedb/gitops/commit/119edc0b) Fix makefile indentation (#33)
+- [5be586ab](https://github.com/kubedb/gitops/commit/5be586ab) Publish Image for Redhat software certification (#32)
+
+
+
+## [kubedb/hanadb](https://github.com/kubedb/hanadb)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/hanadb/releases/tag/v0.1.0-rc.1)
+
+- [ebaf0578](https://github.com/kubedb/hanadb/commit/ebaf0578) Prepare for release v0.1.0-rc.1 (#8)
+- [c80e6397](https://github.com/kubedb/hanadb/commit/c80e6397) Use k8s 1.34 client libs (#7)
+- [3d484cef](https://github.com/kubedb/hanadb/commit/3d484cef) Test against k8s 1.35 (#6)
+
+
+
+## [kubedb/hazelcast](https://github.com/kubedb/hazelcast)
+
+### [v0.6.0-rc.1](https://github.com/kubedb/hazelcast/releases/tag/v0.6.0-rc.1)
+
+- [0257c68a](https://github.com/kubedb/hazelcast/commit/0257c68a) Prepare for release v0.6.0-rc.1 (#22)
+- [62dca5f2](https://github.com/kubedb/hazelcast/commit/62dca5f2) Use k8s 1.34 client libs (#21)
+- [d08bf4d9](https://github.com/kubedb/hazelcast/commit/d08bf4d9) Test against k8s 1.35 (#19)
+
+
+
+## [kubedb/ignite](https://github.com/kubedb/ignite)
+
+### [v0.7.0-rc.1](https://github.com/kubedb/ignite/releases/tag/v0.7.0-rc.1)
+
+- [b9b125a9](https://github.com/kubedb/ignite/commit/b9b125a9) Prepare for release v0.7.0-rc.1 (#31)
+- [70ba3420](https://github.com/kubedb/ignite/commit/70ba3420) Use k8s 1.34 client libs (#30)
+- [e361b1c0](https://github.com/kubedb/ignite/commit/e361b1c0) Test against k8s 1.35 (#28)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2025.12.31-rc.1](https://github.com/kubedb/installer/releases/tag/v2025.12.31-rc.1)
+
+- [25773394](https://github.com/kubedb/installer/commit/257733940) Prepare for release v2025.12.31-rc.1 (#1999)
+- [4f465123](https://github.com/kubedb/installer/commit/4f465123f) Update cve report (#1998)
+- [b0c02f29](https://github.com/kubedb/installer/commit/b0c02f295) Use mssql-export 1.2.0 (#1997)
+- [353be561](https://github.com/kubedb/installer/commit/353be561b) Update cve report (#1996)
+- [53a120a7](https://github.com/kubedb/installer/commit/53a120a76) Update cve report (#1995)
+- [0e4ee1c0](https://github.com/kubedb/installer/commit/0e4ee1c0d) Update cve report (#1994)
+- [5862e1f1](https://github.com/kubedb/installer/commit/5862e1f16) Use k8s 1.34 client libs (#1993)
+- [c16de4ae](https://github.com/kubedb/installer/commit/c16de4aeb) Update crds for kubedb/apimachinery@3fb97b25 (#1992)
+- [54ab719c](https://github.com/kubedb/installer/commit/54ab719ca) Update cve report (#1991)
+- [f904c5e1](https://github.com/kubedb/installer/commit/f904c5e1c) Update cve report (#1990)
+- [dbebecc7](https://github.com/kubedb/installer/commit/dbebecc72) Update cve report (#1989)
+- [70ebf554](https://github.com/kubedb/installer/commit/70ebf5546) Update cve report (#1988)
+- [c88ec938](https://github.com/kubedb/installer/commit/c88ec9382) Update certified chart readme
+- [ba6045a6](https://github.com/kubedb/installer/commit/ba6045a67) Generate certified and certified-crds charts (#1984)
+- [ea30f2d9](https://github.com/kubedb/installer/commit/ea30f2d95) Add WEBHOOK_SERVICE_NAME env (#1986)
+- [97ce9c80](https://github.com/kubedb/installer/commit/97ce9c80a) Update cve report (#1985)
+- [46641ca8](https://github.com/kubedb/installer/commit/46641ca8a) Support ubi mode in kubedb-kubestash-catalog (#1983)
+- [f6a33fc7](https://github.com/kubedb/installer/commit/f6a33fc7b) Add test to kubedb chart (#1982)
+- [3d682762](https://github.com/kubedb/installer/commit/3d6827620) Update cve report (#1981)
+- [9ca5910e](https://github.com/kubedb/installer/commit/9ca5910e0) Update cve report (#1980)
+- [6c307ad8](https://github.com/kubedb/installer/commit/6c307ad8f) Test against k8s 1.35 (#1978)
+- [f880b8bf](https://github.com/kubedb/installer/commit/f880b8bfe) Update cve report (#1979)
+- [d86eb163](https://github.com/kubedb/installer/commit/d86eb163e) Fix operator.ubi and catalog.ubi templates (#1977)
+- [1bb2811e](https://github.com/kubedb/installer/commit/1bb2811e7) Update cve report (#1976)
+- [cdb71959](https://github.com/kubedb/installer/commit/cdb71959b) Update cve report (#1975)
+- [031d08f5](https://github.com/kubedb/installer/commit/031d08f55) Update catalog chart helper
+- [7cea4927](https://github.com/kubedb/installer/commit/7cea49277) Update cve report (#1974)
+- [b756425b](https://github.com/kubedb/installer/commit/b756425b3) Use shared DistroSpec
+- [b48a74da](https://github.com/kubedb/installer/commit/b48a74dab) Update cve report (#1972)
+- [52d4b98a](https://github.com/kubedb/installer/commit/52d4b98a4) Update cve report (#1971)
+- [21e38aa7](https://github.com/kubedb/installer/commit/21e38aa74) Add perses dashboards (#1921)
+- [99b38420](https://github.com/kubedb/installer/commit/99b384208) Fix catalog chart schema
+- [304f5a62](https://github.com/kubedb/installer/commit/304f5a62c) Add endOfLife field to kubedb catalog version object (#1967)
+- [78e81bf8](https://github.com/kubedb/installer/commit/78e81bf83) Update cve report (#1970)
+- [e7275a8f](https://github.com/kubedb/installer/commit/e7275a8f2) FIx MariaDB Restic Plugin Version (#1968)
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.31.0-rc.1](https://github.com/kubedb/kafka/releases/tag/v0.31.0-rc.1)
+
+- [50dda47a](https://github.com/kubedb/kafka/commit/50dda47a) Prepare for release v0.31.0-rc.1 (#171)
+- [6794c280](https://github.com/kubedb/kafka/commit/6794c280) Use k8s 1.34 client libs (#170)
+- [46f4f915](https://github.com/kubedb/kafka/commit/46f4f915) Test against k8s 1.35 (#168)
+
+
+
+## [kubedb/kibana](https://github.com/kubedb/kibana)
+
+### [v0.36.0-rc.1](https://github.com/kubedb/kibana/releases/tag/v0.36.0-rc.1)
+
+- [5a5a15d1](https://github.com/kubedb/kibana/commit/5a5a15d1) Prepare for release v0.36.0-rc.1 (#166)
+- [0d968837](https://github.com/kubedb/kibana/commit/0d968837) Use k8s 1.34 client libs (#165)
+- [ebd87bba](https://github.com/kubedb/kibana/commit/ebd87bba) Fix makefile indentation (#164)
+- [64a99c80](https://github.com/kubedb/kibana/commit/64a99c80) Publish Image for Redhat software certification (#163)
+- [f3dea03e](https://github.com/kubedb/kibana/commit/f3dea03e) Update deps
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.23.0-rc.1](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.23.0-rc.1)
+
+- [4b8b2ed0](https://github.com/kubedb/kubedb-manifest-plugin/commit/4b8b2ed0) Prepare for release v0.23.0-rc.1 (#110)
+- [f062b2b2](https://github.com/kubedb/kubedb-manifest-plugin/commit/f062b2b2) Use k8s 1.34 client libs (#109)
+- [23a4536c](https://github.com/kubedb/kubedb-manifest-plugin/commit/23a4536c) Fix makefile indentation (#108)
+- [0b1e9561](https://github.com/kubedb/kubedb-manifest-plugin/commit/0b1e9561) Publish Image for Redhat software certification (#107)
+
+
+
+## [kubedb/kubedb-verifier](https://github.com/kubedb/kubedb-verifier)
+
+### [v0.11.0-rc.1](https://github.com/kubedb/kubedb-verifier/releases/tag/v0.11.0-rc.1)
+
+- [04634147](https://github.com/kubedb/kubedb-verifier/commit/04634147) Prepare for release v0.11.0-rc.1 (#34)
+- [b99b0af5](https://github.com/kubedb/kubedb-verifier/commit/b99b0af5) Update vulnerable deps (#33)
+- [0ed52eed](https://github.com/kubedb/kubedb-verifier/commit/0ed52eed) Use k8s 1.34 client libs (#32)
+- [acdfea3d](https://github.com/kubedb/kubedb-verifier/commit/acdfea3d) Fix makefile indentation (#31)
+- [562ab0a9](https://github.com/kubedb/kubedb-verifier/commit/562ab0a9) Publish Image for Redhat software certification (#29)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.44.0-rc.1](https://github.com/kubedb/mariadb/releases/tag/v0.44.0-rc.1)
+
+- [5573297f](https://github.com/kubedb/mariadb/commit/5573297fb) Prepare for release v0.44.0-rc.1 (#364)
+- [681968b1](https://github.com/kubedb/mariadb/commit/681968b1c) Use k8s 1.34 client libs (#362)
+- [f3396108](https://github.com/kubedb/mariadb/commit/f33961085) Test against k8s 1.35 (#361)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.20.0-rc.1](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.20.0-rc.1)
+
+- [e9eaec6e](https://github.com/kubedb/mariadb-archiver/commit/e9eaec6e) Prepare for release v0.20.0-rc.1 (#69)
+- [72598a18](https://github.com/kubedb/mariadb-archiver/commit/72598a18) Use k8s 1.34 client libs (#68)
+- [4704b4ad](https://github.com/kubedb/mariadb-archiver/commit/4704b4ad) Fix makefile indentation (#67)
+- [1e935bfa](https://github.com/kubedb/mariadb-archiver/commit/1e935bfa) Publish Image for Redhat software certification (#66)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.40.0-rc.1](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.40.0-rc.1)
+
+- [9b802d89](https://github.com/kubedb/mariadb-coordinator/commit/9b802d89) Prepare for release v0.40.0-rc.1 (#160)
+- [f69441b7](https://github.com/kubedb/mariadb-coordinator/commit/f69441b7) Use k8s 1.34 client libs (#159)
+- [5046d4ba](https://github.com/kubedb/mariadb-coordinator/commit/5046d4ba) Fix makefile indentation (#158)
+- [4b8af065](https://github.com/kubedb/mariadb-coordinator/commit/4b8af065) Publish Image for Redhat software certification (#157)
+
+
+
+## [kubedb/mariadb-csi-snapshotter-plugin](https://github.com/kubedb/mariadb-csi-snapshotter-plugin)
+
+### [v0.20.0-rc.1](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/releases/tag/v0.20.0-rc.1)
+
+- [59c939d3](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/59c939d3) Prepare for release v0.20.0-rc.1 (#63)
+- [9eab57a2](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/9eab57a2) Use k8s 1.34 client libs (#62)
+- [762e091e](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/762e091e) Fix makefile indentation (#61)
+- [bfc6a10d](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/bfc6a10d) Publish Image for Redhat software certification (#60)
+
+
+
+## [kubedb/mariadb-restic-plugin](https://github.com/kubedb/mariadb-restic-plugin)
+
+### [v0.18.0-rc.1](https://github.com/kubedb/mariadb-restic-plugin/releases/tag/v0.18.0-rc.1)
+
+- [c0496d3](https://github.com/kubedb/mariadb-restic-plugin/commit/c0496d3) Prepare for release v0.18.0-rc.1 (#67)
+- [ea8641d](https://github.com/kubedb/mariadb-restic-plugin/commit/ea8641d) Use k8s 1.34 client libs (#66)
+- [74bd202](https://github.com/kubedb/mariadb-restic-plugin/commit/74bd202) Fix makefile indentation (#65)
+- [3a13be1](https://github.com/kubedb/mariadb-restic-plugin/commit/3a13be1) Publish Image for Redhat software certification (#64)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.53.0-rc.1](https://github.com/kubedb/memcached/releases/tag/v0.53.0-rc.1)
+
+- [a03adaf4](https://github.com/kubedb/memcached/commit/a03adaf45) Prepare for release v0.53.0-rc.1 (#517)
+- [eadd34c6](https://github.com/kubedb/memcached/commit/eadd34c62) Use k8s 1.34 client libs (#516)
+- [3bad84ba](https://github.com/kubedb/memcached/commit/3bad84baa) Test against k8s 1.35 (#515)
+
+
+
+## [kubedb/milvus](https://github.com/kubedb/milvus)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/milvus/releases/tag/v0.1.0-rc.1)
+
+- [7dee1617](https://github.com/kubedb/milvus/commit/7dee1617) Prepare for release v0.1.0-rc.1 (#9)
+- [13b241f4](https://github.com/kubedb/milvus/commit/13b241f4) Use k8s 1.34 client libs (#8)
+- [c43dc470](https://github.com/kubedb/milvus/commit/c43dc470) Test against k8s 1.35 (#7)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.53.0-rc.1](https://github.com/kubedb/mongodb/releases/tag/v0.53.0-rc.1)
+
+- [87a59111](https://github.com/kubedb/mongodb/commit/87a591118) Prepare for release v0.53.0-rc.1 (#728)
+- [96ec9961](https://github.com/kubedb/mongodb/commit/96ec99618) Use k8s 1.34 client libs (#727)
+- [a38f8785](https://github.com/kubedb/mongodb/commit/a38f87851) Test against k8s 1.35 (#725)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.21.0-rc.1)
+
+- [6d6f78bf](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/6d6f78bf) Prepare for release v0.21.0-rc.1 (#66)
+- [d9a7e2c2](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/d9a7e2c2) Use k8s 1.34 client libs (#65)
+- [7f6dc710](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/7f6dc710) Fix makefile indentation (#64)
+- [bbf8bfc9](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/bbf8bfc9) Publish Image for Redhat software certification (#63)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.23.0-rc.1](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.23.0-rc.1)
+
+- [eba27b4e](https://github.com/kubedb/mongodb-restic-plugin/commit/eba27b4e) Prepare for release v0.23.0-rc.1 (#99)
+- [7b9d416a](https://github.com/kubedb/mongodb-restic-plugin/commit/7b9d416a) Use k8s 1.34 client libs (#98)
+- [ae919478](https://github.com/kubedb/mongodb-restic-plugin/commit/ae919478) Fix makefile indentation (#97)
+- [e6cd9a26](https://github.com/kubedb/mongodb-restic-plugin/commit/e6cd9a26) Publish Image for Redhat software certification (#96)
+
+
+
+## [kubedb/mssql-coordinator](https://github.com/kubedb/mssql-coordinator)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/mssql-coordinator/releases/tag/v0.15.0-rc.1)
+
+- [2b55ad11](https://github.com/kubedb/mssql-coordinator/commit/2b55ad11) Prepare for release v0.15.0-rc.1 (#51)
+- [29767f76](https://github.com/kubedb/mssql-coordinator/commit/29767f76) Use k8s 1.34 client libs (#50)
+- [b3136eda](https://github.com/kubedb/mssql-coordinator/commit/b3136eda) fix makefile (#49)
+- [22da7333](https://github.com/kubedb/mssql-coordinator/commit/22da7333) Publish Image for Redhat software certification (#48)
+
+
+
+## [kubedb/mssqlserver](https://github.com/kubedb/mssqlserver)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/mssqlserver/releases/tag/v0.15.0-rc.1)
+
+- [605da415](https://github.com/kubedb/mssqlserver/commit/605da415) Prepare for release v0.15.0-rc.1 (#102)
+- [566491fe](https://github.com/kubedb/mssqlserver/commit/566491fe) Use k8s 1.34 client libs (#101)
+- [5125d044](https://github.com/kubedb/mssqlserver/commit/5125d044) Test against k8s 1.35 (#99)
+
+
+
+## [kubedb/mssqlserver-archiver](https://github.com/kubedb/mssqlserver-archiver)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/mssqlserver-archiver/releases/tag/v0.14.0-rc.1)
+
+- [0377147](https://github.com/kubedb/mssqlserver-archiver/commit/0377147) Use k8s 1.34 client libs (#20)
+- [1c173bf](https://github.com/kubedb/mssqlserver-archiver/commit/1c173bf) Fix makefile indentation (#19)
+- [5c69310](https://github.com/kubedb/mssqlserver-archiver/commit/5c69310) Merge pull request #16 from kubedb/rhm
+
+
+
+## [kubedb/mssqlserver-walg-plugin](https://github.com/kubedb/mssqlserver-walg-plugin)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/mssqlserver-walg-plugin/releases/tag/v0.14.0-rc.1)
+
+- [07f0670](https://github.com/kubedb/mssqlserver-walg-plugin/commit/07f0670) Prepare for release v0.14.0-rc.1 (#41)
+- [231ae1c](https://github.com/kubedb/mssqlserver-walg-plugin/commit/231ae1c) Use k8s 1.34 client libs (#40)
+- [343568c](https://github.com/kubedb/mssqlserver-walg-plugin/commit/343568c) Fix makefile indentation (#39)
+- [bc447f8](https://github.com/kubedb/mssqlserver-walg-plugin/commit/bc447f8) Publish Image for Redhat software certification (#38)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.53.0-rc.1](https://github.com/kubedb/mysql/releases/tag/v0.53.0-rc.1)
+
+- [f87bcd7f](https://github.com/kubedb/mysql/commit/f87bcd7fd) Prepare for release v0.53.0-rc.1 (#712)
+- [f8490909](https://github.com/kubedb/mysql/commit/f8490909b) Use k8s 1.34 client libs (#710)
+- [95a71063](https://github.com/kubedb/mysql/commit/95a710638) Test against k8s 1.35 (#709)
+- [5cf311be](https://github.com/kubedb/mysql/commit/5cf311be2) Fix Archiver Panic for Azure backend (#708)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/mysql-archiver/releases/tag/v0.21.0-rc.1)
+
+- [3be30caf](https://github.com/kubedb/mysql-archiver/commit/3be30caf) Prepare for release v0.21.0-rc.1 (#73)
+- [3d14d6df](https://github.com/kubedb/mysql-archiver/commit/3d14d6df) Use k8s 1.34 client libs (#72)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.38.0-rc.1](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.38.0-rc.1)
+
+- [22cf05ff](https://github.com/kubedb/mysql-coordinator/commit/22cf05ff) Prepare for release v0.38.0-rc.1 (#159)
+- [13232ee9](https://github.com/kubedb/mysql-coordinator/commit/13232ee9) Use k8s 1.34 client libs (#157)
+- [1f1196f7](https://github.com/kubedb/mysql-coordinator/commit/1f1196f7) Fix makefile indentation (#156)
+- [e354dcea](https://github.com/kubedb/mysql-coordinator/commit/e354dcea) Publish Image for Redhat software certification (#155)
+
+
+
+## [kubedb/mysql-csi-snapshotter-plugin](https://github.com/kubedb/mysql-csi-snapshotter-plugin)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/mysql-csi-snapshotter-plugin/releases/tag/v0.21.0-rc.1)
+
+- [aacc62c7](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/aacc62c7) Prepare for release v0.21.0-rc.1 (#63)
+- [50746a8e](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/50746a8e) Use k8s 1.34 client libs (#62)
+- [a4ef9a0b](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/a4ef9a0b) Fix makefile indentation (#61)
+- [6b1059ae](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/6b1059ae) Publish Image for Redhat software certification (#60)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.23.0-rc.1](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.23.0-rc.1)
+
+- [0eca6918](https://github.com/kubedb/mysql-restic-plugin/commit/0eca6918) Prepare for release v0.23.0-rc.1 (#89)
+- [0ceec91e](https://github.com/kubedb/mysql-restic-plugin/commit/0ceec91e) Use k8s 1.34 client libs (#88)
+- [d12eee48](https://github.com/kubedb/mysql-restic-plugin/commit/d12eee48) Fix makefile indentation (#87)
+- [c22220cd](https://github.com/kubedb/mysql-restic-plugin/commit/c22220cd) Publish Image for Redhat software certification (#86)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.38.0-rc.1](https://github.com/kubedb/mysql-router-init/releases/tag/v0.38.0-rc.1)
+
+- [757d12e](https://github.com/kubedb/mysql-router-init/commit/757d12e) Use k8s 1.34 client libs (#55)
+
+
+
+## [kubedb/neo4j](https://github.com/kubedb/neo4j)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/neo4j/releases/tag/v0.1.0-rc.1)
+
+- [51303fa4](https://github.com/kubedb/neo4j/commit/51303fa4) Prepare for release v0.1.0-rc.1 (#9)
+- [190cb7ee](https://github.com/kubedb/neo4j/commit/190cb7ee) Use k8s 1.34 client libs (#8)
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.47.0-rc.1](https://github.com/kubedb/ops-manager/releases/tag/v0.47.0-rc.1)
+
+- [5d979ede](https://github.com/kubedb/ops-manager/commit/5d979ede3) Prepare for release v0.47.0-rc.1 (#816)
+- [25ca3a62](https://github.com/kubedb/ops-manager/commit/25ca3a62a) Use k8s 1.34 client libs (#815)
+- [8dd93808](https://github.com/kubedb/ops-manager/commit/8dd93808f) Fix makefile indentation (#814)
+- [af6c8f13](https://github.com/kubedb/ops-manager/commit/af6c8f13f) Test against k8s 1.35 (#811)
+- [6d2d736c](https://github.com/kubedb/ops-manager/commit/6d2d736c9) Update vulnerable deps
+- [116f7351](https://github.com/kubedb/ops-manager/commit/116f7351a) Publish Image for Redhat software certification (#810)
+
+
+
+## [kubedb/oracle](https://github.com/kubedb/oracle)
+
+### [v0.6.0-rc.1](https://github.com/kubedb/oracle/releases/tag/v0.6.0-rc.1)
+
+- [6483df83](https://github.com/kubedb/oracle/commit/6483df83) Prepare for release v0.6.0-rc.1 (#23)
+- [8dcfd2ed](https://github.com/kubedb/oracle/commit/8dcfd2ed) Use k8s 1.34 client libs (#22)
+
+
+
+## [kubedb/oracle-coordinator](https://github.com/kubedb/oracle-coordinator)
+
+### [v0.6.0-rc.1](https://github.com/kubedb/oracle-coordinator/releases/tag/v0.6.0-rc.1)
+
+- [5d1358a](https://github.com/kubedb/oracle-coordinator/commit/5d1358a) Prepare for release v0.6.0-rc.1 (#19)
+- [e0d0e32](https://github.com/kubedb/oracle-coordinator/commit/e0d0e32) Use k8s 1.34 client libs (#18)
+- [028fd7d](https://github.com/kubedb/oracle-coordinator/commit/028fd7d) Fix makefile indentation (#17)
+- [67c4d12](https://github.com/kubedb/oracle-coordinator/commit/67c4d12) Publish Image for Redhat software certification (#16)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.47.0-rc.1](https://github.com/kubedb/percona-xtradb/releases/tag/v0.47.0-rc.1)
+
+- [0047860f](https://github.com/kubedb/percona-xtradb/commit/0047860f3) Prepare for release v0.47.0-rc.1 (#427)
+- [645e9afa](https://github.com/kubedb/percona-xtradb/commit/645e9afaf) Use k8s 1.34 client libs (#426)
+- [d383e813](https://github.com/kubedb/percona-xtradb/commit/d383e813d) Test against k8s 1.35 (#425)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.33.0-rc.1](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.33.0-rc.1)
+
+- [a2ac2089](https://github.com/kubedb/percona-xtradb-coordinator/commit/a2ac2089) Prepare for release v0.33.0-rc.1 (#109)
+- [53ccb3e1](https://github.com/kubedb/percona-xtradb-coordinator/commit/53ccb3e1) Use k8s 1.34 client libs (#108)
+- [3393d9f4](https://github.com/kubedb/percona-xtradb-coordinator/commit/3393d9f4) Fix makefile indentation (#107)
+- [83523a0f](https://github.com/kubedb/percona-xtradb-coordinator/commit/83523a0f) Publish Image for Redhat software certification (#106)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.44.0-rc.1](https://github.com/kubedb/pg-coordinator/releases/tag/v0.44.0-rc.1)
+
+- [b36eb9fa](https://github.com/kubedb/pg-coordinator/commit/b36eb9fa) Prepare for release v0.44.0-rc.1 (#225)
+- [e9f791b6](https://github.com/kubedb/pg-coordinator/commit/e9f791b6) Use k8s 1.34 client libs (#224)
+- [975ac4fd](https://github.com/kubedb/pg-coordinator/commit/975ac4fd) Fix makefile indentation (#223)
+- [d030c49c](https://github.com/kubedb/pg-coordinator/commit/d030c49c) Publish Image for Redhat software certification (#222)
+- [ba00b5d5](https://github.com/kubedb/pg-coordinator/commit/ba00b5d5) Fix parse err check (#221)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.47.0-rc.1](https://github.com/kubedb/pgbouncer/releases/tag/v0.47.0-rc.1)
+
+- [b9a64657](https://github.com/kubedb/pgbouncer/commit/b9a646574) Prepare for release v0.47.0-rc.1 (#391)
+- [8cdeb750](https://github.com/kubedb/pgbouncer/commit/8cdeb7501) Use k8s 1.34 client libs (#390)
+- [1defb0fe](https://github.com/kubedb/pgbouncer/commit/1defb0fe1) Test against k8s 1.35 (#389)
+
+
+
+## [kubedb/pgpool](https://github.com/kubedb/pgpool)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/pgpool/releases/tag/v0.15.0-rc.1)
+
+- [17ba50ae](https://github.com/kubedb/pgpool/commit/17ba50ae) Prepare for release v0.15.0-rc.1 (#94)
+- [f6428269](https://github.com/kubedb/pgpool/commit/f6428269) Use k8s 1.34 client libs (#93)
+- [c93510d6](https://github.com/kubedb/pgpool/commit/c93510d6) Test against k8s 1.35 (#91)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.60.0-rc.1](https://github.com/kubedb/postgres/releases/tag/v0.60.0-rc.1)
+
+- [a4b0d948](https://github.com/kubedb/postgres/commit/a4b0d9486) Prepare for release v0.60.0-rc.1 (#846)
+- [2e264101](https://github.com/kubedb/postgres/commit/2e2641018) Use k8s 1.34 client libs (#845)
+- [44a384b0](https://github.com/kubedb/postgres/commit/44a384b00) Test against k8s 1.35 (#844)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/postgres-archiver/releases/tag/v0.21.0-rc.1)
+
+- [16aaff7c](https://github.com/kubedb/postgres-archiver/commit/16aaff7c) Prepare for release v0.21.0-rc.1 (#77)
+- [da7738a0](https://github.com/kubedb/postgres-archiver/commit/da7738a0) Prepare for release v0.21.0-rc.1 (#76)
+- [7736eaa2](https://github.com/kubedb/postgres-archiver/commit/7736eaa2) Use k8s 1.34 client libs (#75)
+- [53ae9b13](https://github.com/kubedb/postgres-archiver/commit/53ae9b13) Fix makefile indentation (#74)
+- [fc256522](https://github.com/kubedb/postgres-archiver/commit/fc256522) Publish Image for Redhat software certification (#73)
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.21.0-rc.1)
+
+- [7d99eb19](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/7d99eb19) Prepare for release v0.21.0-rc.1 (#73)
+- [2d482cda](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/2d482cda) Use k8s 1.34 client libs (#72)
+- [48e2e4c9](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/48e2e4c9) Fix makefile indentation (#71)
+- [ea89b1db](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/ea89b1db) Publish Image for Redhat software certification (#70)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.23.0-rc.1](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.23.0-rc.1)
+
+- [a8876977](https://github.com/kubedb/postgres-restic-plugin/commit/a8876977) Prepare for release v0.23.0-rc.1 (#87)
+- [13e072fb](https://github.com/kubedb/postgres-restic-plugin/commit/13e072fb) Use k8s 1.34 client libs (#86)
+- [b258277e](https://github.com/kubedb/postgres-restic-plugin/commit/b258277e) Fix makefile indentation (#85)
+- [5a182fc7](https://github.com/kubedb/postgres-restic-plugin/commit/5a182fc7) Publish Image for Redhat software certification (#84)
+
+
+
+## [kubedb/provider-aws](https://github.com/kubedb/provider-aws)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/provider-aws/releases/tag/v0.21.0-rc.1)
+
+
+
+
+## [kubedb/provider-azure](https://github.com/kubedb/provider-azure)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/provider-azure/releases/tag/v0.21.0-rc.1)
+
+
+
+
+## [kubedb/provider-gcp](https://github.com/kubedb/provider-gcp)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/provider-gcp/releases/tag/v0.21.0-rc.1)
+
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.60.0-rc.1](https://github.com/kubedb/provisioner/releases/tag/v0.60.0-rc.1)
+
+- [4726affd](https://github.com/kubedb/provisioner/commit/4726affdf) Prepare for release v0.60.0-rc.1 (#182)
+- [da33384c](https://github.com/kubedb/provisioner/commit/da33384c2) Use k8s 1.34 client libs (#181)
+- [51de966b](https://github.com/kubedb/provisioner/commit/51de966b7) Fix makefile indentation (#180)
+- [11e9f6b6](https://github.com/kubedb/provisioner/commit/11e9f6b60) Test against k8s 1.35 (#179)
+- [7e4a2954](https://github.com/kubedb/provisioner/commit/7e4a29545) Publish Image for Redhat software certification (#178)
+- [1f19bb32](https://github.com/kubedb/provisioner/commit/1f19bb323) Update vulnerable deps
+- [373f5f5c](https://github.com/kubedb/provisioner/commit/373f5f5c2) Check if appscode license api is up whle image building
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.47.0-rc.1](https://github.com/kubedb/proxysql/releases/tag/v0.47.0-rc.1)
+
+- [7ec3ed3f](https://github.com/kubedb/proxysql/commit/7ec3ed3f5) Prepare for release v0.47.0-rc.1 (#411)
+- [99a845b1](https://github.com/kubedb/proxysql/commit/99a845b14) Use k8s 1.34 client libs (#410)
+- [71efc19c](https://github.com/kubedb/proxysql/commit/71efc19c6) Test against k8s 1.35 (#409)
+- [10258db5](https://github.com/kubedb/proxysql/commit/10258db59) Remove github.com/go-xorm/xorm dependency
+
+
+
+## [kubedb/qdrant](https://github.com/kubedb/qdrant)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/qdrant/releases/tag/v0.1.0-rc.1)
+
+- [47542dd7](https://github.com/kubedb/qdrant/commit/47542dd7) Prepare for release v0.1.0-rc.1 (#11)
+- [2653e252](https://github.com/kubedb/qdrant/commit/2653e252) Use k8s 1.34 client libs (#10)
+- [a3318df6](https://github.com/kubedb/qdrant/commit/a3318df6) Test against k8s 1.35 (#8)
+
+
+
+## [kubedb/rabbitmq](https://github.com/kubedb/rabbitmq)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/rabbitmq/releases/tag/v0.15.0-rc.1)
+
+- [5730ad2b](https://github.com/kubedb/rabbitmq/commit/5730ad2b) Prepare for release v0.15.0-rc.1 (#105)
+- [fc6d5de0](https://github.com/kubedb/rabbitmq/commit/fc6d5de0) Use k8s 1.34 client libs (#104)
+- [34ac217c](https://github.com/kubedb/rabbitmq/commit/34ac217c) Test against k8s 1.35 (#103)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.53.0-rc.1](https://github.com/kubedb/redis/releases/tag/v0.53.0-rc.1)
+
+- [504bc21c](https://github.com/kubedb/redis/commit/504bc21c1) Prepare for release v0.53.0-rc.1 (#614)
+- [082ef45b](https://github.com/kubedb/redis/commit/082ef45b4) Use k8s 1.34 client libs (#613)
+- [ce19d04e](https://github.com/kubedb/redis/commit/ce19d04e5) Test against k8s 1.35 (#612)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.39.0-rc.1](https://github.com/kubedb/redis-coordinator/releases/tag/v0.39.0-rc.1)
+
+- [c7289d79](https://github.com/kubedb/redis-coordinator/commit/c7289d79) Prepare for release v0.39.0-rc.1 (#143)
+- [a135f6e5](https://github.com/kubedb/redis-coordinator/commit/a135f6e5) Use k8s 1.34 client libs (#142)
+- [42038efc](https://github.com/kubedb/redis-coordinator/commit/42038efc) Fix makefile indentation (#141)
+- [9924e4eb](https://github.com/kubedb/redis-coordinator/commit/9924e4eb) Publish Image for Redhat software certification (#140)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.23.0-rc.1](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.23.0-rc.1)
+
+- [84b3bcce](https://github.com/kubedb/redis-restic-plugin/commit/84b3bcce) Prepare for release v0.23.0-rc.1 (#82)
+- [b2ea9fc3](https://github.com/kubedb/redis-restic-plugin/commit/b2ea9fc3) Use k8s 1.34 client libs (#81)
+- [3b705e12](https://github.com/kubedb/redis-restic-plugin/commit/3b705e12) Fix makefile indentation (#80)
+- [6801fb25](https://github.com/kubedb/redis-restic-plugin/commit/6801fb25) Publish Image for Redhat software certification (#79)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.47.0-rc.1](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.47.0-rc.1)
+
+- [77ec3ba3](https://github.com/kubedb/replication-mode-detector/commit/77ec3ba3) Prepare for release v0.47.0-rc.1 (#306)
+- [4cb9f404](https://github.com/kubedb/replication-mode-detector/commit/4cb9f404) Use k8s 1.34 client libs (#305)
+- [77e5286c](https://github.com/kubedb/replication-mode-detector/commit/77e5286c) Fix makefile indentation (#304)
+- [9322cc0c](https://github.com/kubedb/replication-mode-detector/commit/9322cc0c) Publish Image for Redhat software certification (#303)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.36.0-rc.1](https://github.com/kubedb/schema-manager/releases/tag/v0.36.0-rc.1)
+
+- [6b881db3](https://github.com/kubedb/schema-manager/commit/6b881db3) Prepare for release v0.36.0-rc.1 (#153)
+- [f9e6fea0](https://github.com/kubedb/schema-manager/commit/f9e6fea0) Use k8s 1.34 client libs (#152)
+- [76951266](https://github.com/kubedb/schema-manager/commit/76951266) Fix makefile indentation (#151)
+- [49234341](https://github.com/kubedb/schema-manager/commit/49234341) Publish Image for Redhat software certification (#150)
+
+
+
+## [kubedb/singlestore](https://github.com/kubedb/singlestore)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/singlestore/releases/tag/v0.15.0-rc.1)
+
+- [9dd2d8a5](https://github.com/kubedb/singlestore/commit/9dd2d8a5) Prepare for release v0.15.0-rc.1 (#94)
+- [73d9f999](https://github.com/kubedb/singlestore/commit/73d9f999) Use k8s 1.34 client libs (#93)
+- [f84e08b4](https://github.com/kubedb/singlestore/commit/f84e08b4) Test against k8s 1.35 (#92)
+
+
+
+## [kubedb/singlestore-coordinator](https://github.com/kubedb/singlestore-coordinator)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/singlestore-coordinator/releases/tag/v0.15.0-rc.1)
+
+- [2b1fa919](https://github.com/kubedb/singlestore-coordinator/commit/2b1fa919) Prepare for release v0.15.0-rc.1 (#56)
+- [4a067f5f](https://github.com/kubedb/singlestore-coordinator/commit/4a067f5f) Use k8s 1.34 client libs (#55)
+- [67248c77](https://github.com/kubedb/singlestore-coordinator/commit/67248c77) Fix makefile indentation (#54)
+- [e7847baf](https://github.com/kubedb/singlestore-coordinator/commit/e7847baf) Publish Image for Redhat software certification (#53)
+
+
+
+## [kubedb/singlestore-restic-plugin](https://github.com/kubedb/singlestore-restic-plugin)
+
+### [v0.18.0-rc.1](https://github.com/kubedb/singlestore-restic-plugin/releases/tag/v0.18.0-rc.1)
+
+- [5762f17e](https://github.com/kubedb/singlestore-restic-plugin/commit/5762f17e) Prepare for release v0.18.0-rc.1 (#62)
+- [3e2214d7](https://github.com/kubedb/singlestore-restic-plugin/commit/3e2214d7) Use k8s 1.34 client libs (#61)
+- [b638ab06](https://github.com/kubedb/singlestore-restic-plugin/commit/b638ab06) Fix makefile indentation (#60)
+- [378183ea](https://github.com/kubedb/singlestore-restic-plugin/commit/378183ea) Publish Image for Redhat software certification (#59)
+
+
+
+## [kubedb/solr](https://github.com/kubedb/solr)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/solr/releases/tag/v0.15.0-rc.1)
+
+- [4073694e](https://github.com/kubedb/solr/commit/4073694e) Prepare for release v0.15.0-rc.1 (#106)
+- [1bd7aa31](https://github.com/kubedb/solr/commit/1bd7aa31) Use k8s 1.34 client libs (#105)
+- [a1581efa](https://github.com/kubedb/solr/commit/a1581efa) Bump k8s.io/kubernetes from 1.32.8 to 1.32.10 (#104)
+- [ec4afd2b](https://github.com/kubedb/solr/commit/ec4afd2b) Test against k8s 1.35 (#103)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.45.0-rc.1](https://github.com/kubedb/tests/releases/tag/v0.45.0-rc.1)
+
+- [66510754](https://github.com/kubedb/tests/commit/66510754) Prepare for release v0.45.0-rc.1 (#499)
+- [3b1d93be](https://github.com/kubedb/tests/commit/3b1d93be) Use k8s 1.34 client libs (#498)
+- [ec3491a2](https://github.com/kubedb/tests/commit/ec3491a2) Test against k8s 1.35 (#496)
+- [5ad85722](https://github.com/kubedb/tests/commit/5ad85722) MSSQLServer Logical Backup (Wal-G) (#481)
+- [f3b02cd7](https://github.com/kubedb/tests/commit/f3b02cd7) MariaDB MaxScale VerticalScale (#491)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.36.0-rc.1](https://github.com/kubedb/ui-server/releases/tag/v0.36.0-rc.1)
+
+- [aa21b74c](https://github.com/kubedb/ui-server/commit/aa21b74c) Prepare for release v0.36.0-rc.1 (#185)
+- [10372bf9](https://github.com/kubedb/ui-server/commit/10372bf9) Update vulnerable deps (#184)
+- [dc899cea](https://github.com/kubedb/ui-server/commit/dc899cea) Use k8s 1.34 client libs (#183)
+- [c1d34c7e](https://github.com/kubedb/ui-server/commit/c1d34c7e) Fix makefile indentation (#182)
+- [9ebbb2ac](https://github.com/kubedb/ui-server/commit/9ebbb2ac) Publish Image for Redhat software certification (#179)
+
+
+
+## [kubedb/weaviate](https://github.com/kubedb/weaviate)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/weaviate/releases/tag/v0.1.0-rc.1)
+
+- [429e6c27](https://github.com/kubedb/weaviate/commit/429e6c27) Prepare for release v0.1.0-rc.1 (#8)
+- [110cd467](https://github.com/kubedb/weaviate/commit/110cd467) Update vulnerable deps (#7)
+- [a5f58ee6](https://github.com/kubedb/weaviate/commit/a5f58ee6) Use k8s 1.34 client libs (#6)
+- [387e92f6](https://github.com/kubedb/weaviate/commit/387e92f6) Test against k8s 1.34 (#1)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.36.0-rc.1](https://github.com/kubedb/webhook-server/releases/tag/v0.36.0-rc.1)
+
+- [dbeae2f7](https://github.com/kubedb/webhook-server/commit/dbeae2f7) Prepare for release v0.36.0-rc.1 (#186)
+- [d85264ab](https://github.com/kubedb/webhook-server/commit/d85264ab) Use k8s 1.34 client libs (#185)
+- [e8ed226a](https://github.com/kubedb/webhook-server/commit/e8ed226a) Fix makefile indentation (#184)
+
+
+
+## [kubedb/xtrabackup-restic-plugin](https://github.com/kubedb/xtrabackup-restic-plugin)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/xtrabackup-restic-plugin/releases/tag/v0.8.0-rc.1)
+
+- [5c0b64e](https://github.com/kubedb/xtrabackup-restic-plugin/commit/5c0b64e) Prepare for release v0.8.0-rc.1 (#30)
+- [39afcc0](https://github.com/kubedb/xtrabackup-restic-plugin/commit/39afcc0) Use k8s 1.34 client libs (#29)
+- [1d360b0](https://github.com/kubedb/xtrabackup-restic-plugin/commit/1d360b0) Fix makefile indentation (#28)
+- [bb44171](https://github.com/kubedb/xtrabackup-restic-plugin/commit/bb44171) Publish Image for Redhat software certification (#27)
+
+
+
+## [kubedb/zookeeper](https://github.com/kubedb/zookeeper)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/zookeeper/releases/tag/v0.15.0-rc.1)
+
+- [05a44ba9](https://github.com/kubedb/zookeeper/commit/05a44ba9) Prepare for release v0.15.0-rc.1 (#97)
+- [bfdf1c28](https://github.com/kubedb/zookeeper/commit/bfdf1c28) Use k8s 1.34 client libs (#96)
+- [ca2cbe8b](https://github.com/kubedb/zookeeper/commit/ca2cbe8b) Test against k8s 1.35 (#95)
+
+
+
+## [kubedb/zookeeper-restic-plugin](https://github.com/kubedb/zookeeper-restic-plugin)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/zookeeper-restic-plugin/releases/tag/v0.16.0-rc.1)
+
+- [1f1a5f1](https://github.com/kubedb/zookeeper-restic-plugin/commit/1f1a5f1) Prepare for release v0.16.0-rc.1 (#51)
+- [f4afa89](https://github.com/kubedb/zookeeper-restic-plugin/commit/f4afa89) Use k8s 1.34 client libs (#50)
+- [ecd338e](https://github.com/kubedb/zookeeper-restic-plugin/commit/ecd338e) Fix makefile indentation (#49)
+- [513fdf0](https://github.com/kubedb/zookeeper-restic-plugin/commit/513fdf0) Publish Image for Redhat software certification (#48)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2025.12.31-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/123
Signed-off-by: 1gtm <1gtm@appscode.com>