### PR TITLE
Prepare for release v2026.2.21-rc.1

### DIFF
--- a/docs/CHANGELOG-v2026.2.21-rc.1.md
+++ b/docs/CHANGELOG-v2026.2.21-rc.1.md
@@ -1,0 +1,678 @@
+---
+title: Changelog | KubeDB
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-kubedb-v2026.2.21-rc.1
+    name: Changelog-v2026.2.21-rc.1
+    parent: welcome
+    weight: 20260221
+product_name: kubedb
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2026.2.21-rc.1/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2026.2.21-rc.1/
+---
+
+# KubeDB v2026.2.21-rc.1 (2026-02-21)
+
+
+## [kubedb/apimachinery](https://github.com/kubedb/apimachinery)
+
+### [v0.61.0-rc.1](https://github.com/kubedb/apimachinery/releases/tag/v0.61.0-rc.1)
+
+- [88d5ab20](https://github.com/kubedb/apimachinery/commit/88d5ab201) Fix CVE (#1603)
+- [913319e2](https://github.com/kubedb/apimachinery/commit/913319e2e) Add Neo4j Monitoring, TLS,  Restart Ops Req  APIs (#1552)
+- [24696181](https://github.com/kubedb/apimachinery/commit/246961815) Fix CVE (#1601)
+- [71337bae](https://github.com/kubedb/apimachinery/commit/71337bae8) Update for release KubeStash@v2026.2.16-rc.0 (#1598)
+- [f207902b](https://github.com/kubedb/apimachinery/commit/f207902b5) go fix ./... (#1597)
+- [54c28427](https://github.com/kubedb/apimachinery/commit/54c284279) Update migrator image spec (#1596)
+
+
+
+## [kubedb/autoscaler](https://github.com/kubedb/autoscaler)
+
+### [v0.46.0-rc.1](https://github.com/kubedb/autoscaler/releases/tag/v0.46.0-rc.1)
+
+- [33a7c8cd](https://github.com/kubedb/autoscaler/commit/33a7c8cd) Prepare for release v0.46.0-rc.1 (#280)
+
+
+
+## [kubedb/cassandra](https://github.com/kubedb/cassandra)
+
+### [v0.14.0-rc.1](https://github.com/kubedb/cassandra/releases/tag/v0.14.0-rc.1)
+
+- [391cc969](https://github.com/kubedb/cassandra/commit/391cc969) Prepare for release v0.14.0-rc.1 (#64)
+
+
+
+## [kubedb/cassandra-medusa-plugin](https://github.com/kubedb/cassandra-medusa-plugin)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/cassandra-medusa-plugin/releases/tag/v0.8.0-rc.1)
+
+- [ca2c82bc](https://github.com/kubedb/cassandra-medusa-plugin/commit/ca2c82bc) Prepare for release v0.8.0-rc.1 (#25)
+
+
+
+## [kubedb/cli](https://github.com/kubedb/cli)
+
+### [v0.61.0-rc.1](https://github.com/kubedb/cli/releases/tag/v0.61.0-rc.1)
+
+- [9bb719ce](https://github.com/kubedb/cli/commit/9bb719cef) Prepare for release v0.61.0-rc.1 (#814)
+
+
+
+## [kubedb/clickhouse](https://github.com/kubedb/clickhouse)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/clickhouse/releases/tag/v0.16.0-rc.1)
+
+- [fb6882db](https://github.com/kubedb/clickhouse/commit/fb6882db) Prepare for release v0.16.0-rc.1 (#87)
+
+
+
+## [kubedb/crd-manager](https://github.com/kubedb/crd-manager)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/crd-manager/releases/tag/v0.16.0-rc.1)
+
+- [b842153d](https://github.com/kubedb/crd-manager/commit/b842153d) Prepare for release v0.16.0-rc.1 (#112)
+
+
+
+## [kubedb/dashboard-restic-plugin](https://github.com/kubedb/dashboard-restic-plugin)
+
+### [v0.19.0-rc.1](https://github.com/kubedb/dashboard-restic-plugin/releases/tag/v0.19.0-rc.1)
+
+- [8174419](https://github.com/kubedb/dashboard-restic-plugin/commit/8174419) Prepare for release v0.19.0-rc.1 (#63)
+
+
+
+## [kubedb/db-client-go](https://github.com/kubedb/db-client-go)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/db-client-go/releases/tag/v0.16.0-rc.1)
+
+- [96ffd3fa](https://github.com/kubedb/db-client-go/commit/96ffd3fa) Prepare for release v0.16.0-rc.1 (#224)
+- [9d31719c](https://github.com/kubedb/db-client-go/commit/9d31719c) Add Neo4j TLS (#220)
+
+
+
+## [kubedb/db2](https://github.com/kubedb/db2)
+
+### [v0.2.0-rc.1](https://github.com/kubedb/db2/releases/tag/v0.2.0-rc.1)
+
+- [7a213b22](https://github.com/kubedb/db2/commit/7a213b22) Prepare for release v0.2.0-rc.1 (#12)
+
+
+
+## [kubedb/db2-coordinator](https://github.com/kubedb/db2-coordinator)
+
+### [v0.2.0-rc.1](https://github.com/kubedb/db2-coordinator/releases/tag/v0.2.0-rc.1)
+
+- [2081e6b](https://github.com/kubedb/db2-coordinator/commit/2081e6b) Cleanup go.mod (#6)
+
+
+
+## [kubedb/druid](https://github.com/kubedb/druid)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/druid/releases/tag/v0.16.0-rc.1)
+
+- [0df0a69d](https://github.com/kubedb/druid/commit/0df0a69d) Prepare for release v0.16.0-rc.1 (#116)
+
+
+
+## [kubedb/elasticsearch](https://github.com/kubedb/elasticsearch)
+
+### [v0.61.0-rc.1](https://github.com/kubedb/elasticsearch/releases/tag/v0.61.0-rc.1)
+
+- [e5fba167](https://github.com/kubedb/elasticsearch/commit/e5fba167e) Prepare for release v0.61.0-rc.1 (#793)
+
+
+
+## [kubedb/elasticsearch-restic-plugin](https://github.com/kubedb/elasticsearch-restic-plugin)
+
+### [v0.24.0-rc.1](https://github.com/kubedb/elasticsearch-restic-plugin/releases/tag/v0.24.0-rc.1)
+
+- [1d7a84f3](https://github.com/kubedb/elasticsearch-restic-plugin/commit/1d7a84f3) Prepare for release v0.24.0-rc.1 (#86)
+
+
+
+## [kubedb/ferretdb](https://github.com/kubedb/ferretdb)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/ferretdb/releases/tag/v0.16.0-rc.1)
+
+- [6f84d429](https://github.com/kubedb/ferretdb/commit/6f84d429) Prepare for release v0.16.0-rc.1 (#104)
+
+
+
+## [kubedb/gitops](https://github.com/kubedb/gitops)
+
+### [v0.9.0-rc.1](https://github.com/kubedb/gitops/releases/tag/v0.9.0-rc.1)
+
+- [6954152b](https://github.com/kubedb/gitops/commit/6954152b) Prepare for release v0.9.0-rc.1 (#42)
+
+
+
+## [kubedb/hanadb](https://github.com/kubedb/hanadb)
+
+### [v0.2.0-rc.1](https://github.com/kubedb/hanadb/releases/tag/v0.2.0-rc.1)
+
+- [e747ed30](https://github.com/kubedb/hanadb/commit/e747ed30) Prepare for release v0.2.0-rc.1 (#17)
+
+
+
+## [kubedb/hazelcast](https://github.com/kubedb/hazelcast)
+
+### [v0.7.0-rc.1](https://github.com/kubedb/hazelcast/releases/tag/v0.7.0-rc.1)
+
+- [56738410](https://github.com/kubedb/hazelcast/commit/56738410) Prepare for release v0.7.0-rc.1 (#29)
+
+
+
+## [kubedb/ignite](https://github.com/kubedb/ignite)
+
+### [v0.8.0-rc.1](https://github.com/kubedb/ignite/releases/tag/v0.8.0-rc.1)
+
+- [668d592b](https://github.com/kubedb/ignite/commit/668d592b) Prepare for release v0.8.0-rc.1 (#38)
+
+
+
+## [kubedb/installer](https://github.com/kubedb/installer)
+
+### [v2026.2.21-rc.1](https://github.com/kubedb/installer/releases/tag/v2026.2.21-rc.1)
+
+
+
+
+## [kubedb/kafka](https://github.com/kubedb/kafka)
+
+### [v0.32.0-rc.1](https://github.com/kubedb/kafka/releases/tag/v0.32.0-rc.1)
+
+- [fd24c63a](https://github.com/kubedb/kafka/commit/fd24c63a) Prepare for release v0.32.0-rc.1 (#178)
+
+
+
+## [kubedb/kibana](https://github.com/kubedb/kibana)
+
+### [v0.37.0-rc.1](https://github.com/kubedb/kibana/releases/tag/v0.37.0-rc.1)
+
+- [cb717901](https://github.com/kubedb/kibana/commit/cb717901) Prepare for release v0.37.0-rc.1 (#170)
+
+
+
+## [kubedb/kubedb-manifest-plugin](https://github.com/kubedb/kubedb-manifest-plugin)
+
+### [v0.24.0-rc.1](https://github.com/kubedb/kubedb-manifest-plugin/releases/tag/v0.24.0-rc.1)
+
+- [c9385129](https://github.com/kubedb/kubedb-manifest-plugin/commit/c9385129) Prepare for release v0.24.0-rc.1 (#118)
+
+
+
+## [kubedb/kubedb-verifier](https://github.com/kubedb/kubedb-verifier)
+
+### [v0.12.0-rc.1](https://github.com/kubedb/kubedb-verifier/releases/tag/v0.12.0-rc.1)
+
+- [2768c2e8](https://github.com/kubedb/kubedb-verifier/commit/2768c2e8) Prepare for release v0.12.0-rc.1 (#40)
+
+
+
+## [kubedb/mariadb](https://github.com/kubedb/mariadb)
+
+### [v0.45.0-rc.1](https://github.com/kubedb/mariadb/releases/tag/v0.45.0-rc.1)
+
+- [8fcaff0c](https://github.com/kubedb/mariadb/commit/8fcaff0cb) Prepare for release v0.45.0-rc.1 (#375)
+
+
+
+## [kubedb/mariadb-archiver](https://github.com/kubedb/mariadb-archiver)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/mariadb-archiver/releases/tag/v0.21.0-rc.1)
+
+- [2cb13461](https://github.com/kubedb/mariadb-archiver/commit/2cb13461) Prepare for release v0.21.0-rc.1 (#77)
+
+
+
+## [kubedb/mariadb-coordinator](https://github.com/kubedb/mariadb-coordinator)
+
+### [v0.41.0-rc.1](https://github.com/kubedb/mariadb-coordinator/releases/tag/v0.41.0-rc.1)
+
+- [c7eff91c](https://github.com/kubedb/mariadb-coordinator/commit/c7eff91c) Prepare for release v0.41.0-rc.1 (#165)
+
+
+
+## [kubedb/mariadb-csi-snapshotter-plugin](https://github.com/kubedb/mariadb-csi-snapshotter-plugin)
+
+### [v0.21.0-rc.1](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/releases/tag/v0.21.0-rc.1)
+
+- [ca82e192](https://github.com/kubedb/mariadb-csi-snapshotter-plugin/commit/ca82e192) Prepare for release v0.21.0-rc.1 (#68)
+
+
+
+## [kubedb/mariadb-restic-plugin](https://github.com/kubedb/mariadb-restic-plugin)
+
+### [v0.19.0-rc.1](https://github.com/kubedb/mariadb-restic-plugin/releases/tag/v0.19.0-rc.1)
+
+- [d0606b0](https://github.com/kubedb/mariadb-restic-plugin/commit/d0606b0) Prepare for release v0.19.0-rc.1 (#75)
+
+
+
+## [kubedb/memcached](https://github.com/kubedb/memcached)
+
+### [v0.54.0-rc.1](https://github.com/kubedb/memcached/releases/tag/v0.54.0-rc.1)
+
+- [7ec689d8](https://github.com/kubedb/memcached/commit/7ec689d8c) Prepare for release v0.54.0-rc.1 (#524)
+
+
+
+## [kubedb/migrator-cli](https://github.com/kubedb/migrator-cli)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/migrator-cli/releases/tag/v0.1.0-rc.1)
+
+- [1ae73cb](https://github.com/kubedb/migrator-cli/commit/1ae73cb) Prepare for release v0.1.0-rc.1 (#5)
+
+
+
+## [kubedb/migrator-operator](https://github.com/kubedb/migrator-operator)
+
+### [v0.1.0-rc.1](https://github.com/kubedb/migrator-operator/releases/tag/v0.1.0-rc.1)
+
+- [ed2f3d8](https://github.com/kubedb/migrator-operator/commit/ed2f3d8) Prepare for release v0.1.0-rc.1 (#6)
+
+
+
+## [kubedb/milvus](https://github.com/kubedb/milvus)
+
+### [v0.2.0-rc.1](https://github.com/kubedb/milvus/releases/tag/v0.2.0-rc.1)
+
+- [31a1617f](https://github.com/kubedb/milvus/commit/31a1617f) Prepare for release v0.2.0-rc.1 (#19)
+
+
+
+## [kubedb/mongodb](https://github.com/kubedb/mongodb)
+
+### [v0.54.0-rc.1](https://github.com/kubedb/mongodb/releases/tag/v0.54.0-rc.1)
+
+- [9a131c8d](https://github.com/kubedb/mongodb/commit/9a131c8df) Prepare for release v0.54.0-rc.1 (#739)
+
+
+
+## [kubedb/mongodb-csi-snapshotter-plugin](https://github.com/kubedb/mongodb-csi-snapshotter-plugin)
+
+### [v0.22.0-rc.1](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/releases/tag/v0.22.0-rc.1)
+
+- [250be44f](https://github.com/kubedb/mongodb-csi-snapshotter-plugin/commit/250be44f) Prepare for release v0.22.0-rc.1 (#72)
+
+
+
+## [kubedb/mongodb-restic-plugin](https://github.com/kubedb/mongodb-restic-plugin)
+
+### [v0.24.0-rc.1](https://github.com/kubedb/mongodb-restic-plugin/releases/tag/v0.24.0-rc.1)
+
+- [004d1ffe](https://github.com/kubedb/mongodb-restic-plugin/commit/004d1ffe) Prepare for release v0.24.0-rc.1 (#108)
+
+
+
+## [kubedb/mssql-coordinator](https://github.com/kubedb/mssql-coordinator)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/mssql-coordinator/releases/tag/v0.16.0-rc.1)
+
+- [78f1c1c2](https://github.com/kubedb/mssql-coordinator/commit/78f1c1c2) Prepare for release v0.16.0-rc.1 (#57)
+
+
+
+## [kubedb/mssqlserver](https://github.com/kubedb/mssqlserver)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/mssqlserver/releases/tag/v0.16.0-rc.1)
+
+- [c86e1178](https://github.com/kubedb/mssqlserver/commit/c86e1178) Prepare for release v0.16.0-rc.1 (#111)
+
+
+
+## [kubedb/mssqlserver-archiver](https://github.com/kubedb/mssqlserver-archiver)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/mssqlserver-archiver/releases/tag/v0.15.0-rc.1)
+
+
+
+
+## [kubedb/mssqlserver-walg-plugin](https://github.com/kubedb/mssqlserver-walg-plugin)
+
+### [v0.15.0-rc.1](https://github.com/kubedb/mssqlserver-walg-plugin/releases/tag/v0.15.0-rc.1)
+
+- [b5eef01](https://github.com/kubedb/mssqlserver-walg-plugin/commit/b5eef01) Prepare for release v0.15.0-rc.1 (#47)
+
+
+
+## [kubedb/mysql](https://github.com/kubedb/mysql)
+
+### [v0.54.0-rc.1](https://github.com/kubedb/mysql/releases/tag/v0.54.0-rc.1)
+
+- [0db51d13](https://github.com/kubedb/mysql/commit/0db51d13c) Prepare for release v0.54.0-rc.1 (#726)
+
+
+
+## [kubedb/mysql-archiver](https://github.com/kubedb/mysql-archiver)
+
+### [v0.22.0-rc.1](https://github.com/kubedb/mysql-archiver/releases/tag/v0.22.0-rc.1)
+
+- [4c36bd86](https://github.com/kubedb/mysql-archiver/commit/4c36bd86) Prepare for release v0.22.0-rc.1 (#85)
+- [f7b9a5e3](https://github.com/kubedb/mysql-archiver/commit/f7b9a5e3) Test against k8s 1.35 (#84)
+- [1b3f57e4](https://github.com/kubedb/mysql-archiver/commit/1b3f57e4) Wait for binlog cleanup until LogStats becomes available. (#82)
+
+
+
+## [kubedb/mysql-coordinator](https://github.com/kubedb/mysql-coordinator)
+
+### [v0.39.0-rc.1](https://github.com/kubedb/mysql-coordinator/releases/tag/v0.39.0-rc.1)
+
+- [11446c8d](https://github.com/kubedb/mysql-coordinator/commit/11446c8d) Prepare for release v0.39.0-rc.1 (#164)
+
+
+
+## [kubedb/mysql-csi-snapshotter-plugin](https://github.com/kubedb/mysql-csi-snapshotter-plugin)
+
+### [v0.22.0-rc.1](https://github.com/kubedb/mysql-csi-snapshotter-plugin/releases/tag/v0.22.0-rc.1)
+
+- [8b1497b4](https://github.com/kubedb/mysql-csi-snapshotter-plugin/commit/8b1497b4) Prepare for release v0.22.0-rc.1 (#69)
+
+
+
+## [kubedb/mysql-restic-plugin](https://github.com/kubedb/mysql-restic-plugin)
+
+### [v0.24.0-rc.1](https://github.com/kubedb/mysql-restic-plugin/releases/tag/v0.24.0-rc.1)
+
+- [399e40e8](https://github.com/kubedb/mysql-restic-plugin/commit/399e40e8) Prepare for release v0.24.0-rc.1 (#98)
+
+
+
+## [kubedb/mysql-router-init](https://github.com/kubedb/mysql-router-init)
+
+### [v0.39.0-rc.1](https://github.com/kubedb/mysql-router-init/releases/tag/v0.39.0-rc.1)
+
+
+
+
+## [kubedb/neo4j](https://github.com/kubedb/neo4j)
+
+### [v0.2.0-rc.1](https://github.com/kubedb/neo4j/releases/tag/v0.2.0-rc.1)
+
+- [c8a9ae6b](https://github.com/kubedb/neo4j/commit/c8a9ae6b) Prepare for release v0.2.0-rc.1 (#16)
+
+
+
+## [kubedb/ops-manager](https://github.com/kubedb/ops-manager)
+
+### [v0.48.0-rc.1](https://github.com/kubedb/ops-manager/releases/tag/v0.48.0-rc.1)
+
+- [e928a28d](https://github.com/kubedb/ops-manager/commit/e928a28d3) Prepare for release v0.48.0-rc.1 (#828)
+- [c2543046](https://github.com/kubedb/ops-manager/commit/c2543046c) Inline findInSlice function (#827)
+- [ebd3ab1c](https://github.com/kubedb/ops-manager/commit/ebd3ab1c8) go fix ./... (#826)
+
+
+
+## [kubedb/oracle](https://github.com/kubedb/oracle)
+
+### [v0.7.0-rc.1](https://github.com/kubedb/oracle/releases/tag/v0.7.0-rc.1)
+
+- [80d26f4a](https://github.com/kubedb/oracle/commit/80d26f4a) Prepare for release v0.7.0-rc.1 (#30)
+
+
+
+## [kubedb/oracle-coordinator](https://github.com/kubedb/oracle-coordinator)
+
+### [v0.7.0-rc.1](https://github.com/kubedb/oracle-coordinator/releases/tag/v0.7.0-rc.1)
+
+- [ff339c9](https://github.com/kubedb/oracle-coordinator/commit/ff339c9) Prepare for release v0.7.0-rc.1 (#24)
+
+
+
+## [kubedb/percona-xtradb](https://github.com/kubedb/percona-xtradb)
+
+### [v0.48.0-rc.1](https://github.com/kubedb/percona-xtradb/releases/tag/v0.48.0-rc.1)
+
+- [6d5d64ac](https://github.com/kubedb/percona-xtradb/commit/6d5d64acc) Prepare for release v0.48.0-rc.1 (#436)
+
+
+
+## [kubedb/percona-xtradb-coordinator](https://github.com/kubedb/percona-xtradb-coordinator)
+
+### [v0.34.0-rc.1](https://github.com/kubedb/percona-xtradb-coordinator/releases/tag/v0.34.0-rc.1)
+
+- [06c7e048](https://github.com/kubedb/percona-xtradb-coordinator/commit/06c7e048) Prepare for release v0.34.0-rc.1 (#115)
+
+
+
+## [kubedb/pg-coordinator](https://github.com/kubedb/pg-coordinator)
+
+### [v0.45.0-rc.1](https://github.com/kubedb/pg-coordinator/releases/tag/v0.45.0-rc.1)
+
+- [dda014e2](https://github.com/kubedb/pg-coordinator/commit/dda014e2) Prepare for release v0.45.0-rc.1 (#233)
+
+
+
+## [kubedb/pgbouncer](https://github.com/kubedb/pgbouncer)
+
+### [v0.48.0-rc.1](https://github.com/kubedb/pgbouncer/releases/tag/v0.48.0-rc.1)
+
+- [18bbb401](https://github.com/kubedb/pgbouncer/commit/18bbb401a) Prepare for release v0.48.0-rc.1 (#398)
+
+
+
+## [kubedb/pgpool](https://github.com/kubedb/pgpool)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/pgpool/releases/tag/v0.16.0-rc.1)
+
+- [43956637](https://github.com/kubedb/pgpool/commit/43956637) Prepare for release v0.16.0-rc.1 (#103)
+- [85ab1429](https://github.com/kubedb/pgpool/commit/85ab1429) Apply go fix (#102)
+
+
+
+## [kubedb/postgres](https://github.com/kubedb/postgres)
+
+### [v0.61.0-rc.1](https://github.com/kubedb/postgres/releases/tag/v0.61.0-rc.1)
+
+- [f27f239b](https://github.com/kubedb/postgres/commit/f27f239b8) Prepare for release v0.61.0-rc.1 (#860)
+- [96d2952b](https://github.com/kubedb/postgres/commit/96d2952b8) Apply go fixes (#859)
+
+
+
+## [kubedb/postgres-archiver](https://github.com/kubedb/postgres-archiver)
+
+### [v0.22.0-rc.1](https://github.com/kubedb/postgres-archiver/releases/tag/v0.22.0-rc.1)
+
+- [4d49152b](https://github.com/kubedb/postgres-archiver/commit/4d49152b) Prepare for release v0.22.0-rc.1 (#89)
+- [905fe453](https://github.com/kubedb/postgres-archiver/commit/905fe453) Wait for WAL cleanup until LogStats becomes available. (#87)
+
+
+
+## [kubedb/postgres-csi-snapshotter-plugin](https://github.com/kubedb/postgres-csi-snapshotter-plugin)
+
+### [v0.22.0-rc.1](https://github.com/kubedb/postgres-csi-snapshotter-plugin/releases/tag/v0.22.0-rc.1)
+
+- [90137c46](https://github.com/kubedb/postgres-csi-snapshotter-plugin/commit/90137c46) Prepare for release v0.22.0-rc.1 (#79)
+
+
+
+## [kubedb/postgres-restic-plugin](https://github.com/kubedb/postgres-restic-plugin)
+
+### [v0.24.0-rc.1](https://github.com/kubedb/postgres-restic-plugin/releases/tag/v0.24.0-rc.1)
+
+- [df7dff18](https://github.com/kubedb/postgres-restic-plugin/commit/df7dff18) Prepare for release v0.24.0-rc.1 (#96)
+
+
+
+## [kubedb/provider-aws](https://github.com/kubedb/provider-aws)
+
+### [v0.22.0-rc.1](https://github.com/kubedb/provider-aws/releases/tag/v0.22.0-rc.1)
+
+
+
+
+## [kubedb/provider-azure](https://github.com/kubedb/provider-azure)
+
+### [v0.22.0-rc.1](https://github.com/kubedb/provider-azure/releases/tag/v0.22.0-rc.1)
+
+
+
+
+## [kubedb/provider-gcp](https://github.com/kubedb/provider-gcp)
+
+### [v0.22.0-rc.1](https://github.com/kubedb/provider-gcp/releases/tag/v0.22.0-rc.1)
+
+
+
+
+## [kubedb/provisioner](https://github.com/kubedb/provisioner)
+
+### [v0.61.0-rc.1](https://github.com/kubedb/provisioner/releases/tag/v0.61.0-rc.1)
+
+- [ac8fe929](https://github.com/kubedb/provisioner/commit/ac8fe9291) Prepare for release v0.61.0-rc.1 (#193)
+
+
+
+## [kubedb/proxysql](https://github.com/kubedb/proxysql)
+
+### [v0.48.0-rc.1](https://github.com/kubedb/proxysql/releases/tag/v0.48.0-rc.1)
+
+- [c9b575a3](https://github.com/kubedb/proxysql/commit/c9b575a3a) Prepare for release v0.48.0-rc.1 (#418)
+
+
+
+## [kubedb/qdrant](https://github.com/kubedb/qdrant)
+
+### [v0.2.0-rc.1](https://github.com/kubedb/qdrant/releases/tag/v0.2.0-rc.1)
+
+- [9b9e78e3](https://github.com/kubedb/qdrant/commit/9b9e78e3) Prepare for release v0.2.0-rc.1 (#20)
+
+
+
+## [kubedb/rabbitmq](https://github.com/kubedb/rabbitmq)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/rabbitmq/releases/tag/v0.16.0-rc.1)
+
+- [d6abc5b1](https://github.com/kubedb/rabbitmq/commit/d6abc5b1) Prepare for release v0.16.0-rc.1 (#115)
+
+
+
+## [kubedb/redis](https://github.com/kubedb/redis)
+
+### [v0.54.0-rc.1](https://github.com/kubedb/redis/releases/tag/v0.54.0-rc.1)
+
+- [4f835baf](https://github.com/kubedb/redis/commit/4f835bafa) Prepare for release v0.54.0-rc.1 (#625)
+
+
+
+## [kubedb/redis-coordinator](https://github.com/kubedb/redis-coordinator)
+
+### [v0.40.0-rc.1](https://github.com/kubedb/redis-coordinator/releases/tag/v0.40.0-rc.1)
+
+- [6dad96ab](https://github.com/kubedb/redis-coordinator/commit/6dad96ab) Prepare for release v0.40.0-rc.1 (#148)
+
+
+
+## [kubedb/redis-restic-plugin](https://github.com/kubedb/redis-restic-plugin)
+
+### [v0.24.0-rc.1](https://github.com/kubedb/redis-restic-plugin/releases/tag/v0.24.0-rc.1)
+
+- [24e23ccd](https://github.com/kubedb/redis-restic-plugin/commit/24e23ccd) Prepare for release v0.24.0-rc.1 (#92)
+
+
+
+## [kubedb/replication-mode-detector](https://github.com/kubedb/replication-mode-detector)
+
+### [v0.48.0-rc.1](https://github.com/kubedb/replication-mode-detector/releases/tag/v0.48.0-rc.1)
+
+- [8c9ceb40](https://github.com/kubedb/replication-mode-detector/commit/8c9ceb40) Prepare for release v0.48.0-rc.1 (#311)
+
+
+
+## [kubedb/schema-manager](https://github.com/kubedb/schema-manager)
+
+### [v0.37.0-rc.1](https://github.com/kubedb/schema-manager/releases/tag/v0.37.0-rc.1)
+
+- [2e9c64ce](https://github.com/kubedb/schema-manager/commit/2e9c64ce) Prepare for release v0.37.0-rc.1 (#158)
+
+
+
+## [kubedb/singlestore](https://github.com/kubedb/singlestore)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/singlestore/releases/tag/v0.16.0-rc.1)
+
+- [1c6aef0e](https://github.com/kubedb/singlestore/commit/1c6aef0e) Prepare for release v0.16.0-rc.1 (#101)
+
+
+
+## [kubedb/singlestore-coordinator](https://github.com/kubedb/singlestore-coordinator)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/singlestore-coordinator/releases/tag/v0.16.0-rc.1)
+
+- [6f1858a4](https://github.com/kubedb/singlestore-coordinator/commit/6f1858a4) Prepare for release v0.16.0-rc.1 (#61)
+
+
+
+## [kubedb/singlestore-restic-plugin](https://github.com/kubedb/singlestore-restic-plugin)
+
+### [v0.19.0-rc.1](https://github.com/kubedb/singlestore-restic-plugin/releases/tag/v0.19.0-rc.1)
+
+- [714be65b](https://github.com/kubedb/singlestore-restic-plugin/commit/714be65b) Prepare for release v0.19.0-rc.1 (#72)
+
+
+
+## [kubedb/solr](https://github.com/kubedb/solr)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/solr/releases/tag/v0.16.0-rc.1)
+
+- [0e1b35d2](https://github.com/kubedb/solr/commit/0e1b35d2) Prepare for release v0.16.0-rc.1 (#114)
+
+
+
+## [kubedb/tests](https://github.com/kubedb/tests)
+
+### [v0.46.0-rc.1](https://github.com/kubedb/tests/releases/tag/v0.46.0-rc.1)
+
+- [9ba6a211](https://github.com/kubedb/tests/commit/9ba6a2115) Prepare for release v0.46.0-rc.1 (#511)
+
+
+
+## [kubedb/ui-server](https://github.com/kubedb/ui-server)
+
+### [v0.37.0-rc.1](https://github.com/kubedb/ui-server/releases/tag/v0.37.0-rc.1)
+
+- [3eb33aa7](https://github.com/kubedb/ui-server/commit/3eb33aa7) Prepare for release v0.37.0-rc.1 (#190)
+
+
+
+## [kubedb/weaviate](https://github.com/kubedb/weaviate)
+
+### [v0.2.0-rc.1](https://github.com/kubedb/weaviate/releases/tag/v0.2.0-rc.1)
+
+- [134a727c](https://github.com/kubedb/weaviate/commit/134a727c) Fix CI (#18)
+- [87e94b4a](https://github.com/kubedb/weaviate/commit/87e94b4a) Prepare for release v0.2.0-rc.1 (#17)
+
+
+
+## [kubedb/webhook-server](https://github.com/kubedb/webhook-server)
+
+### [v0.37.0-rc.1](https://github.com/kubedb/webhook-server/releases/tag/v0.37.0-rc.1)
+
+- [048d980b](https://github.com/kubedb/webhook-server/commit/048d980b) Prepare for release v0.37.0-rc.1 (#196)
+
+
+
+## [kubedb/xtrabackup-restic-plugin](https://github.com/kubedb/xtrabackup-restic-plugin)
+
+### [v0.9.0-rc.1](https://github.com/kubedb/xtrabackup-restic-plugin/releases/tag/v0.9.0-rc.1)
+
+- [3737ea6](https://github.com/kubedb/xtrabackup-restic-plugin/commit/3737ea6) Prepare for release v0.9.0-rc.1 (#40)
+- [d77c796](https://github.com/kubedb/xtrabackup-restic-plugin/commit/d77c796) Apply go fix changes (#39)
+
+
+
+## [kubedb/zookeeper](https://github.com/kubedb/zookeeper)
+
+### [v0.16.0-rc.1](https://github.com/kubedb/zookeeper/releases/tag/v0.16.0-rc.1)
+
+- [fbf787f2](https://github.com/kubedb/zookeeper/commit/fbf787f2) Prepare for release v0.16.0-rc.1 (#105)
+
+
+
+


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2026.2.21-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/126
Signed-off-by: 1gtm <1gtm@appscode.com>