### PR TITLE
docs(weaviate): add guides and examples

### DIFF
--- a/docs/examples/weaviate/quickstart/weaviate.yaml
+++ b/docs/examples/weaviate/quickstart/weaviate.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/weaviate/reconfigure/ops-request.yaml
+++ b/docs/examples/weaviate/reconfigure/ops-request.yaml
@@ -1,0 +1,13 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-reconfigure
+  namespace: demo
+spec:
+  type: Reconfigure
+  databaseRef:
+    name: weaviate-sample
+  configuration:
+    applyConfig:
+      weaviate.yaml: |
+        LOG_LEVEL: info

--- a/docs/examples/weaviate/restart/ops-request.yaml
+++ b/docs/examples/weaviate/restart/ops-request.yaml
@@ -1,0 +1,9 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-restart
+  namespace: demo
+spec:
+  type: Restart
+  databaseRef:
+    name: weaviate-sample

--- a/docs/examples/weaviate/rotate-auth/ops-request.yaml
+++ b/docs/examples/weaviate/rotate-auth/ops-request.yaml
@@ -1,0 +1,10 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-rotate-auth
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: weaviate-sample
+  timeout: 5m

--- a/docs/examples/weaviate/scaling/vertical-scaling/ops-request.yaml
+++ b/docs/examples/weaviate/scaling/vertical-scaling/ops-request.yaml
@@ -1,0 +1,18 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-vertical-scale
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: weaviate-sample
+  verticalScaling:
+    node:
+      resources:
+        requests:
+          cpu: "500m"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 2Gi

--- a/docs/examples/weaviate/update-version/ops-request.yaml
+++ b/docs/examples/weaviate/update-version/ops-request.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-update-version
+  namespace: demo
+spec:
+  type: UpdateVersion
+  databaseRef:
+    name: weaviate-sample
+  updateVersion:
+    targetVersion: 1.34.0

--- a/docs/examples/weaviate/volume-expansion/ops-request.yaml
+++ b/docs/examples/weaviate/volume-expansion/ops-request.yaml
@@ -1,0 +1,12 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-volume-expand
+  namespace: demo
+spec:
+  type: VolumeExpansion
+  databaseRef:
+    name: weaviate-sample
+  volumeExpansion:
+    mode: Online
+    weaviate: 2Gi

--- a/docs/guides/weaviate/README.md
+++ b/docs/guides/weaviate/README.md
@@ -43,6 +43,7 @@ apiVersion: kubedb.com/v1alpha2
 kind: Weaviate
 metadata:
   name: weaviate-sample
+  namespace: demo
 spec:
   version: 1.33.1
   replicas: 3

--- a/docs/guides/weaviate/README.md
+++ b/docs/guides/weaviate/README.md
@@ -17,7 +17,7 @@ aliases:
 
 # Overview
 
-KubeDB supports Weaviate through the `Weaviate` CRD.
+KubeDB supports Weaviate through the `Weaviate` and `WeaviateOpsRequest` CRDs.
 
 ## Supported Weaviate Features
 
@@ -25,11 +25,16 @@ KubeDB supports Weaviate through the `Weaviate` CRD.
 |---------------------------|:------------:|
 | Standalone provisioning   |   &#10003;   |
 | Cluster provisioning      |   &#10003;   |
-| Ops Requests              |      No      |
+| Ops Requests              |   &#10003;   |
 
 ## Supported Ops Requests
 
-This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD. The existing ops pages are placeholder documentation only.
+- `Reconfigure`
+- `Restart`
+- `RotateAuth`
+- `UpdateVersion`
+- `VolumeExpansion`
+- `VerticalScaling`
 
 ## Example Weaviate Manifest
 
@@ -54,14 +59,14 @@ spec:
 
 ## User Guide
 
-- [Quickstart Weaviate](/docs/guides/weaviate/quickstart/quickstart.md) with KubeDB operator.
-- [Weaviate CRD Concept](/docs/guides/weaviate/concepts/weaviate.md).
-- [WeaviateVersion CRD Concept](/docs/guides/weaviate/concepts/catalog.md).
-- [WeaviateOpsRequest CRD Concept](/docs/guides/weaviate/concepts/opsrequest.md).
+- [Quickstart Weaviate](/docs/guides/weaviate/quickstart/quickstart.md)
+- [Weaviate CRD Concept](/docs/guides/weaviate/concepts/weaviate.md)
+- [WeaviateVersion CRD Concept](/docs/guides/weaviate/concepts/catalog.md)
+- [WeaviateOpsRequest CRD Concept](/docs/guides/weaviate/concepts/opsrequest.md)
 - [Private Registry](/docs/guides/weaviate/private-registry/using-private-registry.md)
 - [Custom RBAC](/docs/guides/weaviate/custom-rbac/using-custom-rbac.md)
 - [Custom Configuration](/docs/guides/weaviate/configuration/using-config-file.md)
-- [Ops Request](/docs/guides/weaviate/ops-request/overview.md) for current documentation status.
+- [Ops Request Overview](/docs/guides/weaviate/ops-request/overview.md)
 - [Reconfigure](/docs/guides/weaviate/reconfigure/overview.md)
 - [Restart](/docs/guides/weaviate/restart/restart.md)
 - [Rotate Auth](/docs/guides/weaviate/rotate-auth/overview.md)

--- a/docs/guides/weaviate/README.md
+++ b/docs/guides/weaviate/README.md
@@ -1,0 +1,70 @@
+---
+title: Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-readme
+    name: Weaviate
+    parent: weaviate-guides
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+url: /docs/{{ .version }}/guides/weaviate/
+aliases:
+  - /docs/{{ .version }}/guides/weaviate/README/
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Overview
+
+KubeDB supports Weaviate through the `Weaviate` CRD.
+
+## Supported Weaviate Features
+
+| Features                  | Availability |
+|---------------------------|:------------:|
+| Standalone provisioning   |   &#10003;   |
+| Cluster provisioning      |   &#10003;   |
+| Ops Requests              |      No      |
+
+## Supported Ops Requests
+
+This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD. The existing ops pages are placeholder documentation only.
+
+## Example Weaviate Manifest
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+## User Guide
+
+- [Quickstart Weaviate](/docs/guides/weaviate/quickstart/quickstart.md) with KubeDB operator.
+- [Weaviate CRD Concept](/docs/guides/weaviate/concepts/weaviate.md).
+- [WeaviateVersion CRD Concept](/docs/guides/weaviate/concepts/catalog.md).
+- [WeaviateOpsRequest CRD Concept](/docs/guides/weaviate/concepts/opsrequest.md).
+- [Private Registry](/docs/guides/weaviate/private-registry/using-private-registry.md)
+- [Custom RBAC](/docs/guides/weaviate/custom-rbac/using-custom-rbac.md)
+- [Custom Configuration](/docs/guides/weaviate/configuration/using-config-file.md)
+- [Ops Request](/docs/guides/weaviate/ops-request/overview.md) for current documentation status.
+- [Reconfigure](/docs/guides/weaviate/reconfigure/overview.md)
+- [Restart](/docs/guides/weaviate/restart/restart.md)
+- [Rotate Auth](/docs/guides/weaviate/rotate-auth/overview.md)
+- [Update Version](/docs/guides/weaviate/update-version/overview.md)
+- [Volume Expansion](/docs/guides/weaviate/volume-expansion/overview.md)
+- [Vertical Scaling](/docs/guides/weaviate/scaling/vertical-scaling/overview.md)

--- a/docs/guides/weaviate/_index.md
+++ b/docs/guides/weaviate/_index.md
@@ -1,0 +1,10 @@
+---
+title: Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-guides
+    name: Weaviate
+    parent: guides
+    weight: 18
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/autoscaler/_index.md
+++ b/docs/guides/weaviate/autoscaler/_index.md
@@ -1,0 +1,10 @@
+---
+title: Weaviate Autoscaler
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler
+    name: Autoscaler
+    parent: weaviate-guides
+    weight: 40
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/autoscaler/compute/_index.md
+++ b/docs/guides/weaviate/autoscaler/compute/_index.md
@@ -1,0 +1,10 @@
+---
+title: Compute
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler-compute
+    name: Compute
+    parent: weaviate-autoscaler
+    weight: 10
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/autoscaler/compute/cluster.md
+++ b/docs/guides/weaviate/autoscaler/compute/cluster.md
@@ -1,0 +1,240 @@
+---
+title: Weaviate Compute Autoscaler Cluster
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler-compute-cluster
+    name: Cluster
+    parent: weaviate-autoscaler-compute
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Autoscaling the Compute Resource of a Weaviate Cluster
+
+This guide will show you how to use `KubeDB` to auto-scale compute resources i.e. CPU and memory of a Weaviate cluster database.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install `KubeDB` Community, Ops-Manager and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
+
+- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
+  - [Compute Resource Autoscaling Overview](/docs/guides/weaviate/autoscaler/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Autoscaling of Cluster Database
+
+Here, we are going to deploy a `Weaviate` cluster using a supported version by `KubeDB` operator. Then we are going to apply `WeaviateAutoscaler` to set up autoscaling.
+
+### Deploy Weaviate Cluster
+
+In this section, we are going to deploy a Weaviate cluster with version `1.26.4`. Then, in the next section we will set up autoscaling for this database using `WeaviateAutoscaler` CRD. Below is the YAML of the `Weaviate` CR that we are going to create:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: "1.26.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+      - name: weaviate
+        resources:
+          requests:
+            cpu: "200m"
+            memory: "512Mi"
+          limits:
+            cpu: "200m"
+            memory: "512Mi"
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Weaviate` CR we have shown above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/autoscaler/compute/weaviate-cluster.yaml
+weaviate.kubedb.com/weaviate-sample created
+```
+
+Now, wait until `weaviate-sample` has status `Ready`:
+
+```bash
+$ kubectl get weaviate -n demo
+NAME              VERSION   STATUS   AGE
+weaviate-sample   1.26.4    Ready    4m
+```
+
+Let's check the Pod container resources:
+
+```bash
+$ kubectl get pod -n demo weaviate-sample-0 -o json | jq '.spec.containers[].resources'
+{
+  "limits": {
+    "cpu": "200m",
+    "memory": "512Mi"
+  },
+  "requests": {
+    "cpu": "200m",
+    "memory": "512Mi"
+  }
+}
+```
+
+We are now ready to apply the `WeaviateAutoscaler` CRD to set up autoscaling for this database.
+
+### Compute Resource Autoscaling
+
+Here, we are going to set up compute resource autoscaling using a `WeaviateAutoscaler` Object.
+
+#### Create WeaviateAutoscaler Object
+
+In order to set up compute resource autoscaling for this database cluster, we have to create a `WeaviateAutoscaler` CR with our desired configuration. Below is the YAML of the `WeaviateAutoscaler` object that we are going to create:
+
+```yaml
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: WeaviateAutoscaler
+metadata:
+  name: weaviate-as-compute
+  namespace: demo
+spec:
+  databaseRef:
+    name: weaviate-sample
+  opsRequestOptions:
+    timeout: 3m
+    apply: IfReady
+  compute:
+    node:
+      trigger: "On"
+      podLifeTimeThreshold: 10m
+      resourceDiffPercentage: 20
+      minAllowed:
+        cpu: 400m
+        memory: 400Mi
+      maxAllowed:
+        cpu: 1
+        memory: 2Gi
+      controlledResources: ["cpu", "memory"]
+      containerControlledValues: "RequestsAndLimits"
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are performing compute autoscaling on `weaviate-sample` database.
+- `spec.compute.node.trigger` specifies that compute resource autoscaling is enabled for the Weaviate nodes.
+- `spec.compute.node.podLifeTimeThreshold` specifies the minimum age of a Pod before the `VerticalPodAutoscaler` can recommend a resource update.
+- `spec.compute.node.resourceDiffPercentage` specifies the minimum percentage change needed before applying a new resource recommendation.
+- `spec.compute.node.minAllowed` specifies the minimum allowed resources for the Weaviate nodes.
+- `spec.compute.node.maxAllowed` specifies the maximum allowed resources for the Weaviate nodes.
+- `spec.compute.node.controlledResources` specifies the resource types that will be auto-scaled.
+- `spec.compute.node.containerControlledValues` specifies which resource values should be controlled, here both requests and limits.
+
+Let's create the `WeaviateAutoscaler` CR we have shown above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/autoscaler/compute/weaviate-as-compute.yaml
+weaviateautoscaler.autoscaling.kubedb.com/weaviate-as-compute created
+```
+
+#### Verify Autoscaler is set up successfully
+
+Let's check that the `WeaviateAutoscaler` resource is created successfully:
+
+```bash
+$ kubectl get weaviateautoscaler -n demo
+NAME                  AGE
+weaviate-as-compute   5s
+
+$ kubectl describe weaviateautoscaler weaviate-as-compute -n demo
+Name:         weaviate-as-compute
+Namespace:    demo
+Labels:       <none>
+Annotations:  <none>
+API Version:  autoscaling.kubedb.com/v1alpha1
+Kind:         WeaviateAutoscaler
+Spec:
+  Compute:
+    Node:
+      Container Controlled Values:  RequestsAndLimits
+      Controlled Resources:
+        cpu
+        memory
+      Max Allowed:
+        Cpu:     1
+        Memory:  2Gi
+      Min Allowed:
+        Cpu:     400m
+        Memory:  400Mi
+      Pod Life Time Threshold:      10m0s
+      Resource Diff Percentage:     20
+      Trigger:                      On
+  Database Ref:
+    Name:  weaviate-sample
+  Ops Request Options:
+    Apply:    IfReady
+    Timeout:  3m0s
+Events:       <none>
+```
+
+So, the `WeaviateAutoscaler` resource is created successfully. The operator will now watch the resource usage of the Weaviate pods and create `WeaviateOpsRequest` resources to scale the cluster when needed.
+
+After some time, you can observe that the autoscaler has created a `WeaviateOpsRequest` with type `VerticalScaling`:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo
+NAME                               TYPE              STATUS       AGE
+wvops-weaviate-sample-xxxxxxxx     VerticalScaling   Successful   5m
+```
+
+You can then verify the updated resources on the pods:
+
+```bash
+$ kubectl get pod -n demo weaviate-sample-0 -o json | jq '.spec.containers[].resources'
+{
+  "limits": {
+    "cpu": "400m",
+    "memory": "512Mi"
+  },
+  "requests": {
+    "cpu": "400m",
+    "memory": "512Mi"
+  }
+}
+```
+
+The above output verifies that we have successfully autoscaled the resources of the Weaviate cluster database.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete weaviateautoscaler -n demo weaviate-as-compute
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/autoscaler/compute/cluster.md
+++ b/docs/guides/weaviate/autoscaler/compute/cluster.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `Weaviate` cluster using a supported version by `
 
 ### Deploy Weaviate Cluster
 
-In this section, we are going to deploy a Weaviate cluster with version `1.26.4`. Then, in the next section we will set up autoscaling for this database using `WeaviateAutoscaler` CRD. Below is the YAML of the `Weaviate` CR that we are going to create:
+In this section, we are going to deploy a Weaviate cluster with version `1.33.1`. Then, in the next section we will set up autoscaling for this database using `WeaviateAutoscaler` CRD. Below is the YAML of the `Weaviate` CR that we are going to create:
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -51,7 +51,7 @@ metadata:
   name: weaviate-sample
   namespace: demo
 spec:
-  version: "1.26.4"
+  version: "1.33.1"
   replicas: 3
   storageType: Durable
   storage:
@@ -87,7 +87,7 @@ Now, wait until `weaviate-sample` has status `Ready`:
 ```bash
 $ kubectl get weaviate -n demo
 NAME              VERSION   STATUS   AGE
-weaviate-sample   1.26.4    Ready    4m
+weaviate-sample   1.33.1    Ready    4m
 ```
 
 Let's check the Pod container resources:

--- a/docs/guides/weaviate/autoscaler/overview.md
+++ b/docs/guides/weaviate/autoscaler/overview.md
@@ -1,0 +1,49 @@
+---
+title: Weaviate Autoscaler Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler-overview
+    name: Overview
+    parent: weaviate-autoscaler
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate Autoscaling Overview
+
+This guide will give an overview of how KubeDB autoscales `Weaviate` database resources - both compute (CPU and memory) and storage.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateAutoscaler](/docs/guides/weaviate/concepts/autoscaler.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
+
+## How Autoscaling Works
+
+KubeDB uses the `WeaviateAutoscaler` CR to configure automatic scaling of Weaviate resources. There are two types of autoscaling supported:
+
+### Compute Autoscaling
+
+KubeDB leverages the [Kubernetes Vertical Pod Autoscaler (VPA)](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) to recommend compute resource adjustments. The process works as follows:
+
+1. The user creates a `WeaviateAutoscaler` CR with `spec.compute` configured.
+2. KubeDB creates a VPA resource for the `Weaviate` StatefulSet.
+3. The VPA monitors resource usage and provides recommendations.
+4. When the recommendation differs from the current resources by more than `resourceDiffPercentage`, KubeDB creates a `WeaviateOpsRequest` with `type: VerticalScaling` to apply the recommended resources.
+5. After the OpsRequest completes, the pods are running with the updated resource requests and limits.
+
+### Storage Autoscaling
+
+KubeDB monitors PVC usage to automatically expand storage. The process works as follows:
+
+1. The user creates a `WeaviateAutoscaler` CR with `spec.storage` configured.
+2. KubeDB monitors the PVC storage usage of the Weaviate pods.
+3. When the disk usage exceeds the `usageThreshold` percentage, KubeDB creates a `WeaviateOpsRequest` with `type: VolumeExpansion` to expand the storage by `scalingThreshold` percent.
+4. After the OpsRequest completes, the PVCs are expanded to the new size.
+
+In the next docs, we are going to show step-by-step guides on compute and storage autoscaling for Weaviate databases.

--- a/docs/guides/weaviate/autoscaler/storage/_index.md
+++ b/docs/guides/weaviate/autoscaler/storage/_index.md
@@ -1,0 +1,10 @@
+---
+title: Storage
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler-storage
+    name: Storage
+    parent: weaviate-autoscaler
+    weight: 20
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/autoscaler/storage/cluster.md
+++ b/docs/guides/weaviate/autoscaler/storage/cluster.md
@@ -1,0 +1,229 @@
+---
+title: Weaviate Storage Autoscaler Cluster
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler-storage-cluster
+    name: Cluster
+    parent: weaviate-autoscaler-storage
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Storage Autoscaling of a Weaviate Cluster
+
+This guide will show you how to use `KubeDB` to autoscale the storage of a Weaviate cluster database.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install `KubeDB` Community, Enterprise and Autoscaler operator in your cluster following the steps [here](/docs/setup/README.md).
+
+- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation).
+
+- Install Prometheus from [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack).
+
+- You must have a `StorageClass` that supports volume expansion.
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
+  - [Storage Autoscaling Overview](/docs/guides/weaviate/autoscaler/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Storage Autoscaling of Cluster Database
+
+At first, verify that your cluster has a storage class that supports volume expansion:
+
+```bash
+$ kubectl get storageclass
+NAME                  PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+standard (default)    rancher.io/local-path   Delete          WaitForFirstConsumer   false                  79m
+topolvm-provisioner   topolvm.cybozu.com      Delete          WaitForFirstConsumer   true                   78m
+```
+
+We can see from the output that `topolvm-provisioner` storage class has `ALLOWVOLUMEEXPANSION` set to `true`. We will use it for this tutorial. You can install topolvm from [here](https://github.com/topolvm/topolvm).
+
+Now, we are going to deploy a `Weaviate` cluster using a supported version by `KubeDB` operator. Then we are going to apply `WeaviateAutoscaler` to set up autoscaling.
+
+### Deploy Weaviate Cluster
+
+In this section, we are going to deploy a Weaviate cluster database with version `1.26.4`. Then, in the next section we will set up autoscaling for this database using `WeaviateAutoscaler` CRD. Below is the YAML of the `Weaviate` CR that we are going to create:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: "1.26.4"
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: "topolvm-provisioner"
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Weaviate` CR we have shown above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/autoscaler/storage/weaviate-cluster.yaml
+weaviate.kubedb.com/weaviate-sample created
+```
+
+Now, wait until `weaviate-sample` has status `Ready`:
+
+```bash
+$ kubectl get weaviate -n demo
+NAME              VERSION   STATUS   AGE
+weaviate-sample   1.26.4    Ready    3m46s
+```
+
+Let's check the volume size from the StatefulSet and from the persistent volumes:
+
+```bash
+$ kubectl get sts -n demo weaviate-sample -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+"1Gi"
+
+$ kubectl get pv -n demo
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                               STORAGECLASS          REASON   AGE
+pvc-43266d76-f280-4cca-bd78-d13660a84db9   1Gi        RWO            Delete           Bound    demo/data-weaviate-sample-2         topolvm-provisioner            57s
+pvc-4a509b05-774b-42d9-b36d-599c9056af37   1Gi        RWO            Delete           Bound    demo/data-weaviate-sample-0         topolvm-provisioner            58s
+pvc-c27eee12-cd86-4410-b39e-b1dd735fc14d   1Gi        RWO            Delete           Bound    demo/data-weaviate-sample-1         topolvm-provisioner            57s
+```
+
+You can see the StatefulSet has 1GB storage and the capacity of all the persistent volumes is also 1GB.
+
+We are now ready to apply the `WeaviateAutoscaler` CRD to set up storage autoscaling for this database.
+
+### Storage Autoscaling
+
+Here, we are going to set up storage autoscaling using a `WeaviateAutoscaler` Object.
+
+#### Create WeaviateAutoscaler Object
+
+In order to set up storage autoscaling for this cluster database, we have to create a `WeaviateAutoscaler` CR with our desired configuration. Below is the YAML of the `WeaviateAutoscaler` object that we are going to create:
+
+```yaml
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: WeaviateAutoscaler
+metadata:
+  name: weaviate-as-storage
+  namespace: demo
+spec:
+  databaseRef:
+    name: weaviate-sample
+  storage:
+    node:
+      trigger: "On"
+      usageThreshold: 20
+      scalingThreshold: 20
+      expansionMode: "Online"
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are performing storage autoscaling on `weaviate-sample` database.
+- `spec.storage.node.trigger` specifies that storage autoscaling is enabled for the Weaviate nodes.
+- `spec.storage.node.usageThreshold` specifies the storage usage threshold - if storage usage exceeds `20%`, storage autoscaling will be triggered.
+- `spec.storage.node.scalingThreshold` specifies the scaling threshold - storage will be scaled to `20%` of the current amount.
+- `spec.storage.node.expansionMode` specifies the expansion mode of the volume expansion `WeaviateOpsRequest` created by `WeaviateAutoscaler`. topolvm-provisioner supports online volume expansion so `expansionMode` is set to `Online`.
+
+Let's create the `WeaviateAutoscaler` CR we have shown above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/autoscaler/storage/weaviate-as-storage.yaml
+weaviateautoscaler.autoscaling.kubedb.com/weaviate-as-storage created
+```
+
+#### Verify Autoscaler is set up successfully
+
+Let's check that the `WeaviateAutoscaler` resource is created successfully:
+
+```bash
+$ kubectl get weaviateautoscaler -n demo
+NAME                  AGE
+weaviate-as-storage   33s
+
+$ kubectl describe weaviateautoscaler weaviate-as-storage -n demo
+Name:         weaviate-as-storage
+Namespace:    demo
+Labels:       <none>
+Annotations:  <none>
+API Version:  autoscaling.kubedb.com/v1alpha1
+Kind:         WeaviateAutoscaler
+Spec:
+  Database Ref:
+    Name:  weaviate-sample
+  Storage:
+    Node:
+      Expansion Mode:   Online
+      Scaling Threshold:  20
+      Trigger:            On
+      Usage Threshold:    20
+Events:                   <none>
+```
+
+So, the `WeaviateAutoscaler` resource is created successfully. The operator will now continuously watch the storage usage of the Weaviate pods. When the usage crosses the `usageThreshold`, it will create a `WeaviateOpsRequest` to expand the storage.
+
+Now, for this demo, we are going to manually fill up the persistent volume to exceed the `usageThreshold` using the `dd` command to see if storage autoscaling is working:
+
+```bash
+$ kubectl exec -it -n demo weaviate-sample-0 -- bash
+root@weaviate-sample-0:/var/lib/weaviate# df -h /var/lib/weaviate
+Filesystem                                         Size  Used Avail Use% Mounted on
+/dev/topolvm/57cd4330-784f-42c1-bf8e-e743241df164 1014M   32M  983M   4% /var/lib/weaviate
+root@weaviate-sample-0:/var/lib/weaviate# dd if=/dev/zero of=/var/lib/weaviate/file.img bs=800M count=1
+1+0 records in
+1+0 records out
+838860800 bytes (839 MB, 800 MiB) copied, 6.47 s, 130 MB/s
+root@weaviate-sample-0:/var/lib/weaviate# df -h /var/lib/weaviate
+Filesystem                                         Size  Used Avail Use% Mounted on
+/dev/topolvm/57cd4330-784f-42c1-bf8e-e743241df164 1014M  832M  183M  82% /var/lib/weaviate
+```
+
+Now let's watch the `WeaviateOpsRequest` in the demo namespace:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo -w
+NAME                                     TYPE              STATUS        AGE
+wvops-weaviate-sample-xxxxxxxx           VolumeExpansion   Progressing   10s
+wvops-weaviate-sample-xxxxxxxx           VolumeExpansion   Successful    2m
+```
+
+After the `WeaviateOpsRequest` completes successfully, let's check the updated storage:
+
+```bash
+$ kubectl get pv -n demo
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                               STORAGECLASS          REASON   AGE
+pvc-43266d76-f280-4cca-bd78-d13660a84db9   1217Mi     RWO            Delete           Bound    demo/data-weaviate-sample-2         topolvm-provisioner            15m
+pvc-4a509b05-774b-42d9-b36d-599c9056af37   1217Mi     RWO            Delete           Bound    demo/data-weaviate-sample-0         topolvm-provisioner            15m
+pvc-c27eee12-cd86-4410-b39e-b1dd735fc14d   1217Mi     RWO            Delete           Bound    demo/data-weaviate-sample-1         topolvm-provisioner            15m
+```
+
+The storage has been automatically scaled from 1Gi to ~1.2Gi (120% of 1Gi) as we specified a `scalingThreshold` of 20%.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete weaviateautoscaler -n demo weaviate-as-storage
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/autoscaler/storage/cluster.md
+++ b/docs/guides/weaviate/autoscaler/storage/cluster.md
@@ -57,7 +57,7 @@ Now, we are going to deploy a `Weaviate` cluster using a supported version by `K
 
 ### Deploy Weaviate Cluster
 
-In this section, we are going to deploy a Weaviate cluster database with version `1.26.4`. Then, in the next section we will set up autoscaling for this database using `WeaviateAutoscaler` CRD. Below is the YAML of the `Weaviate` CR that we are going to create:
+In this section, we are going to deploy a Weaviate cluster database with version `1.33.1`. Then, in the next section we will set up autoscaling for this database using `WeaviateAutoscaler` CRD. Below is the YAML of the `Weaviate` CR that we are going to create:
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -66,7 +66,7 @@ metadata:
   name: weaviate-sample
   namespace: demo
 spec:
-  version: "1.26.4"
+  version: "1.33.1"
   replicas: 3
   storageType: Durable
   storage:
@@ -91,7 +91,7 @@ Now, wait until `weaviate-sample` has status `Ready`:
 ```bash
 $ kubectl get weaviate -n demo
 NAME              VERSION   STATUS   AGE
-weaviate-sample   1.26.4    Ready    3m46s
+weaviate-sample   1.33.1    Ready    3m46s
 ```
 
 Let's check the volume size from the StatefulSet and from the persistent volumes:

--- a/docs/guides/weaviate/backup/_index.md
+++ b/docs/guides/weaviate/backup/_index.md
@@ -1,0 +1,10 @@
+---
+title: Weaviate Backup
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-backup
+    name: Backup
+    parent: weaviate-guides
+    weight: 30
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/backup/overview.md
+++ b/docs/guides/weaviate/backup/overview.md
@@ -1,0 +1,58 @@
+---
+title: Weaviate Backup Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-backup-overview
+    name: Overview
+    parent: weaviate-backup
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate Backup Overview
+
+This guide will give an overview of how KubeDB supports backup and restore for `Weaviate` databases using [KubeStash](https://kubestash.com).
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+- You should be familiar with the following `KubeStash` concepts:
+  - [BackupStorage](https://kubestash.com/docs/latest/concepts/crds/backupstorage/)
+  - [BackupConfiguration](https://kubestash.com/docs/latest/concepts/crds/backupconfiguration/)
+  - [BackupSession](https://kubestash.com/docs/latest/concepts/crds/backupsession/)
+  - [RestoreSession](https://kubestash.com/docs/latest/concepts/crds/restoresession/)
+  - [RetentionPolicy](https://kubestash.com/docs/latest/concepts/crds/retentionpolicy/)
+
+## How Backup Works
+
+KubeStash uses a sidecar-based approach to backup Weaviate databases. The backup process consists of the following steps:
+
+1. At first, a user creates a `BackupStorage` CR that defines the backend storage location (e.g., S3, GCS, Azure Blob).
+
+2. Then, the user creates a `RetentionPolicy` CR that defines how long backup snapshots will be retained.
+
+3. Then, the user creates a `BackupConfiguration` CR that references the target `Weaviate` database, the `BackupStorage`, and the `RetentionPolicy`. A backup schedule (cron expression) can be defined.
+
+4. When a `BackupConfiguration` CR is created, KubeStash creates a `CronJob` to trigger backup sessions at the scheduled time.
+
+5. On each scheduled time, a `BackupSession` CR is created. KubeStash executes the backup in a temporary job that connects to the Weaviate database and writes a snapshot to the backend storage.
+
+6. The backup snapshot is stored in the backend storage and a `Snapshot` CR is created to track the backup metadata.
+
+## How Restore Works
+
+The restore process consists of the following steps:
+
+1. At first, the user creates a target `Weaviate` database (or uses an existing one).
+
+2. Then, the user creates a `RestoreSession` CR referencing the `Snapshot` to restore and the target `Weaviate` database.
+
+3. KubeStash executes the restore in a temporary job that reads the snapshot from the backend storage and restores the data to the target Weaviate database.
+
+4. After the restore completes, the `RestoreSession` status transitions to `Succeeded`.
+
+In the next docs, we are going to show step-by-step guides on backup and restore of Weaviate databases using KubeStash.

--- a/docs/guides/weaviate/concepts/_index.md
+++ b/docs/guides/weaviate/concepts/_index.md
@@ -1,0 +1,10 @@
+---
+title: Weaviate Concepts
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-concepts
+    name: Concepts
+    parent: weaviate-guides
+    weight: 15
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/concepts/autoscaler.md
+++ b/docs/guides/weaviate/concepts/autoscaler.md
@@ -1,0 +1,114 @@
+---
+title: WeaviateAutoscaler CRD
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler-concepts
+    name: WeaviateAutoscaler
+    parent: weaviate-concepts-weaviate
+    weight: 30
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# WeaviateAutoscaler
+
+## What is WeaviateAutoscaler
+
+`WeaviateAutoscaler` is a Kubernetes `Custom Resource Definitions` (CRD). It provides a declarative configuration for automatic scaling of [Weaviate](https://weaviate.tech/) compute resources (CPU, memory) and storage in a Kubernetes native way.
+
+## WeaviateAutoscaler CRD Specifications
+
+Like any official Kubernetes resource, a `WeaviateAutoscaler` has `TypeMeta`, `ObjectMeta`, `Spec` and `Status` sections.
+
+**Sample `WeaviateAutoscaler` for compute autoscaling:**
+
+```yaml
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: WeaviateAutoscaler
+metadata:
+  name: weaviate-as-compute
+  namespace: demo
+spec:
+  databaseRef:
+    name: weaviate-sample
+  opsRequestOptions:
+    timeout: 3m
+    apply: IfReady
+  compute:
+    node:
+      trigger: "On"
+      podLifeTimeThreshold: 10m
+      resourceDiffPercentage: 20
+      minAllowed:
+        cpu: 400m
+        memory: 400Mi
+      maxAllowed:
+        cpu: 1
+        memory: 2Gi
+      controlledResources: ["cpu", "memory"]
+      containerControlledValues: "RequestsAndLimits"
+```
+
+**Sample `WeaviateAutoscaler` for storage autoscaling:**
+
+```yaml
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: WeaviateAutoscaler
+metadata:
+  name: weaviate-as-storage
+  namespace: demo
+spec:
+  databaseRef:
+    name: weaviate-sample
+  storage:
+    node:
+      trigger: "On"
+      usageThreshold: 20
+      scalingThreshold: 20
+      expansionMode: "Online"
+```
+
+### WeaviateAutoscaler `Spec`
+
+A `WeaviateAutoscaler` object has the following fields in the `spec` section:
+
+#### spec.databaseRef
+
+`spec.databaseRef` is a required field that points to the [Weaviate](/docs/guides/weaviate/concepts/weaviate.md) object for which autoscaling will be performed. It contains:
+
+- `spec.databaseRef.name` - the name of the target Weaviate database (required).
+
+#### spec.compute
+
+`spec.compute` specifies the compute (CPU and memory) autoscaling configuration. It contains a `node` sub-section with the following fields:
+
+- `spec.compute.node.trigger` - enables (`On`) or disables (`Off`) compute autoscaling.
+- `spec.compute.node.podLifeTimeThreshold` - the minimum age of a pod before VPA can recommend resource updates.
+- `spec.compute.node.resourceDiffPercentage` - the minimum percentage difference required before applying a recommendation.
+- `spec.compute.node.minAllowed` - the minimum allowed CPU and memory resources.
+- `spec.compute.node.maxAllowed` - the maximum allowed CPU and memory resources.
+- `spec.compute.node.controlledResources` - the list of resources to be controlled (e.g., `["cpu", "memory"]`).
+- `spec.compute.node.containerControlledValues` - specifies whether to control `RequestsAndLimits` or `RequestsOnly`.
+
+#### spec.storage
+
+`spec.storage` specifies the storage autoscaling configuration. It contains a `node` sub-section with the following fields:
+
+- `spec.storage.node.trigger` - enables (`On`) or disables (`Off`) storage autoscaling.
+- `spec.storage.node.usageThreshold` - the storage usage threshold (percentage) that triggers autoscaling.
+- `spec.storage.node.scalingThreshold` - the percentage by which storage will be scaled when triggered.
+- `spec.storage.node.expansionMode` - the volume expansion mode (`Online` or `Offline`).
+
+#### spec.opsRequestOptions
+
+`spec.opsRequestOptions` specifies the options for the `WeaviateOpsRequest` created by the autoscaler. It contains:
+
+- `spec.opsRequestOptions.timeout` - the timeout for the generated ops request.
+- `spec.opsRequestOptions.apply` - when to apply the ops request. Can be `Always` or `IfReady`.
+
+## Next Steps
+
+- Read the [Weaviate autoscaler overview](/docs/guides/weaviate/autoscaler/overview.md).
+- See the [compute autoscaler guide](/docs/guides/weaviate/autoscaler/compute/cluster.md) and [storage autoscaler guide](/docs/guides/weaviate/autoscaler/storage/cluster.md).

--- a/docs/guides/weaviate/concepts/catalog.md
+++ b/docs/guides/weaviate/concepts/catalog.md
@@ -16,11 +16,15 @@ section_menu_id: guides
 
 ## What is WeaviateVersion
 
-`WeaviateVersion` is the catalog CRD that defines image and release metadata for KubeDB-managed Weaviate clusters.
+`WeaviateVersion` is a Kubernetes `Custom Resource Definitions` (CRD). It provides a declarative configuration to specify the Docker images to be used for [Weaviate](https://weaviate.io/) vector databases deployed with KubeDB in a Kubernetes native way.
 
-The value in `Weaviate.spec.version` is resolved against `WeaviateVersion` objects.
+When you install KubeDB, a `WeaviateVersion` custom resource will be created automatically for every supported Weaviate version. You have to specify the name of the `WeaviateVersion` CRD in `spec.version` field of the [Weaviate](/docs/guides/weaviate/concepts/weaviate.md) CRD. Then, KubeDB will use the Docker images specified in the `WeaviateVersion` CRD to create your expected database.
+
+Using a separate CRD for specifying respective Docker images allows us to modify images independent of the KubeDB operator. This also allows users to use a custom image for the database.
 
 ## WeaviateVersion Specification
+
+As with all other Kubernetes objects, a `WeaviateVersion` needs `apiVersion`, `kind`, and `metadata` fields. It also needs a `.spec` section.
 
 ```yaml
 apiVersion: catalog.kubedb.com/v1alpha1
@@ -34,14 +38,36 @@ spec:
   deprecated: false
 ```
 
-## Key fields
+### metadata.name
 
-- `metadata.name` is used from `Weaviate.spec.version`.
-- `spec.version` identifies the Weaviate release.
-- `spec.db.image` is the runtime image for Weaviate pods.
-- `spec.deprecated` indicates deprecation status.
+`metadata.name` is a required field that specifies the name of the `WeaviateVersion` CRD. You have to specify this name in `spec.version` field of the [Weaviate](/docs/guides/weaviate/concepts/weaviate.md) CRD.
+
+The naming convention for `WeaviateVersion` CRD follows the pattern `{Original Weaviate version}`.
+
+### spec.version
+
+`spec.version` is a required field that specifies the original version of the Weaviate database that has been used to build the Docker image specified in `spec.db.image` field.
+
+### spec.deprecated
+
+`spec.deprecated` is an optional field that specifies whether the Docker images specified here are supported by the current KubeDB operator.
+
+The default value of this field is `false`. If `spec.deprecated` is set to `true`, KubeDB operator will not create the database and other respective resources for this version.
+
+### spec.db.image
+
+`spec.db.image` is a required field that specifies the Docker image which will be used to create the StatefulSet by KubeDB operator to create the expected Weaviate database.
+
+```bash
+$ kubectl get weaviateversions
+NAME      VERSION   DB_IMAGE                        DEPRECATED   AGE
+1.25.0    1.25.0    kubedb/weaviate:1.25.0                       3d
+1.28.0    1.28.0    kubedb/weaviate:1.28.0                       3d
+1.30.0    1.30.0    kubedb/weaviate:1.30.0                       3d
+1.33.1    1.33.1    kubedb/weaviate:1.33.1                       3d
+```
 
 ## Next Steps
 
-- Read the [Weaviate CRD concept](/docs/guides/weaviate/concepts/weaviate.md).
-- Run the [Weaviate quickstart](/docs/guides/weaviate/quickstart/quickstart.md).
+- Learn about the [Weaviate CRD](/docs/guides/weaviate/concepts/weaviate.md).
+- Deploy your first Weaviate database with KubeDB by following the guide [here](/docs/guides/weaviate/quickstart/quickstart.md).

--- a/docs/guides/weaviate/concepts/catalog.md
+++ b/docs/guides/weaviate/concepts/catalog.md
@@ -1,0 +1,47 @@
+---
+title: WeaviateVersion CRD
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-catalog-concepts
+    name: WeaviateVersion
+    parent: weaviate-concepts-weaviate
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# WeaviateVersion
+
+## What is WeaviateVersion
+
+`WeaviateVersion` is the catalog CRD that defines image and release metadata for KubeDB-managed Weaviate clusters.
+
+The value in `Weaviate.spec.version` is resolved against `WeaviateVersion` objects.
+
+## WeaviateVersion Specification
+
+```yaml
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: WeaviateVersion
+metadata:
+  name: "1.33.1"
+spec:
+  version: "1.33.1"
+  db:
+    image: "kubedb/weaviate:1.33.1"
+  deprecated: false
+```
+
+## Key fields
+
+- `metadata.name` is used from `Weaviate.spec.version`.
+- `spec.version` identifies the Weaviate release.
+- `spec.db.image` is the runtime image for Weaviate pods.
+- `spec.deprecated` indicates deprecation status.
+
+## Next Steps
+
+- Read the [Weaviate CRD concept](/docs/guides/weaviate/concepts/weaviate.md).
+- Run the [Weaviate quickstart](/docs/guides/weaviate/quickstart/quickstart.md).

--- a/docs/guides/weaviate/concepts/opsrequest.md
+++ b/docs/guides/weaviate/concepts/opsrequest.md
@@ -15,12 +15,12 @@ section_menu_id: guides
 # WeaviateOpsRequest
 
 ## What is WeaviateOpsRequest
+`WeaviateOpsRequest` is a Kubernetes `CustomResource` that lets you run day-2 operations on a [Weaviate](/docs/guides/weaviate/concepts/weaviate.md) database in a declarative way.
 
-`WeaviateOpsRequest` is documented here as a planned resource, but this repository does not currently contain the matching Go type or CRD.
+Instead of editing many low-level resources manually, you submit a `WeaviateOpsRequest` and KubeDB Ops Manager performs the requested workflow (for example restart, version update, or resource scaling) and reports progress in the request status.
 
 ## Supported operation types
-
-The current docs set includes these placeholder operation categories:
+The following operation types are supported for Weaviate:
 
 - `Reconfigure`
 - `Restart`
@@ -29,16 +29,79 @@ The current docs set includes these placeholder operation categories:
 - `VerticalScaling`
 - `VolumeExpansion`
 
-Verify support against your installed KubeDB release and [new_db.md](/new_db.md).
+Use one operation type per request. If you need multiple changes, apply multiple ops requests sequentially.
 
 ## Sample WeaviateOpsRequest
+Sample request for `UpdateVersion`:
 
-No repository-backed sample can be provided yet because the API itself is not present in this repo.
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-update-version
+  namespace: demo
+spec:
+  type: UpdateVersion
+  databaseRef:
+    name: weaviate-sample
+  updateVersion:
+    targetVersion: 1.34.0
+```
+
+Sample request for `VerticalScaling`:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-vertical-scale
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: weaviate-sample
+  verticalScaling:
+    node:
+      resources:
+        requests:
+          cpu: "500m"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 2Gi
+```
 
 ## Key fields
 
-- There is no CRD-backed schema to reference yet.
-- Existing examples under `docs/examples/weaviate` should be treated as placeholders.
+- `spec.databaseRef.name` points to the target `Weaviate` object.
+- `spec.type` defines the operation category.
+- `spec.timeout` (optional) controls operation timeout.
+- `spec.apply` (optional) controls when the request is executed.
+
+Operation-specific sections:
+
+- `spec.configuration` for `Reconfigure`
+- `spec.updateVersion.targetVersion` for `UpdateVersion`
+- `spec.verticalScaling.node.resources` for `VerticalScaling`
+- `spec.volumeExpansion` for `VolumeExpansion`
+- `spec.authSecret` for user-defined credential rotation in `RotateAuth`
+
+Always verify the exact shape from operation-specific guides because fields vary by operation.
+
+## Status fields
+
+After you apply a request, watch status to track progress:
+
+```bash
+kubectl get weaviateopsrequest -n demo
+kubectl describe weaviateopsrequest -n demo <opsrequest-name>
+```
+
+Important status information:
+
+- `.status.phase` (`Successful`, `Failed`, or `Denied`)
+- `.status.conditions` for step-by-step controller progress
+- `.status.observedGeneration` for reconciliation state
 
 ## Next Steps
 

--- a/docs/guides/weaviate/concepts/opsrequest.md
+++ b/docs/guides/weaviate/concepts/opsrequest.md
@@ -1,0 +1,46 @@
+---
+title: WeaviateOpsRequest CRD
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-opsrequest-concepts
+    name: WeaviateOpsRequest
+    parent: weaviate-concepts-weaviate
+    weight: 25
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# WeaviateOpsRequest
+
+## What is WeaviateOpsRequest
+
+`WeaviateOpsRequest` is documented here as a planned resource, but this repository does not currently contain the matching Go type or CRD.
+
+## Supported operation types
+
+The current docs set includes these placeholder operation categories:
+
+- `Reconfigure`
+- `Restart`
+- `RotateAuth`
+- `UpdateVersion`
+- `VerticalScaling`
+- `VolumeExpansion`
+
+Verify support against your installed KubeDB release and [new_db.md](/new_db.md).
+
+## Sample WeaviateOpsRequest
+
+No repository-backed sample can be provided yet because the API itself is not present in this repo.
+
+## Key fields
+
+- There is no CRD-backed schema to reference yet.
+- Existing examples under `docs/examples/weaviate` should be treated as placeholders.
+
+## Next Steps
+
+- See [Weaviate ops overview](/docs/guides/weaviate/ops-request/overview.md) for operation links.
+- Follow operation tutorials like [Restart](/docs/guides/weaviate/restart/restart.md) and [UpdateVersion](/docs/guides/weaviate/update-version/overview.md).

--- a/docs/guides/weaviate/concepts/weaviate.md
+++ b/docs/guides/weaviate/concepts/weaviate.md
@@ -16,9 +16,13 @@ section_menu_id: guides
 
 ## What is Weaviate
 
-`Weaviate` is a KubeDB CRD for deploying and managing Weaviate vector databases in Kubernetes.
+`Weaviate` is a Kubernetes `Custom Resource Definitions` (CRD). It provides declarative configuration for [Weaviate](https://weaviate.io/) vector databases in a Kubernetes native way. You only need to describe the desired database configuration in a `Weaviate` object, and the KubeDB operator will create Kubernetes objects in the desired state for you.
 
 ## Weaviate Spec
+
+As with all other Kubernetes objects, a `Weaviate` CR needs `apiVersion`, `kind`, and `metadata` fields. It also needs a `.spec` section.
+
+Below is an example `Weaviate` object:
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -27,25 +31,122 @@ metadata:
   name: weaviate-sample
   namespace: demo
 spec:
-  version: 1.33.1
+  version: "1.33.1"
   replicas: 3
+  authSecret:
+    name: weaviate-sample-auth
+  configuration:
+    secretName: weaviate-config
   storageType: Durable
   storage:
-    storageClassName: longhorn
+    storageClassName: standard
     accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
-  deletionPolicy: WipeOut
+  monitor:
+    agent: prometheus.io/operator
+    prometheus:
+      serviceMonitor:
+        labels:
+          app: kubedb
+        interval: 10s
+  podTemplate:
+    metadata:
+      annotations:
+        passMe: ToDatabasePod
+    spec:
+      serviceAccountName: my-custom-sa
+      nodeSelector:
+        disktype: ssd
+      imagePullSecrets:
+      - name: myregistrykey
+      containers:
+      - name: weaviate
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+          limits:
+            memory: "1Gi"
+            cpu: "1"
+  serviceTemplates:
+  - alias: primary
+    spec:
+      type: LoadBalancer
+  deletionPolicy: Halt
 ```
 
-### Key fields
+### spec.version
 
-- `spec.version` points to a `WeaviateVersion`.
-- `spec.replicas` controls number of Weaviate pods.
-- `spec.storageType` and `spec.storage` control data persistence.
-- `spec.authSecret` and `spec.disableSecurity` control authentication options.
-- `spec.configuration` can provide custom config.
-- `spec.podTemplate` and `spec.serviceTemplates` customize runtime resources.
-- `spec.deletionPolicy` controls deletion behavior.
+`spec.version` is a required field that specifies the name of the [WeaviateVersion](/docs/guides/weaviate/concepts/catalog.md) CRD where the docker images are specified. Currently, when you install KubeDB, it creates the following `WeaviateVersion` CRDs:
+
+```bash
+$ kubectl get weaviateversions
+NAME      VERSION   DB_IMAGE                        DEPRECATED   AGE
+1.25.0    1.25.0    kubedb/weaviate:1.25.0                       3d
+1.28.0    1.28.0    kubedb/weaviate:1.28.0                       3d
+1.30.0    1.30.0    kubedb/weaviate:1.30.0                       3d
+1.33.1    1.33.1    kubedb/weaviate:1.33.1                       3d
+```
+
+### spec.replicas
+
+`spec.replicas` is an optional field that specifies the number of Weaviate pods to run. For a single-node deployment, set it to `1`. For a multi-node cluster, set it to the desired number of replicas (e.g., `3`).
+
+### spec.authSecret
+
+`spec.authSecret` is an optional field that points to a Secret used for Weaviate API key authentication. If not provided, KubeDB will create one automatically. The Secret must contain an `api-key` data field that is injected into pods via the `AUTHENTICATION_APIKEY_ALLOWED_KEYS` environment variable.
+
+### spec.configuration.secretName
+
+`spec.configuration.secretName` is an optional field that points to a Secret containing a custom `weaviate.yaml` configuration file for Weaviate. See [Custom Configuration](/docs/guides/weaviate/configuration/using-config-file.md) for details.
+
+### spec.disableSecurity
+
+`spec.disableSecurity` is an optional boolean field that disables API key authentication when set to `true`. When `false` (the default), KubeDB sets `AUTHENTICATION_APIKEY_ENABLED=true` automatically.
+
+### spec.storageType
+
+`spec.storageType` specifies the type of storage that will be used for Weaviate. It can be `Durable` or `Ephemeral`. The default value is `Durable`. If `Ephemeral` is used, KubeDB will create Weaviate using `EmptyDir` volume. This is useful for testing purposes.
+
+### spec.storage
+
+`spec.storage` specifies the StorageClass of PVCs that will be dynamically allocated to store data for Weaviate pods. If `spec.storageType: Ephemeral` is not set, this field is required.
+
+### spec.monitor
+
+`spec.monitor` specifies the monitoring configuration for Weaviate. It contains the following sub-field:
+
+- `spec.monitor.agent` specifies the monitoring agent. Valid values are `prometheus.io/builtin` and `prometheus.io/operator`.
+
+### spec.podTemplate
+
+KubeDB allows providing a template for database pods through `spec.podTemplate`. KubeDB operator will pass the information provided in `spec.podTemplate` to the StatefulSet created for Weaviate database. Notable sub-fields include:
+
+- `spec.podTemplate.spec.serviceAccountName` to provide a custom ServiceAccount.
+- `spec.podTemplate.spec.imagePullSecrets` to pull images from a private registry.
+- `spec.podTemplate.spec.nodeSelector` to schedule pods on specific nodes.
+- `spec.podTemplate.spec.containers[].resources` to configure CPU and memory resources.
+
+### spec.serviceTemplates
+
+`spec.serviceTemplates` is an optional field that contains a list of the service templates for the Weaviate services. KubeDB allows following service template variables:
+
+- `spec.serviceTemplates[].alias`: specifies which service template (e.g., `primary`).
+- `spec.serviceTemplates[].spec.type`: specifies the service type (e.g., `ClusterIP`, `LoadBalancer`, `NodePort`).
+
+### spec.deletionPolicy
+
+`spec.deletionPolicy` gives freedom to the user to control the behavior of KubeDB when a Weaviate object is deleted. Possible values are:
+
+- `DoNotTerminate`: prevents deletion of the object if admission webhook is enabled.
+- `Halt`: deletes the Weaviate object but keeps the underlying resources (PVCs, Secrets) intact.
+- `Delete`: deletes the Weaviate object and its PVCs, but not Secrets.
+- `WipeOut`: deletes the Weaviate object and all related resources including PVCs and Secrets.
+
+## Next Steps
+
+- Learn about [WeaviateVersion CRD](/docs/guides/weaviate/concepts/catalog.md).
+- Deploy your first Weaviate database with KubeDB by following the guide [here](/docs/guides/weaviate/quickstart/quickstart.md).

--- a/docs/guides/weaviate/concepts/weaviate.md
+++ b/docs/guides/weaviate/concepts/weaviate.md
@@ -1,0 +1,51 @@
+---
+title: Weaviate CRD
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-concepts-weaviate
+    name: Weaviate
+    parent: weaviate-concepts
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate
+
+## What is Weaviate
+
+`Weaviate` is a KubeDB CRD for deploying and managing Weaviate vector databases in Kubernetes.
+
+## Weaviate Spec
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+### Key fields
+
+- `spec.version` points to a `WeaviateVersion`.
+- `spec.replicas` controls number of Weaviate pods.
+- `spec.storageType` and `spec.storage` control data persistence.
+- `spec.authSecret` and `spec.disableSecurity` control authentication options.
+- `spec.configuration` can provide custom config.
+- `spec.podTemplate` and `spec.serviceTemplates` customize runtime resources.
+- `spec.deletionPolicy` controls deletion behavior.

--- a/docs/guides/weaviate/configuration/_index.md
+++ b/docs/guides/weaviate/configuration/_index.md
@@ -1,0 +1,10 @@
+---
+title: Run Weaviate with Custom Configuration
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-configuration
+    name: Custom Configuration
+    parent: weaviate-guides
+    weight: 130
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/configuration/using-config-file.md
+++ b/docs/guides/weaviate/configuration/using-config-file.md
@@ -14,21 +14,34 @@ section_menu_id: guides
 
 # Using Custom Configuration File
 
-KubeDB uses `spec.configuration.secretName` to provide custom Weaviate configuration.
+KubeDB supports providing custom configuration for Weaviate. This tutorial will show you how to use KubeDB to run a Weaviate database with custom configuration.
 
 ## Before You Begin
 
-- You need a Kubernetes cluster and the `kubectl` CLI configured for that cluster.
-- Install KubeDB operator from [setup guide](/docs/setup/README.md).
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Now, install KubeDB cli on your workstation and KubeDB operator in your cluster following the steps [here](/docs/setup/README.md).
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
 
 ```bash
 $ kubectl create ns demo
 namespace/demo created
 ```
 
-## Create Configuration Secret
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/configuration](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/configuration) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
 
-Create a custom configuration file and then create a Secret:
+## Overview
+
+Weaviate allows configuring the database via a YAML configuration file named `weaviate.yaml`. KubeDB takes advantage of this feature to allow users to provide their custom configuration. To know more about configuring Weaviate, see [here](https://weaviate.io/developers/weaviate/configuration).
+
+At first, you have to create a config file named `weaviate.yaml` with your desired configuration. Then create a Secret with this configuration file and provide its name in `spec.configuration.secretName`. The operator reads this Secret and mounts it into the Weaviate pods automatically.
+
+In this tutorial, we will configure `query_defaults.limit` and disable anonymous access via a custom config file.
+
+## Custom Configuration
+
+At first, let's create a `weaviate.yaml` file with custom settings:
 
 ```yaml
 authentication:
@@ -36,7 +49,11 @@ authentication:
     enabled: false
 query_defaults:
   limit: 25
+persistence:
+  data_path: /var/lib/weaviate
 ```
+
+Now, create a Secret with this configuration file:
 
 ```bash
 $ kubectl create secret generic -n demo weaviate-config \
@@ -44,7 +61,27 @@ $ kubectl create secret generic -n demo weaviate-config \
 secret/weaviate-config created
 ```
 
-## Deploy Weaviate with Configuration Secret
+Verify the Secret has the configuration file:
+
+```yaml
+$ kubectl get secret -n demo weaviate-config -o yaml
+apiVersion: v1
+data:
+  weaviate.yaml: YXV0aGVudGljYXRpb246CiAgYW5vbnltb3VzX2FjY2Vzczo...
+kind: Secret
+metadata:
+  name: weaviate-config
+  namespace: demo
+```
+
+Now, create the `Weaviate` CR specifying `spec.configuration.secretName` field:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/configuration/weaviate-configuration.yaml
+weaviate.kubedb.com/custom-weaviate created
+```
+
+Below is the YAML for the `Weaviate` CR we just created:
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -53,35 +90,53 @@ metadata:
   name: custom-weaviate
   namespace: demo
 spec:
-  version: 1.33.1
+  version: "1.33.1"
   replicas: 3
   configuration:
     secretName: weaviate-config
-  storageType: Durable
   storage:
-    storageClassName: longhorn
+    storageClassName: "standard"
     accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
   deletionPolicy: WipeOut
 ```
 
+Now, wait a few minutes. KubeDB operator will create the necessary PVC, StatefulSet, services, and secrets. If everything goes well, we will see that a pod with the name `custom-weaviate-0` has been created.
+
+Check that the StatefulSet's pod is running:
+
 ```bash
-$ kubectl apply -f custom-weaviate.yaml
-weaviate.kubedb.com/custom-weaviate created
+$ kubectl get pod -n demo custom-weaviate-0
+NAME                 READY   STATUS    RESTARTS   AGE
+custom-weaviate-0    1/1     Running   0          2m
 ```
 
-## Verify
+Now, wait for the `Weaviate` CR to go into `Ready` state:
 
 ```bash
 $ kubectl get weaviate -n demo custom-weaviate
 NAME              VERSION   STATUS   AGE
-custom-weaviate   1.33.1    Ready    2m
+custom-weaviate   1.33.1    Ready    3m
 ```
 
+We can verify the Weaviate database is running with our custom configuration by querying the meta endpoint:
+
+```bash
+$ kubectl port-forward -n demo pod/custom-weaviate-0 8080:8080 &
+$ export WEAVIATE_API_KEY=$(kubectl get secret -n demo custom-weaviate-auth -o jsonpath='{.data.api-key}' | base64 -d)
+
+$ curl -H "Authorization: Bearer $WEAVIATE_API_KEY" http://localhost:8080/v1/meta | jq '.version'
+"1.33.1"
+```
+
+Anonymous access is now disabled, and the query default limit is set to `25` as configured.
+
 ## Cleaning up
+
+To cleanup the Kubernetes resources created by this tutorial, run:
 
 ```bash
 kubectl delete weaviate -n demo custom-weaviate

--- a/docs/guides/weaviate/configuration/using-config-file.md
+++ b/docs/guides/weaviate/configuration/using-config-file.md
@@ -1,0 +1,90 @@
+---
+title: Run Weaviate with Custom Configuration
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-using-config-file
+    name: Config File
+    parent: weaviate-configuration
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Using Custom Configuration File
+
+KubeDB uses `spec.configuration.secretName` to provide custom Weaviate configuration.
+
+## Before You Begin
+
+- You need a Kubernetes cluster and the `kubectl` CLI configured for that cluster.
+- Install KubeDB operator from [setup guide](/docs/setup/README.md).
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Create Configuration Secret
+
+Create a custom configuration file and then create a Secret:
+
+```yaml
+authentication:
+  anonymous_access:
+    enabled: false
+query_defaults:
+  limit: 25
+```
+
+```bash
+$ kubectl create secret generic -n demo weaviate-config \
+  --from-file=weaviate.yaml=./weaviate.yaml
+secret/weaviate-config created
+```
+
+## Deploy Weaviate with Configuration Secret
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: custom-weaviate
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  configuration:
+    secretName: weaviate-config
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f custom-weaviate.yaml
+weaviate.kubedb.com/custom-weaviate created
+```
+
+## Verify
+
+```bash
+$ kubectl get weaviate -n demo custom-weaviate
+NAME              VERSION   STATUS   AGE
+custom-weaviate   1.33.1    Ready    2m
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviate -n demo custom-weaviate
+kubectl delete secret -n demo weaviate-config
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/custom-rbac/_index.md
+++ b/docs/guides/weaviate/custom-rbac/_index.md
@@ -1,0 +1,10 @@
+---
+title: Run Weaviate with Custom RBAC resources
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-custom-rbac
+    name: Custom RBAC
+    parent: weaviate-guides
+    weight: 90
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/custom-rbac/using-custom-rbac.md
+++ b/docs/guides/weaviate/custom-rbac/using-custom-rbac.md
@@ -1,0 +1,89 @@
+---
+title: Run Weaviate with Custom RBAC resources
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-custom-rbac-quickstart
+    name: Custom RBAC
+    parent: weaviate-custom-rbac
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Using Custom RBAC Resources
+
+This tutorial shows how to run Weaviate with custom `ServiceAccount`, `Role`, and `RoleBinding` resources.
+
+## Before You Begin
+
+- You need a Kubernetes cluster and the `kubectl` CLI configured for that cluster.
+- Install KubeDB operator from [setup guide](/docs/setup/README.md).
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Create Custom RBAC Resources
+
+```bash
+$ kubectl create serviceaccount -n demo my-custom-serviceaccount
+serviceaccount/my-custom-serviceaccount created
+
+$ kubectl create role my-custom-role -n demo --verb=get,list,watch --resource=pods
+role.rbac.authorization.k8s.io/my-custom-role created
+
+$ kubectl create rolebinding my-custom-rolebinding \
+  --role=my-custom-role \
+  --serviceaccount=demo:my-custom-serviceaccount \
+  --namespace=demo
+rolebinding.rbac.authorization.k8s.io/my-custom-rolebinding created
+```
+
+## Deploy Weaviate with Custom Service Account
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-custom-rbac
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  podTemplate:
+    spec:
+      serviceAccountName: my-custom-serviceaccount
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f weaviate-custom-rbac.yaml
+weaviate.kubedb.com/weaviate-custom-rbac created
+```
+
+## Verify
+
+```bash
+$ kubectl get weaviate -n demo weaviate-custom-rbac
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviate -n demo weaviate-custom-rbac
+kubectl delete rolebinding -n demo my-custom-rolebinding
+kubectl delete role -n demo my-custom-role
+kubectl delete serviceaccount -n demo my-custom-serviceaccount
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/custom-rbac/using-custom-rbac.md
+++ b/docs/guides/weaviate/custom-rbac/using-custom-rbac.md
@@ -14,27 +14,121 @@ section_menu_id: guides
 
 # Using Custom RBAC Resources
 
-This tutorial shows how to run Weaviate with custom `ServiceAccount`, `Role`, and `RoleBinding` resources.
+KubeDB supports finer user control over role-based access permissions provided to a Weaviate instance. This tutorial will show you how to use KubeDB to run a Weaviate instance with custom RBAC resources.
 
 ## Before You Begin
 
-- You need a Kubernetes cluster and the `kubectl` CLI configured for that cluster.
-- Install KubeDB operator from [setup guide](/docs/setup/README.md).
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Now, install KubeDB cli on your workstation and KubeDB operator in your cluster following the steps [here](/docs/setup/README.md).
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
 
 ```bash
 $ kubectl create ns demo
 namespace/demo created
 ```
 
-## Create Custom RBAC Resources
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/custom-rbac](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/custom-rbac) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Overview
+
+KubeDB allows users to provide custom RBAC resources, namely `ServiceAccount`, `Role`, and `RoleBinding` for Weaviate. This is provided via the `spec.podTemplate.spec.serviceAccountName` field in the Weaviate CRD. If this field is left empty, the KubeDB operator will create a ServiceAccount matching the Weaviate name. Role and RoleBinding that provide necessary access permissions will also be generated automatically for this ServiceAccount.
+
+If a ServiceAccount name is given but there is no existing ServiceAccount by that name, the KubeDB operator will create one, and Role and RoleBinding will also be generated automatically.
+
+If a ServiceAccount name is given and there is an existing ServiceAccount by that name, the KubeDB operator will use that existing ServiceAccount. Since this ServiceAccount is not managed by KubeDB, users are responsible for providing necessary access permissions manually.
+
+This guide will show you how to create custom `ServiceAccount`, `Role`, and `RoleBinding` for a Weaviate instance named `weaviate-custom-rbac` to provide the bare minimum access permissions.
+
+## Custom RBAC for Weaviate
+
+At first, let's create a `ServiceAccount` in the `demo` namespace:
 
 ```bash
 $ kubectl create serviceaccount -n demo my-custom-serviceaccount
 serviceaccount/my-custom-serviceaccount created
+```
 
-$ kubectl create role my-custom-role -n demo --verb=get,list,watch --resource=pods
+Verify that the ServiceAccount was created:
+
+```yaml
+$ kubectl get serviceaccount -n demo my-custom-serviceaccount -o yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-custom-serviceaccount
+  namespace: demo
+```
+
+Now, create a Role that has the necessary access permissions for the Weaviate database named `weaviate-custom-rbac`:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/custom-rbac/weaviate-custom-role.yaml
 role.rbac.authorization.k8s.io/my-custom-role created
+```
 
+Below is the YAML for the Role we just created:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: my-custom-role
+  namespace: demo
+rules:
+- apiGroups:
+  - apps
+  resourceNames:
+  - weaviate-custom-rbac
+  resources:
+  - statefulsets
+  verbs:
+  - get
+- apiGroups:
+  - kubedb.com
+  resourceNames:
+  - weaviate-custom-rbac
+  resources:
+  - weaviates
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - update
+```
+
+Note that `resourceNames` like `weaviate-custom-rbac` are unique to this particular Weaviate instance. Another database instance `weaviate-custom-rbac-2` would require these `resourceNames` to be updated accordingly.
+
+Now, create a `RoleBinding` to bind this `Role` with the already created ServiceAccount:
+
+```bash
 $ kubectl create rolebinding my-custom-rolebinding \
   --role=my-custom-role \
   --serviceaccount=demo:my-custom-serviceaccount \
@@ -42,7 +136,33 @@ $ kubectl create rolebinding my-custom-rolebinding \
 rolebinding.rbac.authorization.k8s.io/my-custom-rolebinding created
 ```
 
-## Deploy Weaviate with Custom Service Account
+Verify the RoleBinding was created:
+
+```yaml
+$ kubectl get rolebinding -n demo my-custom-rolebinding -o yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: my-custom-rolebinding
+  namespace: demo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: my-custom-role
+subjects:
+- kind: ServiceAccount
+  name: my-custom-serviceaccount
+  namespace: demo
+```
+
+Now, create a `Weaviate` CR specifying `spec.podTemplate.spec.serviceAccountName` field to `my-custom-serviceaccount`:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/custom-rbac/weaviate-custom-db.yaml
+weaviate.kubedb.com/weaviate-custom-rbac created
+```
+
+Below is the YAML for the `Weaviate` CR we just created:
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -51,34 +171,40 @@ metadata:
   name: weaviate-custom-rbac
   namespace: demo
 spec:
-  version: 1.33.1
+  version: "1.33.1"
   replicas: 3
   podTemplate:
     spec:
       serviceAccountName: my-custom-serviceaccount
-  storageType: Durable
   storage:
-    storageClassName: longhorn
+    storageClassName: "standard"
     accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
   deletionPolicy: WipeOut
 ```
 
-```bash
-$ kubectl apply -f weaviate-custom-rbac.yaml
-weaviate.kubedb.com/weaviate-custom-rbac created
-```
-
-## Verify
+Now, wait a few minutes. If everything goes well, we will see that the Weaviate pods are running with the custom ServiceAccount:
 
 ```bash
 $ kubectl get weaviate -n demo weaviate-custom-rbac
+NAME                   VERSION   STATUS   AGE
+weaviate-custom-rbac   1.33.1    Ready    2m
+
+$ kubectl get pod -n demo -l app.kubernetes.io/instance=weaviate-custom-rbac -o=custom-columns=NAME:.metadata.name,SERVICEACCOUNT:.spec.serviceAccountName
+NAME                     SERVICEACCOUNT
+weaviate-custom-rbac-0   my-custom-serviceaccount
+weaviate-custom-rbac-1   my-custom-serviceaccount
+weaviate-custom-rbac-2   my-custom-serviceaccount
 ```
 
+The output confirms that all Weaviate pods are running with our custom `my-custom-serviceaccount` ServiceAccount.
+
 ## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
 kubectl delete weaviate -n demo weaviate-custom-rbac

--- a/docs/guides/weaviate/monitoring/_index.md
+++ b/docs/guides/weaviate/monitoring/_index.md
@@ -1,0 +1,10 @@
+---
+title: Weaviate Monitoring
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-monitoring
+    name: Monitoring
+    parent: weaviate-guides
+    weight: 20
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/monitoring/overview.md
+++ b/docs/guides/weaviate/monitoring/overview.md
@@ -1,0 +1,38 @@
+---
+title: Weaviate Monitoring Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-monitoring-overview
+    name: Overview
+    parent: weaviate-monitoring
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate Monitoring Overview
+
+This guide will give an overview of how KubeDB supports monitoring for `Weaviate` databases.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+
+## How KubeDB Monitoring Works
+
+KubeDB uses Prometheus to monitor `Weaviate` databases. KubeDB operator watches the `Weaviate` CR and sets up monitoring as follows:
+
+1. When a `Weaviate` database is deployed with `spec.monitor` configured, KubeDB creates a dedicated `stats` service (or uses the existing service) with the appropriate annotations for Prometheus scraping.
+
+2. KubeDB supports two monitoring approaches:
+   - **Builtin Prometheus** - uses Prometheus' built-in auto-discovery mechanism (`prometheus.io/scrape` annotations on the stats service).
+   - **Prometheus Operator** - creates a `ServiceMonitor` CR that is picked up by the Prometheus Operator.
+
+3. The Weaviate stats service exposes Prometheus-compatible metrics at the `/metrics` endpoint, including metrics about objects, memory usage, and gRPC/REST request performance.
+
+4. Prometheus scrapes the metrics from the stats service and makes them available for alerting and dashboards.
+
+In the next docs, we are going to show step-by-step guides on monitoring a Weaviate database using Builtin Prometheus and Prometheus Operator.

--- a/docs/guides/weaviate/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/weaviate/monitoring/using-builtin-prometheus.md
@@ -49,7 +49,7 @@ metadata:
   name: builtin-prom-weaviate
   namespace: demo
 spec:
-  version: "1.26.4"
+  version: "1.33.1"
   replicas: 3
   storage:
     storageClassName: "standard"
@@ -79,7 +79,7 @@ Now, wait for the database to go into `Ready` state:
 ```bash
 $ kubectl get weaviate -n demo builtin-prom-weaviate
 NAME                     VERSION   STATUS   AGE
-builtin-prom-weaviate    1.26.4    Ready    1m
+builtin-prom-weaviate    1.33.1    Ready    1m
 ```
 
 KubeDB will create a separate stats service with name `{Weaviate cr name}-stats` for monitoring purpose.

--- a/docs/guides/weaviate/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/weaviate/monitoring/using-builtin-prometheus.md
@@ -1,0 +1,159 @@
+---
+title: Monitor Weaviate using Builtin Prometheus Discovery
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-using-builtin-prometheus-monitoring
+    name: Builtin Prometheus
+    parent: weaviate-monitoring
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Monitoring Weaviate with Builtin Prometheus
+
+This tutorial will show you how to monitor `Weaviate` database using builtin [Prometheus](https://github.com/prometheus/prometheus) scraper.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install `KubeDB` operator in your cluster following the steps [here](/docs/setup/README.md).
+
+- If you are not familiar with how to configure Prometheus to scrape metrics from various Kubernetes resources, please read the tutorial from [here](https://github.com/appscode/third-party-tools/tree/master/monitoring/prometheus/builtin).
+
+- To learn how Prometheus monitoring works with KubeDB in general, please visit [here](/docs/guides/weaviate/monitoring/overview.md).
+
+- To keep Prometheus resources isolated, we are going to use a separate namespace called `monitoring` to deploy respective monitoring resources. We are going to deploy the database in `demo` namespace.
+
+```bash
+$ kubectl create ns monitoring
+namespace/monitoring created
+
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/monitoring](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/monitoring) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Weaviate with Monitoring Enabled
+
+At first, let's deploy a `Weaviate` database with monitoring enabled. Below is the `Weaviate` object that we are going to create:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: builtin-prom-weaviate
+  namespace: demo
+spec:
+  version: "1.26.4"
+  replicas: 3
+  storage:
+    storageClassName: "standard"
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  monitor:
+    agent: prometheus.io/builtin
+  deletionPolicy: WipeOut
+```
+
+Here,
+
+- `spec.monitor.agent: prometheus.io/builtin` specifies that we are going to monitor this server using builtin Prometheus scraper.
+
+Let's create the `Weaviate` CR we have shown above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/monitoring/builtin-prom-weaviate.yaml
+weaviate.kubedb.com/builtin-prom-weaviate created
+```
+
+Now, wait for the database to go into `Ready` state:
+
+```bash
+$ kubectl get weaviate -n demo builtin-prom-weaviate
+NAME                     VERSION   STATUS   AGE
+builtin-prom-weaviate    1.26.4    Ready    1m
+```
+
+KubeDB will create a separate stats service with name `{Weaviate cr name}-stats` for monitoring purpose.
+
+```bash
+$ kubectl get svc -n demo --selector="app.kubernetes.io/instance=builtin-prom-weaviate"
+NAME                            TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)     AGE
+builtin-prom-weaviate           ClusterIP   10.102.7.190    <none>        8080/TCP    87s
+builtin-prom-weaviate-stats     ClusterIP   10.102.128.153  <none>        8080/TCP    56s
+```
+
+Here, `builtin-prom-weaviate-stats` service has been created for monitoring purpose. Let's describe the service:
+
+```bash
+$ kubectl describe svc -n demo builtin-prom-weaviate-stats
+Name:              builtin-prom-weaviate-stats
+Namespace:         demo
+Labels:            app.kubernetes.io/component=database
+                   app.kubernetes.io/instance=builtin-prom-weaviate
+                   app.kubernetes.io/managed-by=kubedb.com
+                   app.kubernetes.io/name=weaviates.kubedb.com
+Annotations:       monitoring.appscode.com/agent: prometheus.io/builtin
+                   prometheus.io/path: /metrics
+                   prometheus.io/port: 8080
+                   prometheus.io/scrape: true
+Selector:          app.kubernetes.io/instance=builtin-prom-weaviate,app.kubernetes.io/name=weaviates.kubedb.com
+Type:              ClusterIP
+Port:              metrics  8080/TCP
+TargetPort:        metrics/TCP
+Endpoints:         10.244.1.5:8080,10.244.1.6:8080,10.244.1.7:8080
+```
+
+You can see that the service contains the following annotations:
+
+```
+prometheus.io/scrape: true
+prometheus.io/path: /metrics
+prometheus.io/port: 8080
+```
+
+The Prometheus server will discover this service endpoint using these annotations and will scrape metrics from all endpoints.
+
+## Configure Prometheus to Scrape
+
+To get the monitoring of this `Weaviate` database, you need to configure a Prometheus server. Below is the necessary configuration:
+
+```yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+- job_name: 'kubedb-databases'
+  kubernetes_sd_configs:
+  - role: endpoints
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+    regex: true
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    regex: (.+)
+    target_label: __metrics_path__
+    action: replace
+```
+
+## Verify Monitoring
+
+Once Prometheus is configured and running, you can check the monitoring is working by navigating to the Prometheus dashboard (by default at `localhost:9090`). You should see the `builtin-prom-weaviate-stats` endpoint in the list of scrape targets.
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete weaviate -n demo builtin-prom-weaviate
+kubectl delete ns demo
+kubectl delete ns monitoring
+```

--- a/docs/guides/weaviate/monitoring/using-prometheus-operator.md
+++ b/docs/guides/weaviate/monitoring/using-prometheus-operator.md
@@ -85,7 +85,7 @@ metadata:
   name: coreos-prom-weaviate
   namespace: demo
 spec:
-  version: "1.26.4"
+  version: "1.33.1"
   replicas: 3
   storage:
     storageClassName: "standard"
@@ -122,7 +122,7 @@ Now, wait for the database to go into `Ready` state:
 ```bash
 $ kubectl get weaviate -n demo coreos-prom-weaviate
 NAME                    VERSION   STATUS   AGE
-coreos-prom-weaviate    1.26.4    Ready    1m
+coreos-prom-weaviate    1.33.1    Ready    1m
 ```
 
 KubeDB will create a `ServiceMonitor` object for this `Weaviate` database:

--- a/docs/guides/weaviate/monitoring/using-prometheus-operator.md
+++ b/docs/guides/weaviate/monitoring/using-prometheus-operator.md
@@ -1,0 +1,180 @@
+---
+title: Monitor Weaviate using Prometheus Operator
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-using-prometheus-operator-monitoring
+    name: Prometheus Operator
+    parent: weaviate-monitoring
+    weight: 30
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Monitoring Weaviate Using Prometheus Operator
+
+[Prometheus operator](https://github.com/prometheus-operator/prometheus-operator) provides a simple and Kubernetes-native way to deploy and configure Prometheus server. This tutorial will show you how to use Prometheus operator to monitor `Weaviate` database deployed with KubeDB.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- To learn how Prometheus monitoring works with KubeDB in general, please visit [here](/docs/guides/weaviate/monitoring/overview.md).
+
+- To keep Prometheus resources isolated, we are going to use a separate namespace called `monitoring` to deploy respective monitoring resources. We are going to deploy the database in `demo` namespace.
+
+```bash
+$ kubectl create ns monitoring
+namespace/monitoring created
+
+$ kubectl create ns demo
+namespace/demo created
+```
+
+- We need a [Prometheus operator](https://github.com/prometheus-operator/prometheus-operator) instance running. If you don't already have a running instance, deploy one following the docs from [here](https://github.com/appscode/third-party-tools/blob/master/monitoring/prometheus/operator/README.md).
+
+- If you don't already have a Prometheus server running, deploy one following the tutorial from [here](https://github.com/appscode/third-party-tools/blob/master/monitoring/prometheus/operator/README.md#deploy-prometheus-server).
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/monitoring](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/monitoring) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Find out required labels for ServiceMonitor
+
+We need to know the labels used to select `ServiceMonitor` by a `Prometheus` CR. We are going to provide these labels in `spec.monitor.prometheus.serviceMonitor.labels` field of the `Weaviate` CR so that KubeDB creates `ServiceMonitor` object accordingly.
+
+At first, let's find out the available Prometheus server in our cluster:
+
+```bash
+$ kubectl get prometheus --all-namespaces
+NAMESPACE    NAME         AGE
+monitoring   prometheus   18m
+```
+
+Now, let's view the YAML of the available Prometheus server `prometheus` in `monitoring` namespace:
+
+```yaml
+$ kubectl get prometheus -n monitoring prometheus -o yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  labels:
+    prometheus: prometheus
+  name: prometheus
+  namespace: monitoring
+spec:
+  replicas: 1
+  resources:
+    requests:
+      memory: 400Mi
+  serviceAccountName: prometheus
+  serviceMonitorSelector:
+    matchLabels:
+      release: prometheus
+```
+
+Notice the `spec.serviceMonitorSelector` section. Here, `release: prometheus` label is used to select `ServiceMonitor` CR. So, we are going to use this label in `spec.monitor.prometheus.serviceMonitor.labels` field of the `Weaviate` CR.
+
+## Deploy Weaviate with Monitoring Enabled
+
+At first, let's deploy a `Weaviate` database with monitoring enabled. Below is the `Weaviate` object that we are going to create:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: coreos-prom-weaviate
+  namespace: demo
+spec:
+  version: "1.26.4"
+  replicas: 3
+  storage:
+    storageClassName: "standard"
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  monitor:
+    agent: prometheus.io/operator
+    prometheus:
+      serviceMonitor:
+        labels:
+          release: prometheus
+        interval: 10s
+  deletionPolicy: WipeOut
+```
+
+Here,
+
+- `spec.monitor.agent: prometheus.io/operator` specifies that we are going to monitor this server using Prometheus operator.
+- `spec.monitor.prometheus.serviceMonitor.labels` specifies that KubeDB should create `ServiceMonitor` with these labels.
+- `spec.monitor.prometheus.serviceMonitor.interval` specifies how frequently Prometheus should scrape this database.
+
+Let's create the `Weaviate` CR we have shown above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/monitoring/coreos-prom-weaviate.yaml
+weaviate.kubedb.com/coreos-prom-weaviate created
+```
+
+Now, wait for the database to go into `Ready` state:
+
+```bash
+$ kubectl get weaviate -n demo coreos-prom-weaviate
+NAME                    VERSION   STATUS   AGE
+coreos-prom-weaviate    1.26.4    Ready    1m
+```
+
+KubeDB will create a `ServiceMonitor` object for this `Weaviate` database:
+
+```bash
+$ kubectl get servicemonitor -n demo
+NAME                       AGE
+coreos-prom-weaviate       65s
+```
+
+Let's verify the `ServiceMonitor` has the labels we specified:
+
+```bash
+$ kubectl get servicemonitor -n demo coreos-prom-weaviate -o yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: coreos-prom-weaviate
+    app.kubernetes.io/managed-by: kubedb.com
+    app.kubernetes.io/name: weaviates.kubedb.com
+    release: prometheus
+  name: coreos-prom-weaviate
+  namespace: demo
+spec:
+  endpoints:
+  - honorLabels: true
+    interval: 10s
+    path: /metrics
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - demo
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: coreos-prom-weaviate
+      app.kubernetes.io/name: weaviates.kubedb.com
+```
+
+Notice that the `ServiceMonitor` has the label `release: prometheus`, which will be picked up by the Prometheus server.
+
+## Verify Monitoring
+
+Once everything is set up, you can visit the Prometheus dashboard. The `coreos-prom-weaviate` service monitor will be discovered and its metrics will be scraped. You should be able to query Weaviate metrics in Prometheus.
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete weaviate -n demo coreos-prom-weaviate
+kubectl delete ns demo
+kubectl delete ns monitoring
+```

--- a/docs/guides/weaviate/ops-request/_index.md
+++ b/docs/guides/weaviate/ops-request/_index.md
@@ -1,0 +1,10 @@
+---
+title: Weaviate Ops Request
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-ops-request
+    name: Ops Request
+    parent: weaviate-guides
+    weight: 20
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/ops-request/overview.md
+++ b/docs/guides/weaviate/ops-request/overview.md
@@ -1,0 +1,39 @@
+---
+title: Weaviate Ops Request Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-ops-request-overview
+    name: Overview
+    parent: weaviate-ops-request
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+# Weaviate Ops Request
+
+This guide lists the Weaviate operation categories currently documented in the guide tree.
+
+## Before You Begin
+
+- Deploy Weaviate first using the [quickstart guide](/docs/guides/weaviate/quickstart/quickstart.md).
+- Review the operation-specific pages for documentation status.
+- This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD.
+
+## Documented Operation Categories
+
+- [Reconfigure](/docs/guides/weaviate/reconfigure/overview.md)
+- [VerticalScaling](/docs/guides/weaviate/scaling/vertical-scaling/overview.md)
+- [VolumeExpansion](/docs/guides/weaviate/volume-expansion/overview.md)
+- [UpdateVersion](/docs/guides/weaviate/update-version/overview.md)
+- [RotateAuth](/docs/guides/weaviate/rotate-auth/overview.md)
+- [Restart](/docs/guides/weaviate/restart/restart.md)
+
+## How Ops Requests Work
+
+There is no CRD-backed `WeaviateOpsRequest` schema in this repository today, so no validated operation manifest can be generated from the current source tree.
+
+## Next Steps
+
+- Choose the specific operation page that matches your intended change.
+- Apply one operation at a time and verify support against your installed release.

--- a/docs/guides/weaviate/ops-request/overview.md
+++ b/docs/guides/weaviate/ops-request/overview.md
@@ -10,52 +10,40 @@ menu_name: docs_{{ .version }}
 section_menu_id: guides
 ---
 
-# Weaviate Ops Request
+> New to KubeDB? Please start [here](/docs/README.md).
 
-This guide provides an overview of day-2 operations for Weaviate databases managed by KubeDB.
+# Weaviate Day-2 Operations
 
-A `WeaviateOpsRequest` allows you to run operational workflows in a declarative way. You submit a request, then monitor status until the operation completes.
+This guide provides an overview of the day-2 operational workflows that KubeDB supports for `Weaviate` databases via the `WeaviateOpsRequest` CRD.
 
 ## Before You Begin
 
-- Deploy Weaviate first using the [quickstart guide](/docs/guides/weaviate/quickstart/quickstart.md).
-- Install KubeDB and Ops Manager following [setup docs](/docs/setup/README.md).
-- Use a dedicated namespace for testing.
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
 
-```bash
-kubectl create ns demo
-```
+## Supported Operations
 
-## Documented Operation Categories
+KubeDB supports the following day-2 operations for Weaviate:
 
-- [Reconfigure](/docs/guides/weaviate/reconfigure/overview.md)
-- [VerticalScaling](/docs/guides/weaviate/scaling/vertical-scaling/overview.md)
-- [VolumeExpansion](/docs/guides/weaviate/volume-expansion/overview.md)
-- [UpdateVersion](/docs/guides/weaviate/update-version/overview.md)
-- [RotateAuth](/docs/guides/weaviate/rotate-auth/overview.md)
-- [Restart](/docs/guides/weaviate/restart/restart.md)
+| Operation | Description |
+|-----------|-------------|
+| [UpdateVersion](/docs/guides/weaviate/update-version/overview.md) | Update the version of a running Weaviate database |
+| [VerticalScaling](/docs/guides/weaviate/scaling/vertical-scaling/overview.md) | Update CPU and memory resources of Weaviate nodes |
+| [VolumeExpansion](/docs/guides/weaviate/volume-expansion/overview.md) | Expand the persistent volume claim size of Weaviate nodes |
+| [Reconfigure](/docs/guides/weaviate/reconfigure/overview.md) | Reconfigure a running Weaviate database with new configuration |
+| [Restart](/docs/guides/weaviate/restart/restart.md) | Restart the Weaviate database pods in a rolling fashion |
+| [RotateAuth](/docs/guides/weaviate/rotate-auth/overview.md) | Rotate the API key credentials of a Weaviate database |
 
 ## How Ops Requests Work
 
-Every operation follows the same high-level flow:
+All day-2 operations for Weaviate are performed through the `WeaviateOpsRequest` CRD. The general workflow is:
 
-1. Deploy or identify a healthy `Weaviate` database.
-2. Apply one `WeaviateOpsRequest` manifest for a single operation type.
-3. Monitor request status and database readiness.
-4. Validate the expected outcome.
+1. The user creates a `WeaviateOpsRequest` CR with the desired operation type and parameters.
+2. `KubeDB-ops-manager` operator watches for `WeaviateOpsRequest` CRs.
+3. When it finds one, it pauses the `Weaviate` object to prevent conflicting operations.
+4. The operator performs the requested operation (e.g., updates images, scales nodes, expands volumes).
+5. After the operation completes successfully, the operator updates the `Weaviate` object and resumes it.
+6. The `WeaviateOpsRequest` status transitions to `Successful`.
 
-Use these commands for monitoring:
-
-```bash
-kubectl get weaviateopsrequest -n demo
-kubectl describe weaviateopsrequest -n demo <opsrequest-name>
-kubectl get weaviate -n demo -w
-kubectl get pods -n demo -l app.kubernetes.io/instance=weaviate-sample
-```
-
-For best results, avoid applying multiple ops requests for the same database at the same time.
-
-## Next Steps
-
-- Choose the specific operation page that matches your intended change.
-- Apply one operation at a time and verify the request reaches `Successful` state.
+> **Note:** Only one `WeaviateOpsRequest` should be active at a time for a given `Weaviate` database. Wait for one operation to complete before starting another.

--- a/docs/guides/weaviate/ops-request/overview.md
+++ b/docs/guides/weaviate/ops-request/overview.md
@@ -12,13 +12,19 @@ section_menu_id: guides
 
 # Weaviate Ops Request
 
-This guide lists the Weaviate operation categories currently documented in the guide tree.
+This guide provides an overview of day-2 operations for Weaviate databases managed by KubeDB.
+
+A `WeaviateOpsRequest` allows you to run operational workflows in a declarative way. You submit a request, then monitor status until the operation completes.
 
 ## Before You Begin
 
 - Deploy Weaviate first using the [quickstart guide](/docs/guides/weaviate/quickstart/quickstart.md).
-- Review the operation-specific pages for documentation status.
-- This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD.
+- Install KubeDB and Ops Manager following [setup docs](/docs/setup/README.md).
+- Use a dedicated namespace for testing.
+
+```bash
+kubectl create ns demo
+```
 
 ## Documented Operation Categories
 
@@ -31,9 +37,25 @@ This guide lists the Weaviate operation categories currently documented in the g
 
 ## How Ops Requests Work
 
-There is no CRD-backed `WeaviateOpsRequest` schema in this repository today, so no validated operation manifest can be generated from the current source tree.
+Every operation follows the same high-level flow:
+
+1. Deploy or identify a healthy `Weaviate` database.
+2. Apply one `WeaviateOpsRequest` manifest for a single operation type.
+3. Monitor request status and database readiness.
+4. Validate the expected outcome.
+
+Use these commands for monitoring:
+
+```bash
+kubectl get weaviateopsrequest -n demo
+kubectl describe weaviateopsrequest -n demo <opsrequest-name>
+kubectl get weaviate -n demo -w
+kubectl get pods -n demo -l app.kubernetes.io/instance=weaviate-sample
+```
+
+For best results, avoid applying multiple ops requests for the same database at the same time.
 
 ## Next Steps
 
 - Choose the specific operation page that matches your intended change.
-- Apply one operation at a time and verify support against your installed release.
+- Apply one operation at a time and verify the request reaches `Successful` state.

--- a/docs/guides/weaviate/private-registry/_index.md
+++ b/docs/guides/weaviate/private-registry/_index.md
@@ -1,0 +1,10 @@
+---
+title: Run Weaviate using Private Registry
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-private-registry
+    name: Private Registry
+    parent: weaviate-guides
+    weight: 120
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/private-registry/using-private-registry.md
+++ b/docs/guides/weaviate/private-registry/using-private-registry.md
@@ -78,7 +78,7 @@ Here is an example of a `WeaviateVersion` CRD. Replace `PRIVATE_REGISTRY` with y
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: WeaviateVersion
 metadata:
-  name: "1.33.1-private"
+  name: "1.33.1"
 spec:
   db:
     image: PRIVATE_REGISTRY/weaviate:1.33.1
@@ -87,12 +87,12 @@ spec:
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/private-registry/weaviateversion.yaml
-weaviateversion.catalog.kubedb.com/1.33.1-private created
+weaviateversion.catalog.kubedb.com/1.33.1 created
 ```
 
 ## Deploy Weaviate from Private Registry
 
-While deploying `Weaviate` from private registry, you have to add `myregistrykey` secret in `spec.podTemplate.spec.imagePullSecrets` and specify `1.33.1-private` in `spec.version` field.
+While deploying `Weaviate` from private registry, you have to add `myregistrykey` secret in `spec.podTemplate.spec.imagePullSecrets` and specify `1.33.1` in `spec.version` field.
 
 Below is the YAML for Weaviate crd we are going to create:
 
@@ -103,7 +103,7 @@ metadata:
   name: pvt-reg-weaviate
   namespace: demo
 spec:
-  version: "1.33.1-private"
+  version: "1.33.1"
   replicas: 3
   storage:
     storageClassName: "standard"
@@ -131,8 +131,8 @@ To check if the images pulled successfully from the registry, wait for the Weavi
 ```bash
 $ kubectl get weaviate -n demo pvt-reg-weaviate -w
 NAME               VERSION          STATUS         AGE
-pvt-reg-weaviate   1.33.1-private   Provisioning   5s
-pvt-reg-weaviate   1.33.1-private   Ready          1m
+pvt-reg-weaviate   1.33.1           Provisioning   5s
+pvt-reg-weaviate   1.33.1           Ready          1m
 ```
 
 ## Cleaning up

--- a/docs/guides/weaviate/private-registry/using-private-registry.md
+++ b/docs/guides/weaviate/private-registry/using-private-registry.md
@@ -1,0 +1,77 @@
+---
+title: Run Weaviate using Private Registry
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-using-private-registry
+    name: Quickstart
+    parent: weaviate-private-registry
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Using Private Docker Registry
+
+This tutorial shows how to run KubeDB managed Weaviate using private Docker images.
+
+## Before You Begin
+
+- You need a Kubernetes cluster and the `kubectl` CLI configured for that cluster.
+- Create an image pull secret for your private registry in the target namespace.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+
+$ kubectl create secret docker-registry -n demo myregistrykey \
+  --docker-server=DOCKER_REGISTRY_SERVER \
+  --docker-username=DOCKER_USER \
+  --docker-email=DOCKER_EMAIL \
+  --docker-password=DOCKER_PASSWORD
+```
+
+## Deploy Weaviate from Private Registry
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: pvt-reg-weaviate
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      imagePullSecrets:
+        - name: myregistrykey
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f pvt-reg-weaviate.yaml
+weaviate.kubedb.com/pvt-reg-weaviate created
+```
+
+## Verify
+
+```bash
+$ kubectl get pod -n demo -l app.kubernetes.io/instance=pvt-reg-weaviate
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviate -n demo pvt-reg-weaviate
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/private-registry/using-private-registry.md
+++ b/docs/guides/weaviate/private-registry/using-private-registry.md
@@ -14,25 +14,87 @@ section_menu_id: guides
 
 # Using Private Docker Registry
 
-This tutorial shows how to run KubeDB managed Weaviate using private Docker images.
+KubeDB supports using private Docker registry. This tutorial will show you how to run KubeDB managed Weaviate database using private Docker images.
 
 ## Before You Begin
 
-- You need a Kubernetes cluster and the `kubectl` CLI configured for that cluster.
-- Create an image pull secret for your private registry in the target namespace.
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
 
 ```bash
 $ kubectl create ns demo
 namespace/demo created
+```
 
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/private-registry](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/private-registry) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Prepare Private Docker Registry
+
+You will need a Docker private [registry](https://docs.docker.com/registry/) or [private repository](https://docs.docker.com/docker-hub/repos/#private-repositories). In this tutorial we will use a private repository on [Docker Hub](https://hub.docker.com/).
+
+You need to push the required images from KubeDB's [Docker hub account](https://hub.docker.com/r/kubedb/) into your private registry. For Weaviate, push `DB_IMAGE` of the following `WeaviateVersion`s, where `deprecated` is not true, to your private registry.
+
+```bash
+$ kubectl get weaviateversions -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,DB_IMAGE:.spec.db.image,DEPRECATED:.spec.deprecated
+NAME      VERSION   DB_IMAGE                        DEPRECATED
+1.25.0    1.25.0    kubedb/weaviate:1.25.0          <none>
+1.28.0    1.28.0    kubedb/weaviate:1.28.0          <none>
+1.30.0    1.30.0    kubedb/weaviate:1.30.0          <none>
+1.33.1    1.33.1    kubedb/weaviate:1.33.1          <none>
+```
+
+Docker hub repository:
+- [kubedb/weaviate](https://hub.docker.com/r/kubedb/weaviate)
+
+## Create ImagePullSecret
+
+`ImagePullSecrets` is a type of Kubernetes Secret whose purpose is to pull private images from a Docker registry. It allows you to specify the URL of the Docker registry, credentials for logging in, and the image name of your private Docker image.
+
+Run the following command, substituting the appropriate uppercase values, to create an image pull secret for your private Docker registry:
+
+```bash
 $ kubectl create secret docker-registry -n demo myregistrykey \
   --docker-server=DOCKER_REGISTRY_SERVER \
   --docker-username=DOCKER_USER \
   --docker-email=DOCKER_EMAIL \
   --docker-password=DOCKER_PASSWORD
+secret/myregistrykey created
+```
+
+If you wish to follow other ways to pull private images see [official docs](https://kubernetes.io/docs/concepts/containers/images/) of Kubernetes.
+
+## Install KubeDB operator
+
+When installing KubeDB operator, set the flags `--docker-registry` and `--image-pull-secret` to the appropriate values. Follow the steps to [install KubeDB operator](/docs/setup/README.md) properly in your cluster so that it points to the `DOCKER_REGISTRY` you wish to pull images from.
+
+## Create WeaviateVersion CRD
+
+KubeDB uses images specified in `WeaviateVersion` CRD for the database. You have to create a `WeaviateVersion` CRD specifying images from your private registry. Then, you have to point this `WeaviateVersion` CRD in `spec.version` field of the `Weaviate` object. For more details about `WeaviateVersion` CRD, please visit [here](/docs/guides/weaviate/concepts/catalog.md).
+
+Here is an example of a `WeaviateVersion` CRD. Replace `PRIVATE_REGISTRY` with your private registry:
+
+```yaml
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: WeaviateVersion
+metadata:
+  name: "1.33.1-private"
+spec:
+  db:
+    image: PRIVATE_REGISTRY/weaviate:1.33.1
+  version: "1.33.1"
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/private-registry/weaviateversion.yaml
+weaviateversion.catalog.kubedb.com/1.33.1-private created
 ```
 
 ## Deploy Weaviate from Private Registry
+
+While deploying `Weaviate` from private registry, you have to add `myregistrykey` secret in `spec.podTemplate.spec.imagePullSecrets` and specify `1.33.1-private` in `spec.version` field.
+
+Below is the YAML for Weaviate crd we are going to create:
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -41,35 +103,41 @@ metadata:
   name: pvt-reg-weaviate
   namespace: demo
 spec:
-  version: 1.33.1
+  version: "1.33.1-private"
   replicas: 3
-  storageType: Durable
   storage:
-    storageClassName: longhorn
+    storageClassName: "standard"
     accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
   podTemplate:
     spec:
       imagePullSecrets:
-        - name: myregistrykey
+      - name: myregistrykey
   deletionPolicy: WipeOut
 ```
 
+Now run the command to create this Weaviate object:
+
 ```bash
-$ kubectl apply -f pvt-reg-weaviate.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/private-registry/pvt-reg-weaviate.yaml
 weaviate.kubedb.com/pvt-reg-weaviate created
 ```
 
-## Verify
+To check if the images pulled successfully from the registry, wait for the Weaviate to go into `Ready` state:
 
 ```bash
-$ kubectl get pod -n demo -l app.kubernetes.io/instance=pvt-reg-weaviate
+$ kubectl get weaviate -n demo pvt-reg-weaviate -w
+NAME               VERSION          STATUS         AGE
+pvt-reg-weaviate   1.33.1-private   Provisioning   5s
+pvt-reg-weaviate   1.33.1-private   Ready          1m
 ```
 
 ## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
 kubectl delete weaviate -n demo pvt-reg-weaviate

--- a/docs/guides/weaviate/quickstart/_index.md
+++ b/docs/guides/weaviate/quickstart/_index.md
@@ -1,0 +1,10 @@
+---
+title: Weaviate Quickstart
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-quickstart
+    name: Quickstart
+    parent: weaviate-guides
+    weight: 15
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/quickstart/quickstart.md
+++ b/docs/guides/weaviate/quickstart/quickstart.md
@@ -14,34 +14,57 @@ section_menu_id: guides
 
 # Running Weaviate
 
-This tutorial shows how to run Weaviate with KubeDB.
-
-> Note: YAML files used in this tutorial are stored in [docs/examples/weaviate/quickstart](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/quickstart).
+This tutorial will show you how to use KubeDB to run a Weaviate vector database.
 
 ## Before You Begin
 
-- Prepare a Kubernetes cluster and `kubectl`.
-- Install KubeDB from [/docs/setup/README.md](/docs/setup/README.md).
-- This tutorial uses `docs/examples/weaviate/quickstart/weaviate.yaml` as the working example manifest.
-- Create namespace:
+At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+Now, install KubeDB cli on your workstation and KubeDB operator in your cluster following the steps [here](/docs/setup/README.md).
+
+To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
 
 ```bash
-kubectl create ns demo
+$ kubectl create ns demo
+namespace/demo created
 ```
 
-## Check Available StorageClass
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/quickstart](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/quickstart) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Find Available StorageClass
+
+We will need to provide `StorageClass` in the Weaviate CR specification. Check available `StorageClass` in your cluster using the following command:
 
 ```bash
-kubectl get storageclass
+$ kubectl get storageclass
+NAME                 PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+standard (default)   rancher.io/local-path   Delete          WaitForFirstConsumer   false                  10d
 ```
 
-## Check Available WeaviateVersion
+Here, we have `standard` StorageClass in our cluster.
+
+## Find Available WeaviateVersion
+
+When you install KubeDB, it creates `WeaviateVersion` CRDs for all supported Weaviate versions. Let's check available `WeaviateVersion`s:
 
 ```bash
-kubectl get weaviateversions
+$ kubectl get weaviateversions
+NAME      VERSION   DB_IMAGE                        DEPRECATED   AGE
+1.25.0    1.25.0    kubedb/weaviate:1.25.0                       3d
+1.28.0    1.28.0    kubedb/weaviate:1.28.0                       3d
+1.30.0    1.30.0    kubedb/weaviate:1.30.0                       3d
+1.33.1    1.33.1    kubedb/weaviate:1.33.1                       3d
 ```
+
+Notice the `DEPRECATED` column. `true` means that WeaviateVersion is deprecated for the current KubeDB version and KubeDB will not work for that version.
+
+In this tutorial, we will use `1.33.1` WeaviateVersion CR to create a Weaviate cluster. To know more about what `WeaviateVersion` CR is and why there may be variation in version names, please visit [here](/docs/guides/weaviate/concepts/catalog.md).
 
 ## Create a Weaviate Database
+
+KubeDB implements a `Weaviate` CRD to define the specification of a Weaviate database.
+
+Below is the `Weaviate` object created in this tutorial:
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -50,34 +73,152 @@ metadata:
   name: weaviate-sample
   namespace: demo
 spec:
-  version: 1.33.1
+  version: "1.33.1"
   replicas: 3
-  storageType: Durable
   storage:
-    storageClassName: longhorn
+    storageClassName: "standard"
     accessModes:
       - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
-  deletionPolicy: WipeOut
+  deletionPolicy: DoNotTerminate
 ```
 
 ```bash
-kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
-kubectl get weaviate -n demo weaviate-sample -w
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate-sample.yaml
+weaviate.kubedb.com/weaviate-sample created
 ```
 
-## Verify Weaviate Database
+Here,
+
+- `spec.version` is the name of the WeaviateVersion CR where Docker images are specified. In this tutorial, a Weaviate `1.33.1` cluster is created.
+- `spec.replicas` specifies the number of Weaviate nodes in the cluster.
+- `spec.storage` specifies the size and StorageClass of the PVC that will be dynamically allocated to store data for each Weaviate pod. This storage spec will be passed to the StatefulSet created by KubeDB operator to run database pods.
+- `spec.deletionPolicy` specifies what KubeDB should do when a user tries to delete the `Weaviate` CR. Deletion policy `DoNotTerminate` prevents deletion of this object if the admission webhook is enabled.
+
+> **Note:** `spec.storage` section is used to create PVC for the database pods. Specify only `requests`, not `limits` — PVC does not resize automatically.
+
+Now, let's watch the progress of creating the `Weaviate` cluster:
 
 ```bash
-kubectl get weaviate -n demo
-kubectl describe weaviate -n demo weaviate-sample
+$ kubectl get weaviate -n demo weaviate-sample -w
+NAME               VERSION   STATUS         AGE
+weaviate-sample    1.33.1    Provisioning   5s
+weaviate-sample    1.33.1    Provisioning   30s
+weaviate-sample    1.33.1    Ready          2m
 ```
 
-When `status.phase` becomes `Ready`, the Weaviate cluster is ready for schema and vector indexing requests.
+## Describe Weaviate
+
+Let's describe the `Weaviate` object to see its current state:
+
+```bash
+$ kubectl describe weaviate -n demo weaviate-sample
+Name:         weaviate-sample
+Namespace:    demo
+Labels:       <none>
+Annotations:  <none>
+API Version:  kubedb.com/v1alpha2
+Kind:         Weaviate
+Metadata:
+  ...
+Spec:
+  Auth Secret:
+    Name:  weaviate-sample-auth
+  Deletion Policy:  DoNotTerminate
+  Replicas:         3
+  Storage:
+    Access Modes:
+      ReadWriteOnce
+    Resources:
+      Requests:
+        Storage:         1Gi
+    Storage Class Name:  standard
+  Storage Type:          Durable
+  Version:               1.33.1
+Status:
+  Conditions:
+    Last Transition Time:  2024-10-01T10:00:00Z
+    Message:               The KubeDB operator has started the provisioning of Weaviate: demo/weaviate-sample
+    Reason:                DatabaseProvisioningStartedSuccessfully
+    Status:                True
+    Type:                  ProvisioningStarted
+    Last Transition Time:  2024-10-01T10:01:30Z
+    Message:               All desired replicas are ready.
+    Reason:                AllReplicasReady
+    Status:                True
+    Type:                  ReplicaReady
+    Last Transition Time:  2024-10-01T10:02:00Z
+    Message:               The Weaviate: demo/weaviate-sample is accepting client requests.
+    Reason:                DatabaseAcceptingConnectionRequest
+    Status:                True
+    Type:                  AcceptingConnection
+    Last Transition Time:  2024-10-01T10:02:00Z
+    Message:               DB is ready because of reason
+    Reason:                ReadinessCheckSucceeded
+    Status:                True
+    Type:                  Ready
+    Last Transition Time:  2024-10-01T10:02:00Z
+    Message:               The Weaviate: demo/weaviate-sample is successfully provisioned.
+    Reason:                DatabaseSuccessfullyProvisioned
+    Status:                True
+    Type:                  Provisioned
+  Phase:  Ready
+```
+
+## Connect to Weaviate
+
+KubeDB creates a Secret containing the API key for the Weaviate cluster. Let's check it:
+
+```bash
+$ kubectl get secret -n demo weaviate-sample-auth -o yaml
+apiVersion: v1
+data:
+  api-key: <base64-encoded-api-key>
+kind: Secret
+metadata:
+  name: weaviate-sample-auth
+  namespace: demo
+type: Opaque
+```
+
+Now, let's connect to the Weaviate cluster using port forwarding. Weaviate exposes a REST API on port `8080` and gRPC on port `50051`:
+
+```bash
+$ kubectl port-forward -n demo svc/weaviate-sample 8080:8080 &
+$ export WEAVIATE_API_KEY=$(kubectl get secret -n demo weaviate-sample-auth -o jsonpath='{.data.api-key}' | base64 -d)
+
+$ curl -H "Authorization: Bearer $WEAVIATE_API_KEY" http://localhost:8080/v1/meta
+{"hostname":"http://[::]:8080","modules":{},"version":"1.33.1"}
+```
+
+You can also check the cluster health:
+
+```bash
+$ curl -H "Authorization: Bearer $WEAVIATE_API_KEY" http://localhost:8080/v1/.well-known/ready
+{}
+```
+
+And list collections (empty at first):
+
+```bash
+$ curl -H "Authorization: Bearer $WEAVIATE_API_KEY" http://localhost:8080/v1/schema
+{"classes":[]}
+```
+
+## Database DeletionPolicy
+
+This tutorial has set `deletionPolicy: DoNotTerminate`. This will prevent you from deleting the database. If you try to delete it, you will get an error. Once you are done experimenting, change the `deletionPolicy` to `WipeOut` before deleting the Weaviate CR:
+
+```bash
+$ kubectl patch -n demo weaviate/weaviate-sample -p '{"spec":{"deletionPolicy":"WipeOut"}}' --type="merge"
+weaviate.kubedb.com/weaviate-sample patched
+```
 
 ## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
 kubectl delete weaviate -n demo weaviate-sample

--- a/docs/guides/weaviate/quickstart/quickstart.md
+++ b/docs/guides/weaviate/quickstart/quickstart.md
@@ -1,0 +1,85 @@
+---
+title: Weaviate Quickstart
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-quickstart-overview
+    name: Overview
+    parent: weaviate-quickstart
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Running Weaviate
+
+This tutorial shows how to run Weaviate with KubeDB.
+
+> Note: YAML files used in this tutorial are stored in [docs/examples/weaviate/quickstart](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/quickstart).
+
+## Before You Begin
+
+- Prepare a Kubernetes cluster and `kubectl`.
+- Install KubeDB from [/docs/setup/README.md](/docs/setup/README.md).
+- This tutorial uses `docs/examples/weaviate/quickstart/weaviate.yaml` as the working example manifest.
+- Create namespace:
+
+```bash
+kubectl create ns demo
+```
+
+## Check Available StorageClass
+
+```bash
+kubectl get storageclass
+```
+
+## Check Available WeaviateVersion
+
+```bash
+kubectl get weaviateversions
+```
+
+## Create a Weaviate Database
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+```bash
+kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
+kubectl get weaviate -n demo weaviate-sample -w
+```
+
+## Verify Weaviate Database
+
+```bash
+kubectl get weaviate -n demo
+kubectl describe weaviate -n demo weaviate-sample
+```
+
+When `status.phase` becomes `Ready`, the Weaviate cluster is ready for schema and vector indexing requests.
+
+## Cleaning up
+
+```bash
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/quickstart/rbac.md
+++ b/docs/guides/weaviate/quickstart/rbac.md
@@ -1,0 +1,70 @@
+---
+title: Weaviate RBAC
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-quickstart-rbac
+    name: RBAC
+    parent: weaviate-quickstart
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Run Weaviate with RBAC Enabled
+
+This tutorial shows how to run Weaviate with the RBAC permissions required by KubeDB.
+
+## Before You Begin
+
+- You need a Kubernetes cluster and the `kubectl` CLI configured for that cluster.
+- Install KubeDB operator from [setup guide](/docs/setup/README.md).
+- This tutorial uses a dedicated namespace named `demo`.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Deploy Weaviate
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-rbac
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f weaviate-rbac.yaml
+weaviate.kubedb.com/weaviate-rbac created
+```
+
+## Verify
+
+```bash
+$ kubectl get weaviate -n demo weaviate-rbac
+NAME            VERSION   STATUS   AGE
+weaviate-rbac   1.33.1    Ready    2m
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviate -n demo weaviate-rbac
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/quickstart/rbac.md
+++ b/docs/guides/weaviate/quickstart/rbac.md
@@ -12,22 +12,39 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-# Run Weaviate with RBAC Enabled
+# RBAC Permissions for Weaviate
 
-This tutorial shows how to run Weaviate with the RBAC permissions required by KubeDB.
+If RBAC is enabled in clusters, some Weaviate-specific RBAC permissions are required. These permissions are required for the KubeDB operator to manage Weaviate pods properly.
+
+Here is the list of additional permissions required by the StatefulSet of Weaviate:
+
+| Kubernetes Resource | Resource Names     | Permission required    |
+|---------------------|--------------------|------------------------|
+| statefulsets        | `{weaviate-name}`  | get                    |
+| pods                |                    | list, patch            |
+| pods/exec           |                    | create                 |
+| weaviates           |                    | get                    |
+| configmaps          | `{weaviate-name}`  | get, update, create    |
+| secrets             |                    | get, list              |
 
 ## Before You Begin
 
-- You need a Kubernetes cluster and the `kubectl` CLI configured for that cluster.
-- Install KubeDB operator from [setup guide](/docs/setup/README.md).
-- This tutorial uses a dedicated namespace named `demo`.
+At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+Now, install KubeDB cli on your workstation and KubeDB operator in your cluster following the steps [here](/docs/setup/README.md).
+
+To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
 
 ```bash
 $ kubectl create ns demo
 namespace/demo created
 ```
 
-## Deploy Weaviate
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/quickstart](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/quickstart) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Create a Weaviate Database
+
+Below is the `Weaviate` object created in this tutorial:
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -36,35 +53,164 @@ metadata:
   name: weaviate-rbac
   namespace: demo
 spec:
-  version: 1.33.1
+  version: "1.33.1"
   replicas: 3
-  storageType: Durable
   storage:
-    storageClassName: longhorn
+    storageClassName: "standard"
     accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
-  deletionPolicy: WipeOut
+  deletionPolicy: Delete
 ```
 
 ```bash
-$ kubectl apply -f weaviate-rbac.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate-rbac.yaml
 weaviate.kubedb.com/weaviate-rbac created
 ```
 
-## Verify
+When this `Weaviate` object is created, KubeDB operator creates a Role, ServiceAccount, and RoleBinding with the matching Weaviate name and uses that ServiceAccount in the corresponding StatefulSet.
 
-```bash
-$ kubectl get weaviate -n demo weaviate-rbac
-NAME            VERSION   STATUS   AGE
-weaviate-rbac   1.33.1    Ready    2m
+Let's see what KubeDB operator has created for additional RBAC permissions.
+
+### Role
+
+KubeDB operator creates a Role object `weaviate-rbac` in the same namespace as the Weaviate object:
+
+```yaml
+$ kubectl get role -n demo weaviate-rbac -o yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: weaviate-rbac
+    app.kubernetes.io/managed-by: kubedb.com
+    app.kubernetes.io/name: weaviates.kubedb.com
+  name: weaviate-rbac
+  namespace: demo
+  ownerReferences:
+  - apiVersion: kubedb.com/v1alpha2
+    blockOwnerDeletion: true
+    controller: true
+    kind: Weaviate
+    name: weaviate-rbac
+rules:
+- apiGroups:
+  - apps
+  resourceNames:
+  - weaviate-rbac
+  resources:
+  - statefulsets
+  verbs:
+  - get
+- apiGroups:
+  - kubedb.com
+  resourceNames:
+  - weaviate-rbac
+  resources:
+  - weaviates
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - update
 ```
+
+### ServiceAccount
+
+KubeDB operator creates a ServiceAccount object `weaviate-rbac` in the same namespace as the Weaviate object:
+
+```yaml
+$ kubectl get serviceaccount -n demo weaviate-rbac -o yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: weaviate-rbac
+    app.kubernetes.io/managed-by: kubedb.com
+    app.kubernetes.io/name: weaviates.kubedb.com
+  name: weaviate-rbac
+  namespace: demo
+  ownerReferences:
+  - apiVersion: kubedb.com/v1alpha2
+    blockOwnerDeletion: true
+    controller: true
+    kind: Weaviate
+    name: weaviate-rbac
+```
+
+This ServiceAccount is used in the StatefulSet created for the Weaviate object.
+
+### RoleBinding
+
+KubeDB operator creates a RoleBinding object `weaviate-rbac` in the same namespace as the Weaviate object:
+
+```yaml
+$ kubectl get rolebinding -n demo weaviate-rbac -o yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: weaviate-rbac
+    app.kubernetes.io/managed-by: kubedb.com
+    app.kubernetes.io/name: weaviates.kubedb.com
+  name: weaviate-rbac
+  namespace: demo
+  ownerReferences:
+  - apiVersion: kubedb.com/v1alpha2
+    blockOwnerDeletion: true
+    controller: true
+    kind: Weaviate
+    name: weaviate-rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: weaviate-rbac
+subjects:
+- kind: ServiceAccount
+  name: weaviate-rbac
+  namespace: demo
+```
+
+This object binds Role `weaviate-rbac` with ServiceAccount `weaviate-rbac`.
 
 ## Cleaning up
 
+To clean up the Kubernetes resources created by this tutorial, run:
+
 ```bash
-kubectl delete weaviate -n demo weaviate-rbac
+kubectl patch -n demo weaviate/weaviate-rbac -p '{"spec":{"deletionPolicy":"WipeOut"}}' --type="merge"
+kubectl delete -n demo weaviate/weaviate-rbac
 kubectl delete ns demo
 ```

--- a/docs/guides/weaviate/reconfigure-tls/_index.md
+++ b/docs/guides/weaviate/reconfigure-tls/_index.md
@@ -1,0 +1,10 @@
+---
+title: Reconfigure TLS
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-reconfigure-tls
+    name: Reconfigure TLS
+    parent: weaviate-guides
+    weight: 33
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/reconfigure-tls/overview.md
+++ b/docs/guides/weaviate/reconfigure-tls/overview.md
@@ -1,0 +1,59 @@
+---
+title: Reconfiguring Weaviate TLS
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-reconfigure-tls-overview
+    name: Overview
+    parent: weaviate-reconfigure-tls
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Reconfiguring TLS for Weaviate
+
+This guide will give an overview of how KubeDB Ops-manager reconfigures TLS for a `Weaviate` database.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
+- Use the example files from `docs/examples/weaviate/quickstart/distributed.yaml` and `docs/examples/weaviate/reconfigure-tls/ops-request.yaml`.
+
+```bash
+kubectl create ns demo
+```
+
+## Deploy Weaviate
+
+```bash
+kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/distributed.yaml
+kubectl get weaviate -n demo weaviate-sample -w
+```
+
+## How Reconfigure TLS Works
+
+The Reconfigure TLS process consists of the following steps:
+
+1. At first, a user creates a `Weaviate` CR.
+
+2. `KubeDB-Provisioner` operator watches the `Weaviate` CR.
+
+3. When the operator finds a `Weaviate` CR, it creates a `StatefulSet` and related necessary stuff like secrets, services, etc.
+
+4. Then, in order to reconfigure TLS of the `Weaviate` database, the user creates a `WeaviateOpsRequest` CR specifying the desired TLS configuration. The user can add TLS to an existing non-TLS database, rotate the existing certificates, or remove TLS entirely.
+
+5. `KubeDB` Ops-manager operator watches the `WeaviateOpsRequest` CR.
+
+6. When it finds a `WeaviateOpsRequest` CR, it pauses the `Weaviate` object so that the `KubeDB-Provisioner` operator doesn't perform any operations on the `Weaviate` during the TLS reconfiguration process.
+
+7. Then the `KubeDB` Ops-manager operator updates the TLS secrets and restarts the pods in a rolling fashion with the new TLS configuration.
+
+8. After the successful TLS reconfiguration, the `KubeDB` Ops-manager updates the `Weaviate` object to reflect the updated TLS state.
+
+9. After the successful Reconfigure TLS, the `KubeDB` Ops-manager resumes the `Weaviate` object so that the `KubeDB-Provisioner` resumes its usual operations.
+
+In the next doc, we are going to show a step-by-step guide on reconfiguring TLS for a Weaviate database using `WeaviateOpsRequest` CRD.

--- a/docs/guides/weaviate/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/weaviate/reconfigure-tls/reconfigure-tls.md
@@ -53,7 +53,7 @@ metadata:
   name: weaviate-sample
   namespace: demo
 spec:
-  version: "1.26.4"
+  version: "1.33.1"
   replicas: 3
   storage:
     accessModes:
@@ -76,7 +76,7 @@ Now, wait until `weaviate-sample` has status `Ready`:
 ```bash
 $ kubectl get weaviate -n demo
 NAME              VERSION   STATUS   AGE
-weaviate-sample   1.26.4    Ready    3m22s
+weaviate-sample   1.33.1    Ready    3m22s
 ```
 
 ### Create Issuer

--- a/docs/guides/weaviate/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/weaviate/reconfigure-tls/reconfigure-tls.md
@@ -1,0 +1,252 @@
+---
+title: Reconfigure TLS of Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-reconfigure-tls-cluster
+    name: Cluster
+    parent: weaviate-reconfigure-tls
+    weight: 30
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Reconfigure Weaviate TLS/SSL (Transport Encryption)
+
+KubeDB supports reconfiguring TLS/SSL certificates for Weaviate - adding, removing, updating, and rotating certificates via a `WeaviateOpsRequest`. This tutorial will show you how to use KubeDB to reconfigure TLS/SSL encryption.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install `cert-manager` v1.0.0 or later to your cluster to manage your SSL/TLS certificates from [here](https://cert-manager.io/docs/installation/).
+
+- Now, install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
+  - [TLS/SSL Overview](/docs/guides/weaviate/tls/overview.md)
+
+To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/guides/weaviate/reconfigure-tls/yamls](/docs/guides/weaviate/reconfigure-tls/yamls) directory of [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+## Add TLS to a Weaviate database
+
+Here, we are going to create a Weaviate database without TLS and then reconfigure the database to use TLS.
+
+### Deploy Weaviate without TLS
+
+In this section, we are going to deploy a Weaviate cluster without TLS. Below is the YAML of the `Weaviate` CR that we are going to create:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: "1.26.4"
+  replicas: 3
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Weaviate` CR we have shown above:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/weaviate/reconfigure-tls/yamls/weaviate.yaml
+weaviate.kubedb.com/weaviate-sample created
+```
+
+Now, wait until `weaviate-sample` has status `Ready`:
+
+```bash
+$ kubectl get weaviate -n demo
+NAME              VERSION   STATUS   AGE
+weaviate-sample   1.26.4    Ready    3m22s
+```
+
+### Create Issuer
+
+Now, we are going to create an example `Issuer` that will be used to enable SSL/TLS in Weaviate. Alternatively you can follow this [cert-manager tutorial](https://cert-manager.io/docs/configuration/ca/) to create your own `Issuer`. By following the below steps, we are going to create our desired issuer,
+
+1. Start off by generating our ca-certificates using openssl,
+
+```bash
+$ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ./ca.key -out ./ca.crt -subj "/CN=weaviate/O=kubedb"
+Generating a RSA private key
+................+++++
+........................+++++
+writing new private key to './ca.key'
+```
+
+2. Create a secret using the certificate files we have just generated,
+
+```bash
+$ kubectl create secret tls weaviate-ca --cert=ca.crt  --key=ca.key --namespace=demo
+secret/weaviate-ca created
+```
+
+3. Now we are going to create an `Issuer` using the `weaviate-ca` secret that contains the CA certificate we have just created:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: weaviate-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: weaviate-ca
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/weaviate/reconfigure-tls/yamls/issuer.yaml
+issuer.cert-manager.io/weaviate-issuer created
+```
+
+### Add TLS
+
+Now, we are going to create a `WeaviateOpsRequest` to add TLS to the running database.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-add-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: weaviate-sample
+  tls:
+    issuerRef:
+      name: weaviate-issuer
+      kind: Issuer
+      apiGroup: "cert-manager.io"
+    certificates:
+    - alias: server
+      subject:
+        organizations:
+        - kubedb:server
+      dnsNames:
+      - localhost
+      ipAddresses:
+      - "127.0.0.1"
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are performing reconfigure TLS operation on `weaviate-sample` database.
+- `spec.type` specifies that we are performing `ReconfigureTLS` on our database.
+- `spec.tls.issuerRef` specifies the issuer to use for signing certificates.
+- `spec.tls.certificates` specifies the certificate configuration.
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/weaviate/reconfigure-tls/yamls/add-tls.yaml
+weaviateopsrequest.ops.kubedb.com/wvops-add-tls created
+```
+
+Let's wait for `WeaviateOpsRequest` to be `Successful`:
+
+```bash
+$ watch -n 3 kubectl get WeaviateOpsRequest -n demo wvops-add-tls
+Every 3.0s: kubectl get WeaviateOpsRequest -n demo wvops-add-tls
+
+NAME             TYPE             STATUS       AGE
+wvops-add-tls    ReconfigureTLS   Successful   6m30s
+```
+
+## Rotate Certificates
+
+Now we are going to rotate the certificates of the database.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-rotate-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: weaviate-sample
+  tls:
+    rotateCertificates: true
+```
+
+Here,
+
+- `spec.tls.rotateCertificates` specifies that we are requesting to rotate the certificates of the `weaviate-sample` database.
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/weaviate/reconfigure-tls/yamls/rotate-tls.yaml
+weaviateopsrequest.ops.kubedb.com/wvops-rotate-tls created
+```
+
+Let's wait for `WeaviateOpsRequest` to be `Successful`:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo wvops-rotate-tls
+NAME               TYPE             STATUS       AGE
+wvops-rotate-tls   ReconfigureTLS   Successful   3m8s
+```
+
+## Remove TLS from the Database
+
+In this section, we are going to reconfigure TLS setting of the database by removing the TLS configuration.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-remove-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: weaviate-sample
+  tls:
+    remove: true
+```
+
+Here,
+
+- `spec.tls.remove` specifies that we are removing the TLS configuration from `weaviate-sample` database.
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/weaviate/reconfigure-tls/yamls/remove-tls.yaml
+weaviateopsrequest.ops.kubedb.com/wvops-remove-tls created
+```
+
+Let's wait for `WeaviateOpsRequest` to be `Successful`:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo wvops-remove-tls
+NAME               TYPE             STATUS       AGE
+wvops-remove-tls   ReconfigureTLS   Successful   4m20s
+```
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete weaviateopsrequest -n demo wvops-add-tls wvops-rotate-tls wvops-remove-tls
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete issuer -n demo weaviate-issuer
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/reconfigure/_index.md
+++ b/docs/guides/weaviate/reconfigure/_index.md
@@ -1,0 +1,10 @@
+---
+title: Reconfigure
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-reconfigure
+    name: Reconfigure
+    parent: weaviate-guides
+    weight: 22
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/reconfigure/overview.md
+++ b/docs/guides/weaviate/reconfigure/overview.md
@@ -1,0 +1,51 @@
+---
+title: Reconfiguring Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-reconfigure-overview
+    name: Overview
+    parent: weaviate-reconfigure
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Reconfiguring Weaviate
+
+This guide tracks the reconfiguration workflow documentation for Weaviate.
+
+This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD, so the example manifests referenced by older placeholder docs are not CRD-backed.
+
+## Before You Begin
+
+- Install KubeDB and Ops-manager from [here](/docs/setup/README.md).
+- Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/reconfigure/ops-request.yaml`.
+
+```bash
+kubectl create ns demo
+```
+
+## Deploy Weaviate
+
+```bash
+kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
+kubectl get weaviate -n demo weaviate-sample -w
+```
+
+See the detailed note in [Reconfigure Weaviate](/docs/guides/weaviate/reconfigure/reconfigure.md).
+
+## Verify
+
+```bash
+kubectl describe weaviateopsrequest -n demo weaviate-reconfigure
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviateopsrequest -n demo weaviate-reconfigure
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/reconfigure/overview.md
+++ b/docs/guides/weaviate/reconfigure/overview.md
@@ -14,39 +14,34 @@ section_menu_id: guides
 
 # Reconfiguring Weaviate
 
-Use `WeaviateOpsRequest` with type `Reconfigure` to change runtime configuration for a running Weaviate database.
+This guide will give an overview of how KubeDB Ops-manager reconfigures a `Weaviate` database.
 
 ## Before You Begin
 
-- Install KubeDB and Ops Manager from [here](/docs/setup/README.md).
-- Review [Weaviate](/docs/guides/weaviate/concepts/weaviate.md) and [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md) concepts.
-- Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/reconfigure/ops-request.yaml`.
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
 
-```bash
-kubectl create ns demo
-```
+## How Reconfiguration Works
 
-## Deploy Weaviate
+The Reconfiguration process consists of the following steps:
 
-```bash
-kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
-kubectl get weaviate -n demo weaviate-sample -w
-```
+1. At first, a user creates a `Weaviate` CR.
 
-When the database is `Ready`, continue with the detailed reconfiguration workflow in [Reconfigure Weaviate](/docs/guides/weaviate/reconfigure/reconfigure.md).
+2. `KubeDB-Provisioner` operator watches the `Weaviate` CR.
 
-## Verify
+3. When the operator finds a `Weaviate` CR, it creates a `StatefulSet` and related necessary stuff like secrets, services, etc.
 
-```bash
-kubectl get weaviateopsrequest -n demo weaviate-reconfigure
-kubectl describe weaviateopsrequest -n demo weaviate-reconfigure
-kubectl get weaviate -n demo weaviate-sample -o yaml
-```
+4. Then, in order to reconfigure the `Weaviate` database, the user creates a `WeaviateOpsRequest` CR with the new configuration. The user can provide the new configuration either via a new config secret, via `applyConfig`, or by removing the custom configuration (reverting to defaults).
 
-## Cleaning up
+5. `KubeDB` Ops-manager operator watches the `WeaviateOpsRequest` CR.
 
-```bash
-kubectl delete weaviateopsrequest -n demo weaviate-reconfigure
-kubectl delete weaviate -n demo weaviate-sample
-kubectl delete ns demo
-```
+6. When it finds a `WeaviateOpsRequest` CR, it pauses the `Weaviate` object so that the `KubeDB-Provisioner` operator doesn't perform any operations on the `Weaviate` during the reconfiguration process.
+
+7. Then the `KubeDB` Ops-manager operator updates the configuration secret and restarts the pods in a rolling fashion to apply the new configuration.
+
+8. After the successful configuration update, the `KubeDB` Ops-manager updates the `Weaviate` object to reflect the updated configuration state.
+
+9. After the successful reconfiguration, the `KubeDB` Ops-manager resumes the `Weaviate` object so that the `KubeDB-Provisioner` resumes its usual operations.
+
+In the next doc, we are going to show a step-by-step guide on reconfiguring a Weaviate database using `WeaviateOpsRequest` CRD.

--- a/docs/guides/weaviate/reconfigure/overview.md
+++ b/docs/guides/weaviate/reconfigure/overview.md
@@ -14,13 +14,12 @@ section_menu_id: guides
 
 # Reconfiguring Weaviate
 
-This guide tracks the reconfiguration workflow documentation for Weaviate.
-
-This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD, so the example manifests referenced by older placeholder docs are not CRD-backed.
+Use `WeaviateOpsRequest` with type `Reconfigure` to change runtime configuration for a running Weaviate database.
 
 ## Before You Begin
 
-- Install KubeDB and Ops-manager from [here](/docs/setup/README.md).
+- Install KubeDB and Ops Manager from [here](/docs/setup/README.md).
+- Review [Weaviate](/docs/guides/weaviate/concepts/weaviate.md) and [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md) concepts.
 - Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/reconfigure/ops-request.yaml`.
 
 ```bash
@@ -34,12 +33,14 @@ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}
 kubectl get weaviate -n demo weaviate-sample -w
 ```
 
-See the detailed note in [Reconfigure Weaviate](/docs/guides/weaviate/reconfigure/reconfigure.md).
+When the database is `Ready`, continue with the detailed reconfiguration workflow in [Reconfigure Weaviate](/docs/guides/weaviate/reconfigure/reconfigure.md).
 
 ## Verify
 
 ```bash
+kubectl get weaviateopsrequest -n demo weaviate-reconfigure
 kubectl describe weaviateopsrequest -n demo weaviate-reconfigure
+kubectl get weaviate -n demo weaviate-sample -o yaml
 ```
 
 ## Cleaning up

--- a/docs/guides/weaviate/reconfigure/reconfigure.md
+++ b/docs/guides/weaviate/reconfigure/reconfigure.md
@@ -14,22 +14,92 @@ section_menu_id: guides
 
 # Reconfigure Weaviate
 
-This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD.
+This guide shows how to use `WeaviateOpsRequest` with `type: Reconfigure` to update Weaviate runtime configuration.
 
-Because of that, there is no repository-backed manifest for a Weaviate reconfiguration request yet. The example files under `docs/examples/weaviate` are placeholders and should not be treated as CRD-validated manifests until the API is added.
+## Before You Begin
 
-## What You Can Safely Do Today
+- You need a Kubernetes cluster with `kubectl` configured.
+- Install KubeDB and Ops Manager from [setup docs](/docs/setup/README.md).
+- Review [Weaviate](/docs/guides/weaviate/concepts/weaviate.md) and [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md).
 
-- Use `spec.configuration.secretName` in `Weaviate` CRD for configuration changes.
-- Apply those changes through a normal `Weaviate` spec update workflow.
-
-## How to Confirm API Availability in Your Cluster
-
-Run the following commands to check whether your installed release has introduced the missing API:
+To keep things isolated, use a namespace named `demo`:
 
 ```bash
-kubectl get crd | grep -i weaviate
-kubectl get crd | grep -i opsrequest
+$ kubectl create ns demo
+namespace/demo created
 ```
 
-If your cluster includes `weaviateopsrequests.ops.kubedb.com`, follow your release-specific docs. Otherwise, keep using direct `Weaviate` spec updates.
+## Deploy Weaviate
+
+Apply the sample manifest:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
+weaviate.kubedb.com/weaviate-sample created
+```
+
+Wait for readiness:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample -w
+NAME              VERSION   STATUS   AGE
+weaviate-sample   1.33.1    Ready    2m
+```
+
+## Apply Reconfigure OpsRequest
+
+Use the following request:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-reconfigure
+  namespace: demo
+spec:
+  type: Reconfigure
+  databaseRef:
+    name: weaviate-sample
+  configuration:
+    applyConfig:
+      weaviate.yaml: |
+        LOG_LEVEL: info
+```
+
+Apply from the example file:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/reconfigure/ops-request.yaml
+weaviateopsrequest.ops.kubedb.com/weaviate-reconfigure created
+```
+
+## Verify Reconfiguration
+
+Watch request status:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo weaviate-reconfigure
+NAME                  TYPE          STATUS       AGE
+weaviate-reconfigure  Reconfigure   Successful   2m
+```
+
+Inspect reconciliation details:
+
+```bash
+$ kubectl describe weaviateopsrequest -n demo weaviate-reconfigure
+```
+
+Confirm database is healthy after config rollout:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=weaviate-sample
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviateopsrequest -n demo weaviate-reconfigure
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/reconfigure/reconfigure.md
+++ b/docs/guides/weaviate/reconfigure/reconfigure.md
@@ -1,0 +1,35 @@
+---
+title: Reconfigure Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-reconfigure-cluster
+    name: Cluster
+    parent: weaviate-reconfigure
+    weight: 30
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Reconfigure Weaviate
+
+This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD.
+
+Because of that, there is no repository-backed manifest for a Weaviate reconfiguration request yet. The example files under `docs/examples/weaviate` are placeholders and should not be treated as CRD-validated manifests until the API is added.
+
+## What You Can Safely Do Today
+
+- Use `spec.configuration.secretName` in `Weaviate` CRD for configuration changes.
+- Apply those changes through a normal `Weaviate` spec update workflow.
+
+## How to Confirm API Availability in Your Cluster
+
+Run the following commands to check whether your installed release has introduced the missing API:
+
+```bash
+kubectl get crd | grep -i weaviate
+kubectl get crd | grep -i opsrequest
+```
+
+If your cluster includes `weaviateopsrequests.ops.kubedb.com`, follow your release-specific docs. Otherwise, keep using direct `Weaviate` spec updates.

--- a/docs/guides/weaviate/restart/_index.md
+++ b/docs/guides/weaviate/restart/_index.md
@@ -1,0 +1,10 @@
+---
+title: Restart Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-restart
+    name: Restart
+    parent: weaviate-guides
+    weight: 21
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/restart/restart.md
+++ b/docs/guides/weaviate/restart/restart.md
@@ -1,0 +1,52 @@
+---
+title: Restart Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-restart-overview
+    name: Restart Weaviate
+    parent: weaviate-restart
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Restart Weaviate
+
+This guide tracks restart documentation for Weaviate.
+
+This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD, so there is no validated restart manifest to publish yet.
+
+## Before You Begin
+
+- Install KubeDB and Ops-manager.
+- Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/restart/ops-request.yaml`.
+- Create namespace:
+
+```bash
+kubectl create ns demo
+```
+
+## Deploy Weaviate
+
+```bash
+kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
+kubectl get weaviate -n demo weaviate-sample -w
+```
+
+No CRD-backed restart manifest can be generated from this repository today.
+
+## Verify
+
+```bash
+kubectl describe weaviateopsrequest -n demo weaviate-restart
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviateopsrequest -n demo weaviate-restart
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/restart/restart.md
+++ b/docs/guides/weaviate/restart/restart.md
@@ -14,33 +14,59 @@ section_menu_id: guides
 
 # Restart Weaviate
 
-This guide tracks restart documentation for Weaviate.
-
-This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD, so there is no validated restart manifest to publish yet.
+KubeDB supports restarting Weaviate through a `WeaviateOpsRequest` with `type: Restart`.
 
 ## Before You Begin
 
-- Install KubeDB and Ops-manager.
-- Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/restart/ops-request.yaml`.
-- Create namespace:
+- You need a Kubernetes cluster and configured `kubectl`.
+- Install KubeDB and Ops Manager following [setup docs](/docs/setup/README.md).
+- Review [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md).
+- Use `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/restart/ops-request.yaml`.
 
 ```bash
-kubectl create ns demo
+$ kubectl create ns demo
+namespace/demo created
 ```
 
 ## Deploy Weaviate
 
 ```bash
-kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
-kubectl get weaviate -n demo weaviate-sample -w
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
+weaviate.kubedb.com/weaviate-sample created
+
+$ kubectl get weaviate -n demo weaviate-sample -w
+NAME              VERSION   STATUS   AGE
+weaviate-sample   1.33.1    Ready    2m
 ```
 
-No CRD-backed restart manifest can be generated from this repository today.
+## Apply Restart OpsRequest
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-restart
+  namespace: demo
+spec:
+  type: Restart
+  databaseRef:
+    name: weaviate-sample
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/restart/ops-request.yaml
+weaviateopsrequest.ops.kubedb.com/weaviate-restart created
+```
+
+During restart, Ops Manager restarts Weaviate pods in a controlled order and reconciles the database back to `Ready` state.
 
 ## Verify
 
 ```bash
-kubectl describe weaviateopsrequest -n demo weaviate-restart
+$ kubectl get weaviateopsrequest -n demo weaviate-restart
+$ kubectl describe weaviateopsrequest -n demo weaviate-restart
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=weaviate-sample
+$ kubectl get weaviate -n demo weaviate-sample
 ```
 
 ## Cleaning up

--- a/docs/guides/weaviate/rotate-auth/_index.md
+++ b/docs/guides/weaviate/rotate-auth/_index.md
@@ -1,0 +1,10 @@
+---
+title: Rotate Auth
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-rotate-auth
+    name: Rotate Auth
+    parent: weaviate-guides
+    weight: 23
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/rotate-auth/overview.md
+++ b/docs/guides/weaviate/rotate-auth/overview.md
@@ -1,0 +1,51 @@
+---
+title: Rotating Weaviate Credentials
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-rotate-auth-overview
+    name: Overview
+    parent: weaviate-rotate-auth
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Rotate Auth for Weaviate
+
+This guide tracks rotate-auth documentation for Weaviate.
+
+This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD, so there is no validated rotate-auth manifest to publish yet.
+
+## Before You Begin
+
+- Install KubeDB and Ops-manager from [here](/docs/setup/README.md).
+- Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/rotate-auth/ops-request.yaml`.
+
+```bash
+kubectl create ns demo
+```
+
+## Deploy Weaviate
+
+```bash
+kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
+kubectl get weaviate -n demo weaviate-sample -w
+```
+
+See the detailed note in [Rotate Auth for Weaviate](/docs/guides/weaviate/rotate-auth/rotateauth.md).
+
+## Verify
+
+```bash
+kubectl describe weaviateopsrequest -n demo weaviate-rotate-auth
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviateopsrequest -n demo weaviate-rotate-auth
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/rotate-auth/overview.md
+++ b/docs/guides/weaviate/rotate-auth/overview.md
@@ -14,13 +14,12 @@ section_menu_id: guides
 
 # Rotate Auth for Weaviate
 
-This guide tracks rotate-auth documentation for Weaviate.
-
-This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD, so there is no validated rotate-auth manifest to publish yet.
+Rotate authentication credentials for Weaviate using a `WeaviateOpsRequest` with `type: RotateAuth`.
 
 ## Before You Begin
 
 - Install KubeDB and Ops-manager from [here](/docs/setup/README.md).
+- Review [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md) concepts.
 - Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/rotate-auth/ops-request.yaml`.
 
 ```bash
@@ -34,11 +33,12 @@ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}
 kubectl get weaviate -n demo weaviate-sample -w
 ```
 
-See the detailed note in [Rotate Auth for Weaviate](/docs/guides/weaviate/rotate-auth/rotateauth.md).
+Continue with the complete procedure in [Rotate Auth for Weaviate](/docs/guides/weaviate/rotate-auth/rotateauth.md).
 
 ## Verify
 
 ```bash
+kubectl get secret -n demo weaviate-sample-auth -o yaml
 kubectl describe weaviateopsrequest -n demo weaviate-rotate-auth
 ```
 

--- a/docs/guides/weaviate/rotate-auth/overview.md
+++ b/docs/guides/weaviate/rotate-auth/overview.md
@@ -12,40 +12,36 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-# Rotate Auth for Weaviate
+# Rotating Weaviate Authentication Credentials
 
-Rotate authentication credentials for Weaviate using a `WeaviateOpsRequest` with `type: RotateAuth`.
+This guide will give an overview of how KubeDB Ops-manager rotates the authentication credentials of a `Weaviate` database.
 
 ## Before You Begin
 
-- Install KubeDB and Ops-manager from [here](/docs/setup/README.md).
-- Review [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md) concepts.
-- Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/rotate-auth/ops-request.yaml`.
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
 
-```bash
-kubectl create ns demo
-```
+## How Rotate Auth Works
 
-## Deploy Weaviate
+The Rotate Auth process consists of the following steps:
 
-```bash
-kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
-kubectl get weaviate -n demo weaviate-sample -w
-```
+1. At first, a user creates a `Weaviate` CR.
 
-Continue with the complete procedure in [Rotate Auth for Weaviate](/docs/guides/weaviate/rotate-auth/rotateauth.md).
+2. `KubeDB-Provisioner` operator watches the `Weaviate` CR.
 
-## Verify
+3. When the operator finds a `Weaviate` CR, it creates a `StatefulSet` and generates an `authSecret` containing the initial API key for the Weaviate database. This API key is injected into Weaviate pods via the `AUTHENTICATION_APIKEY_ALLOWED_KEYS` environment variable.
 
-```bash
-kubectl get secret -n demo weaviate-sample-auth -o yaml
-kubectl describe weaviateopsrequest -n demo weaviate-rotate-auth
-```
+4. Then, in order to rotate the authentication credentials, the user creates a `WeaviateOpsRequest` CR with `type: RotateAuth`. The user can optionally provide a new custom secret, or let KubeDB auto-generate a new API key.
 
-## Cleaning up
+5. `KubeDB` Ops-manager operator watches the `WeaviateOpsRequest` CR.
 
-```bash
-kubectl delete weaviateopsrequest -n demo weaviate-rotate-auth
-kubectl delete weaviate -n demo weaviate-sample
-kubectl delete ns demo
-```
+6. When it finds a `WeaviateOpsRequest` CR, it pauses the `Weaviate` object so that the `KubeDB-Provisioner` operator doesn't perform any operations on the `Weaviate` during the credential rotation process.
+
+7. Then the `KubeDB` Ops-manager operator generates a new API key (or uses the provided secret), updates the `authSecret`, and restarts the pods in a rolling fashion to apply the new credentials.
+
+8. After the successful credential rotation, the `KubeDB` Ops-manager updates the `Weaviate` object to reflect the updated auth state.
+
+9. After the successful Rotate Auth, the `KubeDB` Ops-manager resumes the `Weaviate` object so that the `KubeDB-Provisioner` resumes its usual operations.
+
+In the next doc, we are going to show a step-by-step guide on rotating authentication credentials of a Weaviate database using `WeaviateOpsRequest` CRD.

--- a/docs/guides/weaviate/rotate-auth/rotateauth.md
+++ b/docs/guides/weaviate/rotate-auth/rotateauth.md
@@ -1,0 +1,32 @@
+---
+title: Rotate Auth of Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-rotate-auth-cluster
+    name: Cluster
+    parent: weaviate-rotate-auth
+    weight: 30
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Rotate Auth for Weaviate
+
+This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD.
+
+There is no CRD-backed authentication rotation manifest for Weaviate to document yet.
+
+## Current Recommendation
+
+- Manage credential rotation using the auth secret referenced by the `Weaviate` resource.
+- Roll out updates using your standard deployment process for the database.
+
+## Check API Status
+
+```bash
+kubectl get crd | grep -i weaviateopsrequest
+```
+
+If no CRD is returned, do not apply any `kind: WeaviateOpsRequest` manifest from placeholders.

--- a/docs/guides/weaviate/rotate-auth/rotateauth.md
+++ b/docs/guides/weaviate/rotate-auth/rotateauth.md
@@ -14,19 +14,95 @@ section_menu_id: guides
 
 # Rotate Auth for Weaviate
 
-This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD.
+`RotateAuth` updates authentication credentials used by Weaviate. This guide shows how to trigger rotation using `WeaviateOpsRequest`.
 
-There is no CRD-backed authentication rotation manifest for Weaviate to document yet.
+## Before You Begin
 
-## Current Recommendation
-
-- Manage credential rotation using the auth secret referenced by the `Weaviate` resource.
-- Roll out updates using your standard deployment process for the database.
-
-## Check API Status
+- Ensure KubeDB and Ops Manager are installed.
+- Review [Weaviate](/docs/guides/weaviate/concepts/weaviate.md) and [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md).
+- Use namespace `demo` for this guide.
 
 ```bash
-kubectl get crd | grep -i weaviateopsrequest
+$ kubectl create ns demo
+namespace/demo created
 ```
 
-If no CRD is returned, do not apply any `kind: WeaviateOpsRequest` manifest from placeholders.
+## Deploy Weaviate
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
+weaviate.kubedb.com/weaviate-sample created
+
+$ kubectl get weaviate -n demo weaviate-sample -w
+NAME              VERSION   STATUS   AGE
+weaviate-sample   1.33.1    Ready    2m
+```
+
+## Rotate Authentication Using Operator Generated Credentials
+
+Apply the sample ops request:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-rotate-auth
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: weaviate-sample
+  timeout: 5m
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/rotate-auth/ops-request.yaml
+weaviateopsrequest.ops.kubedb.com/weaviate-rotate-auth created
+```
+
+## Verify Credential Rotation
+
+Check request completion:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo weaviate-rotate-auth
+NAME                   TYPE         STATUS       AGE
+weaviate-rotate-auth   RotateAuth   Successful   2m
+```
+
+Inspect operation details:
+
+```bash
+$ kubectl describe weaviateopsrequest -n demo weaviate-rotate-auth
+```
+
+Inspect auth secret after rotation:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.authSecret.name}{"\n"}'
+$ kubectl get secret -n demo weaviate-sample-auth -o yaml
+```
+
+If your environment stores previous credentials, you can inspect previous values from secret keys such as `username.prev` and `password.prev`.
+
+## Optional: Use User-Provided Credentials
+
+You can rotate to user-provided credentials by creating a `kubernetes.io/basic-auth` secret and referencing it from `spec.authSecret` in the ops request.
+
+```bash
+kubectl create secret generic weaviate-user-auth -n demo \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=admin \
+  --from-literal=password='strong-pass'
+```
+
+Then apply a `WeaviateOpsRequest` with `type: RotateAuth` and `spec.authSecret.name: weaviate-user-auth`.
+
+## Cleaning up
+
+```bash
+kubectl delete weaviateopsrequest -n demo weaviate-rotate-auth
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete secret -n demo weaviate-user-auth --ignore-not-found
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/scaling/_index.md
+++ b/docs/guides/weaviate/scaling/_index.md
@@ -1,0 +1,10 @@
+---
+title: Scaling
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-scaling
+    name: Scaling
+    parent: weaviate-guides
+    weight: 26
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/scaling/horizontal-scaling/_index.md
+++ b/docs/guides/weaviate/scaling/horizontal-scaling/_index.md
@@ -1,0 +1,10 @@
+---
+title: Horizontal Scaling
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-horizontal-scaling
+    name: Horizontal Scaling
+    parent: weaviate-scaling
+    weight: 10
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/scaling/horizontal-scaling/overview.md
+++ b/docs/guides/weaviate/scaling/horizontal-scaling/overview.md
@@ -1,0 +1,47 @@
+---
+title: Weaviate Horizontal Scaling Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-horizontal-scaling-overview
+    name: Overview
+    parent: weaviate-horizontal-scaling
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate Horizontal Scaling
+
+This guide will give an overview of how KubeDB Ops-manager scales the number of nodes in a `Weaviate` database cluster.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
+
+## How Horizontal Scaling Works
+
+The Horizontal Scaling process consists of the following steps:
+
+1. At first, a user creates a `Weaviate` CR.
+
+2. `KubeDB-Provisioner` operator watches the `Weaviate` CR.
+
+3. When the operator finds a `Weaviate` CR, it creates a `StatefulSet` with the specified number of node replicas, along with related necessary stuff like secrets, services, etc.
+
+4. Then, in order to scale the number of nodes in the `Weaviate` cluster, the user creates a `WeaviateOpsRequest` CR with the desired node count.
+
+5. `KubeDB` Ops-manager operator watches the `WeaviateOpsRequest` CR.
+
+6. When it finds a `WeaviateOpsRequest` CR, it pauses the `Weaviate` object so that the `KubeDB-Provisioner` operator doesn't perform any operations on the `Weaviate` during the scaling process.
+
+7. Then the `KubeDB` Ops-manager operator scales the `StatefulSet` to the desired number of replicas.
+
+8. After the successful scaling of the `StatefulSet`, the `KubeDB` Ops-manager updates the replica count in the `Weaviate` object to reflect the updated state.
+
+9. After the successful Horizontal Scaling, the `KubeDB` Ops-manager resumes the `Weaviate` object so that the `KubeDB-Provisioner` resumes its usual operations.
+
+In the next doc, we are going to show a step-by-step guide on Horizontal Scaling of a Weaviate database using `WeaviateOpsRequest` CRD.

--- a/docs/guides/weaviate/scaling/horizontal-scaling/scale-horizontally/index.md
+++ b/docs/guides/weaviate/scaling/horizontal-scaling/scale-horizontally/index.md
@@ -55,7 +55,7 @@ metadata:
   name: weaviate-sample
   namespace: demo
 spec:
-  version: "1.26.4"
+  version: "1.33.1"
   replicas: 3
   storage:
     storageClassName: "standard"
@@ -85,7 +85,7 @@ $ watch -n 3 kubectl get weaviate -n demo weaviate-sample
 Every 3.0s: kubectl get weaviate -n demo weaviate-sample
 
 NAME              VERSION   STATUS   AGE
-weaviate-sample   1.26.4    Ready    4m40m
+weaviate-sample   1.33.1    Ready    4m40m
 
 
 $ watch -n 3 kubectl get petset -n demo weaviate-sample

--- a/docs/guides/weaviate/scaling/horizontal-scaling/scale-horizontally/index.md
+++ b/docs/guides/weaviate/scaling/horizontal-scaling/scale-horizontally/index.md
@@ -1,0 +1,234 @@
+---
+title: Scale Weaviate Horizontally
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-scale-horizontally
+    name: Scale Horizontally
+    parent: weaviate-horizontal-scaling
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Horizontal Scale Weaviate Cluster
+
+This guide will show you how to use `KubeDB` Ops Manager to increase/decrease the number of nodes in a `Weaviate` cluster.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
+  - [Horizontal Scaling Overview](/docs/guides/weaviate/scaling/horizontal-scaling/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/guides/weaviate/scaling/horizontal-scaling/scale-horizontally/yamls](/docs/guides/weaviate/scaling/horizontal-scaling/scale-horizontally/yamls) directory of [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+### Apply Horizontal Scaling on Weaviate Cluster
+
+Here, we are going to deploy a `Weaviate` cluster using a supported version by `KubeDB` operator. Then we are going to apply horizontal scaling on it.
+
+#### Prepare Cluster
+
+At first, we are going to deploy a cluster with 3 nodes. Then, we are going to add two additional nodes through horizontal scaling. Finally, we will remove 1 node from the cluster again via horizontal scaling.
+
+**Deploy Weaviate Cluster:**
+
+In this section, we are going to deploy a Weaviate cluster with 3 nodes. Then, in the next section we will scale the cluster using horizontal scaling. Below is the YAML of the `Weaviate` CR that we are going to create:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: "1.26.4"
+  replicas: 3
+  storage:
+    storageClassName: "standard"
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Weaviate` CR we have shown above:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/weaviate/scaling/horizontal-scaling/scale-horizontally/yamls/weaviate.yaml
+weaviate.kubedb.com/weaviate-sample created
+```
+
+**Wait for the cluster to be ready:**
+
+`KubeDB` operator watches for `Weaviate` objects using Kubernetes API. When a `Weaviate` object is created, `KubeDB` operator will create a new PetSet, Services, and Secrets, etc.
+
+Now, watch `Weaviate` is going to `Running` state and also watch `PetSet` and its pods:
+
+```bash
+$ watch -n 3 kubectl get weaviate -n demo weaviate-sample
+Every 3.0s: kubectl get weaviate -n demo weaviate-sample
+
+NAME              VERSION   STATUS   AGE
+weaviate-sample   1.26.4    Ready    4m40m
+
+
+$ watch -n 3 kubectl get petset -n demo weaviate-sample
+Every 3.0s: kubectl get petset -n demo weaviate-sample
+
+NAME              READY   AGE
+weaviate-sample   3/3     4m41m
+
+
+$ watch -n 3 kubectl get pods -n demo
+Every 3.0s: kubectl get pod -n demo
+
+NAME                READY   STATUS    RESTARTS   AGE
+weaviate-sample-0   1/1     Running   0          4m25m
+weaviate-sample-1   1/1     Running   0          4m26m
+weaviate-sample-2   1/1     Running   0          4m26m
+```
+
+Let's check the current number of nodes:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample -o=jsonpath='{.spec.replicas}{"\n"}'
+3
+```
+
+We are ready to apply the `WeaviateOpsRequest` CR to scale horizontally.
+
+#### Scale Up
+
+Here, we are going to scale up the cluster from 3 nodes to 5 nodes.
+
+**Create WeaviateOpsRequest:**
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-hscale-up
+  namespace: demo
+spec:
+  type: HorizontalScaling
+  databaseRef:
+    name: weaviate-sample
+  horizontalScaling:
+    node: 5
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are performing horizontal scaling on `weaviate-sample` Weaviate database.
+- `spec.type` specifies that we are performing `HorizontalScaling` on our database.
+- `spec.horizontalScaling.node` specifies the desired number of nodes after scaling.
+
+Let's create the `WeaviateOpsRequest` CR we have shown above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/weaviate/scaling/horizontal-scaling/scale-horizontally/yamls/hscale-up.yaml
+weaviateopsrequest.ops.kubedb.com/wvops-hscale-up created
+```
+
+**Verify Weaviate scale-up completed successfully:**
+
+```bash
+$ watch -n 3 kubectl get WeaviateOpsRequest -n demo wvops-hscale-up
+Every 3.0s: kubectl get WeaviateOpsRequest -n demo wvops-hscale-up
+
+NAME               TYPE               STATUS       AGE
+wvops-hscale-up    HorizontalScaling  Successful   3m57s
+```
+
+Now let's verify that the number of nodes has increased:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample -o=jsonpath='{.spec.replicas}{"\n"}'
+5
+
+$ kubectl get pods -n demo
+NAME                READY   STATUS    RESTARTS   AGE
+weaviate-sample-0   1/1     Running   0          10m
+weaviate-sample-1   1/1     Running   0          10m
+weaviate-sample-2   1/1     Running   0          10m
+weaviate-sample-3   1/1     Running   0          2m
+weaviate-sample-4   1/1     Running   0          1m
+```
+
+#### Scale Down
+
+Here, we are going to scale down the cluster from 5 nodes to 4 nodes.
+
+**Create WeaviateOpsRequest:**
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-hscale-down
+  namespace: demo
+spec:
+  type: HorizontalScaling
+  databaseRef:
+    name: weaviate-sample
+  horizontalScaling:
+    node: 4
+```
+
+Let's create the `WeaviateOpsRequest` CR we have shown above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/weaviate/scaling/horizontal-scaling/scale-horizontally/yamls/hscale-down.yaml
+weaviateopsrequest.ops.kubedb.com/wvops-hscale-down created
+```
+
+**Verify Weaviate scale-down completed successfully:**
+
+```bash
+$ watch -n 3 kubectl get WeaviateOpsRequest -n demo wvops-hscale-down
+Every 3.0s: kubectl get WeaviateOpsRequest -n demo wvops-hscale-down
+
+NAME                 TYPE               STATUS       AGE
+wvops-hscale-down    HorizontalScaling  Successful   2m15s
+```
+
+Now let's verify that the number of nodes has decreased:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample -o=jsonpath='{.spec.replicas}{"\n"}'
+4
+
+$ kubectl get pods -n demo
+NAME                READY   STATUS    RESTARTS   AGE
+weaviate-sample-0   1/1     Running   0          14m
+weaviate-sample-1   1/1     Running   0          14m
+weaviate-sample-2   1/1     Running   0          14m
+weaviate-sample-3   1/1     Running   0          6m
+```
+
+We have successfully performed horizontal scaling on the Weaviate cluster.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete WeaviateOpsRequest -n demo wvops-hscale-up wvops-hscale-down
+```

--- a/docs/guides/weaviate/scaling/vertical-scaling/_index.md
+++ b/docs/guides/weaviate/scaling/vertical-scaling/_index.md
@@ -1,0 +1,10 @@
+---
+title: Vertical Scaling
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-vertical-scaling
+    name: Vertical Scaling
+    parent: weaviate-scaling
+    weight: 10
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/scaling/vertical-scaling/overview.md
+++ b/docs/guides/weaviate/scaling/vertical-scaling/overview.md
@@ -14,39 +14,34 @@ section_menu_id: guides
 
 # Weaviate Vertical Scaling
 
-Scale Weaviate node CPU and memory resources using a `WeaviateOpsRequest` with `type: VerticalScaling`.
+This guide will give an overview of how KubeDB Ops-manager updates the CPU and memory resources of `Weaviate` database nodes.
 
 ## Before You Begin
 
-- Ensure database is healthy and all pods are running.
-- Install KubeDB and Ops Manager.
-- Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/scaling/vertical-scaling/ops-request.yaml`.
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
 
-```bash
-kubectl create ns demo
-```
+## How Vertical Scaling Works
 
-## Deploy Weaviate
+The Vertical Scaling process consists of the following steps:
 
-```bash
-kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
-kubectl get weaviate -n demo weaviate-sample -w
-```
+1. At first, a user creates a `Weaviate` CR.
 
-Continue with [Scale Weaviate Vertically](/docs/guides/weaviate/scaling/vertical-scaling/scale-vertically/).
+2. `KubeDB-Provisioner` operator watches the `Weaviate` CR.
 
-## Verify
+3. When the operator finds a `Weaviate` CR, it creates a `StatefulSet` and related necessary stuff like secrets, services, etc.
 
-```bash
-kubectl describe weaviateopsrequest -n demo weaviate-vertical-scale
-kubectl get weaviate -n demo weaviate-sample
-kubectl get pods -n demo -l app.kubernetes.io/instance=weaviate-sample
-```
+4. Then, in order to update the CPU and memory resources of the `Weaviate` database nodes, the user creates a `WeaviateOpsRequest` CR with the desired resource specifications.
 
-## Cleaning up
+5. `KubeDB` Ops-manager operator watches the `WeaviateOpsRequest` CR.
 
-```bash
-kubectl delete weaviateopsrequest -n demo weaviate-vertical-scale
-kubectl delete weaviate -n demo weaviate-sample
-kubectl delete ns demo
-```
+6. When it finds a `WeaviateOpsRequest` CR, it pauses the `Weaviate` object so that the `KubeDB-Provisioner` operator doesn't perform any operations on the `Weaviate` during the scaling process.
+
+7. Then the `KubeDB` Ops-manager operator updates the resources of the `StatefulSet` pods to the desired values defined in the `WeaviateOpsRequest` CR.
+
+8. After the successful resource update of the pods, the `KubeDB` Ops-manager updates the resource specifications in the `Weaviate` object to reflect the updated state.
+
+9. After the successful Vertical Scaling, the `KubeDB` Ops-manager resumes the `Weaviate` object so that the `KubeDB-Provisioner` resumes its usual operations.
+
+In the next doc, we are going to show a step-by-step guide on Vertical Scaling of a Weaviate database using `WeaviateOpsRequest` CRD.

--- a/docs/guides/weaviate/scaling/vertical-scaling/overview.md
+++ b/docs/guides/weaviate/scaling/vertical-scaling/overview.md
@@ -1,0 +1,51 @@
+---
+title: Weaviate Vertical Scaling Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-vertical-scaling-overview
+    name: Overview
+    parent: weaviate-vertical-scaling
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate Vertical Scaling
+
+This guide tracks vertical scaling documentation for Weaviate.
+
+This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD, so there is no validated vertical scaling manifest to publish yet.
+
+## Before You Begin
+
+- Ensure database is healthy and all pods are running.
+- Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/scaling/vertical-scaling/ops-request.yaml`.
+
+```bash
+kubectl create ns demo
+```
+
+## Deploy Weaviate
+
+```bash
+kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
+kubectl get weaviate -n demo weaviate-sample -w
+```
+
+See the detailed note in [Vertical Scaling for Weaviate](/docs/guides/weaviate/scaling/vertical-scaling/scale-vertically/).
+
+## Verify
+
+```bash
+kubectl describe weaviateopsrequest -n demo weaviate-vertical-scale
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviateopsrequest -n demo weaviate-vertical-scale
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/scaling/vertical-scaling/overview.md
+++ b/docs/guides/weaviate/scaling/vertical-scaling/overview.md
@@ -14,13 +14,12 @@ section_menu_id: guides
 
 # Weaviate Vertical Scaling
 
-This guide tracks vertical scaling documentation for Weaviate.
-
-This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD, so there is no validated vertical scaling manifest to publish yet.
+Scale Weaviate node CPU and memory resources using a `WeaviateOpsRequest` with `type: VerticalScaling`.
 
 ## Before You Begin
 
 - Ensure database is healthy and all pods are running.
+- Install KubeDB and Ops Manager.
 - Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/scaling/vertical-scaling/ops-request.yaml`.
 
 ```bash
@@ -34,12 +33,14 @@ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}
 kubectl get weaviate -n demo weaviate-sample -w
 ```
 
-See the detailed note in [Vertical Scaling for Weaviate](/docs/guides/weaviate/scaling/vertical-scaling/scale-vertically/).
+Continue with [Scale Weaviate Vertically](/docs/guides/weaviate/scaling/vertical-scaling/scale-vertically/).
 
 ## Verify
 
 ```bash
 kubectl describe weaviateopsrequest -n demo weaviate-vertical-scale
+kubectl get weaviate -n demo weaviate-sample
+kubectl get pods -n demo -l app.kubernetes.io/instance=weaviate-sample
 ```
 
 ## Cleaning up

--- a/docs/guides/weaviate/scaling/vertical-scaling/scale-vertically/index.md
+++ b/docs/guides/weaviate/scaling/vertical-scaling/scale-vertically/index.md
@@ -1,0 +1,31 @@
+---
+title: Scale Weaviate Vertically
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-scale-vertically
+    name: Scale Vertically
+    parent: weaviate-vertical-scaling
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Vertical Scaling for Weaviate
+
+This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD.
+
+That means there is no validated vertical scaling manifest to publish for Weaviate at this time.
+
+## Current Recommendation
+
+Use direct `Weaviate` spec updates for resource requests and limits in `spec.podTemplate` while following maintenance best practices.
+
+## Check API Status
+
+```bash
+kubectl get crd | grep -i weaviateopsrequest
+```
+
+If this CRD becomes available in a newer release, use that release documentation for vertical scaling request examples.

--- a/docs/guides/weaviate/scaling/vertical-scaling/scale-vertically/index.md
+++ b/docs/guides/weaviate/scaling/vertical-scaling/scale-vertically/index.md
@@ -14,18 +14,96 @@ section_menu_id: guides
 
 # Vertical Scaling for Weaviate
 
-This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD.
+This guide shows how to increase or decrease Weaviate node resources using `WeaviateOpsRequest`.
 
-That means there is no validated vertical scaling manifest to publish for Weaviate at this time.
+## Before You Begin
 
-## Current Recommendation
+- Ensure your cluster has enough allocatable resources for the target CPU/memory.
+- Install KubeDB and Ops Manager from [setup docs](/docs/setup/README.md).
+- Review [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md).
 
-Use direct `Weaviate` spec updates for resource requests and limits in `spec.podTemplate` while following maintenance best practices.
-
-## Check API Status
+Create a test namespace:
 
 ```bash
-kubectl get crd | grep -i weaviateopsrequest
+$ kubectl create ns demo
+namespace/demo created
 ```
 
-If this CRD becomes available in a newer release, use that release documentation for vertical scaling request examples.
+## Deploy Weaviate
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
+weaviate.kubedb.com/weaviate-sample created
+
+$ kubectl get weaviate -n demo weaviate-sample -w
+NAME              VERSION   STATUS   AGE
+weaviate-sample   1.33.1    Ready    2m
+```
+
+## Create VerticalScaling OpsRequest
+
+Use this manifest:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-vertical-scale
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: weaviate-sample
+  verticalScaling:
+    node:
+      resources:
+        requests:
+          cpu: "500m"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 2Gi
+```
+
+Apply the sample file:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/scaling/vertical-scaling/ops-request.yaml
+weaviateopsrequest.ops.kubedb.com/weaviate-vertical-scale created
+```
+
+## Verify Vertical Scaling
+
+Monitor request:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo weaviate-vertical-scale
+NAME                     TYPE              STATUS       AGE
+weaviate-vertical-scale  VerticalScaling   Successful   3m
+```
+
+Inspect details:
+
+```bash
+$ kubectl describe weaviateopsrequest -n demo weaviate-vertical-scale
+```
+
+Verify pod resources after reconciliation:
+
+```bash
+$ kubectl get pod -n demo weaviate-sample-0 -o json | jq '.spec.containers[].resources'
+```
+
+Confirm database remains healthy:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviateopsrequest -n demo weaviate-vertical-scale
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/tls/_index.md
+++ b/docs/guides/weaviate/tls/_index.md
@@ -1,0 +1,10 @@
+---
+title: Weaviate TLS
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-tls
+    name: TLS
+    parent: weaviate-guides
+    weight: 25
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/tls/configure/index.md
+++ b/docs/guides/weaviate/tls/configure/index.md
@@ -1,0 +1,172 @@
+---
+title: Configure TLS in Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-tls-configure
+    name: Configure TLS
+    parent: weaviate-tls
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Configure TLS/SSL in Weaviate
+
+`KubeDB` provides support for TLS/SSL encryption for `Weaviate`. This tutorial will show you how to use `KubeDB` to deploy a `Weaviate` database with TLS/SSL configuration.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Install [`cert-manager`](https://cert-manager.io/docs/installation/) v1.4.0 or later to your cluster to manage your SSL/TLS certificates.
+
+- Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [TLS Overview](/docs/guides/weaviate/tls/overview.md)
+
+To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/guides/weaviate/tls/configure/yamls](/docs/guides/weaviate/tls/configure/yamls) directory of [kubedb/docs](https://github.com/kubedb/docs) repository.
+
+### Deploy Weaviate database with TLS/SSL configuration
+
+As a pre-requisite, we are going to create an Issuer/ClusterIssuer. This Issuer/ClusterIssuer is used to create certificates. Then we are going to deploy a Weaviate with TLS/SSL configuration.
+
+### Create Issuer/ClusterIssuer
+
+Now, we are going to create an example `Issuer` that will be used throughout the duration of this tutorial. Alternatively, you can follow this [cert-manager tutorial](https://cert-manager.io/docs/configuration/ca/) to create your own `Issuer`. By following the below steps, we are going to create our desired issuer,
+
+- Start off by generating our ca-certificates using openssl:
+
+```bash
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ./ca.key -out ./ca.crt -subj "/CN=weaviate/O=kubedb"
+```
+
+- Create a secret using the certificate files we have just generated:
+
+```bash
+$ kubectl create secret tls weaviate-ca --cert=ca.crt --key=ca.key --namespace=demo
+secret/weaviate-ca created
+```
+
+Now, we are going to create an `Issuer` using the `weaviate-ca` secret that contains the CA certificate we have just created. Below is the YAML of the `Issuer` CR that we are going to create:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: weaviate-ca-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: weaviate-ca
+```
+
+Let's create the `Issuer` CR we have shown above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/weaviate/tls/configure/yamls/issuer.yaml
+issuer.cert-manager.io/weaviate-ca-issuer created
+```
+
+### Deploy Weaviate cluster with TLS/SSL configuration
+
+Here, our issuer `weaviate-ca-issuer` is ready to deploy a `Weaviate` cluster with TLS/SSL configuration. Below is the YAML for the Weaviate cluster that we are going to create:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: "1.26.4"
+  replicas: 3
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      name: weaviate-ca-issuer
+      kind: Issuer
+    certificates:
+    - alias: server
+      subject:
+        organizations:
+        - kubedb:server
+      dnsNames:
+      - localhost
+      ipAddresses:
+      - "127.0.0.1"
+  storage:
+    storageClassName: "standard"
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Here,
+
+- `spec.tls.issuerRef` refers to the `weaviate-ca-issuer` issuer.
+- `spec.tls.certificates` provides options to configure certificate renewal and keep-alive. You can find more details from [here](/docs/guides/weaviate/concepts/weaviate.md#tls).
+
+**Deploy Weaviate Cluster:**
+
+Let's create the `Weaviate` CR we have shown above:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/weaviate/tls/configure/yamls/tls-weaviate.yaml
+weaviate.kubedb.com/weaviate-sample created
+```
+
+**Wait for the database to be ready:**
+
+Now, watch `Weaviate` going to `Running` state and also watch `PetSet` and its pods going to `Running` state:
+
+```bash
+$ watch kubectl get weaviate -n demo weaviate-sample
+NAME              VERSION   STATUS   AGE
+weaviate-sample   1.26.4    Ready    62s
+
+$ watch -n 3 kubectl get petset -n demo weaviate-sample
+NAME              READY   AGE
+weaviate-sample   3/3     2m30s
+
+$ watch -n 3 kubectl get pod -n demo -l app.kubernetes.io/instance=weaviate-sample
+NAME                READY   STATUS    RESTARTS   AGE
+weaviate-sample-0   1/1     Running   0          3m5s
+weaviate-sample-1   1/1     Running   0          2m40s
+weaviate-sample-2   1/1     Running   0          2m20s
+```
+
+**Verify TLS/SSL configuration:**
+
+Now, let's verify the TLS/SSL configuration by checking the secrets created for the Weaviate database:
+
+```bash
+$ kubectl get secrets -n demo | grep weaviate-sample
+weaviate-sample-server-cert   kubernetes.io/tls   3      3m
+weaviate-sample-client-cert   kubernetes.io/tls   3      3m
+```
+
+The TLS certificates have been created and the Weaviate cluster is now configured to use TLS/SSL for both client connections and peer-to-peer communication.
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete issuer -n demo weaviate-ca-issuer
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/tls/configure/index.md
+++ b/docs/guides/weaviate/tls/configure/index.md
@@ -89,7 +89,7 @@ metadata:
   name: weaviate-sample
   namespace: demo
 spec:
-  version: "1.26.4"
+  version: "1.33.1"
   replicas: 3
   tls:
     issuerRef:
@@ -136,7 +136,7 @@ Now, watch `Weaviate` going to `Running` state and also watch `PetSet` and its p
 ```bash
 $ watch kubectl get weaviate -n demo weaviate-sample
 NAME              VERSION   STATUS   AGE
-weaviate-sample   1.26.4    Ready    62s
+weaviate-sample   1.33.1    Ready    62s
 
 $ watch -n 3 kubectl get petset -n demo weaviate-sample
 NAME              READY   AGE

--- a/docs/guides/weaviate/tls/overview.md
+++ b/docs/guides/weaviate/tls/overview.md
@@ -1,0 +1,49 @@
+---
+title: Weaviate TLS Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-tls-overview
+    name: Overview
+    parent: weaviate-tls
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate TLS/SSL Encryption
+
+This guide will give an overview of how KubeDB supports TLS/SSL encryption for `Weaviate` databases.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
+
+## How TLS Works for Weaviate
+
+KubeDB uses `cert-manager` to manage TLS certificates for Weaviate databases. The TLS configuration process consists of the following steps:
+
+1. At first, a user creates a `ClusterIssuer` or `Issuer` using `cert-manager`.
+
+2. The user then creates a `Weaviate` CR with the `spec.tls` field configured, pointing to the `Issuer` or `ClusterIssuer`.
+
+3. `KubeDB-Provisioner` operator watches the `Weaviate` CR.
+
+4. When the operator finds a `Weaviate` CR with `spec.tls` configured, it requests TLS certificates from `cert-manager` using the specified issuer.
+
+5. `cert-manager` creates the certificates and stores them in a `Secret`.
+
+6. `KubeDB-Provisioner` operator creates the `StatefulSet` with the TLS secrets mounted, enabling encrypted communication.
+
+7. The `Weaviate` database nodes use these certificates for encrypted client-to-server and peer-to-peer communication.
+
+KubeDB supports the following TLS configurations for Weaviate:
+
+- **Add TLS** — Enable TLS on an existing non-TLS Weaviate database using a `WeaviateOpsRequest`.
+- **Rotate TLS** — Rotate the existing TLS certificates to refresh expiring certificates.
+- **Remove TLS** — Remove TLS from an existing TLS-enabled Weaviate database.
+
+In the next doc, we are going to show a step-by-step guide on configuring TLS for a Weaviate database.

--- a/docs/guides/weaviate/update-version/_index.md
+++ b/docs/guides/weaviate/update-version/_index.md
@@ -1,0 +1,10 @@
+---
+title: Update Version
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-update-version
+    name: Update Version
+    parent: weaviate-guides
+    weight: 24
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/update-version/overview.md
+++ b/docs/guides/weaviate/update-version/overview.md
@@ -1,0 +1,52 @@
+---
+title: Updating Weaviate Version
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-update-version-overview
+    name: Overview
+    parent: weaviate-update-version
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Updating Weaviate Version
+
+This guide tracks version update documentation for Weaviate.
+
+This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD, so there is no validated update-version manifest to publish yet.
+
+## Before You Begin
+
+- Ensure Weaviate is `Ready` before submitting the update request.
+- Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/update-version/ops-request.yaml`.
+
+```bash
+kubectl create ns demo
+kubectl get weaviateversions
+```
+
+## Deploy Weaviate
+
+```bash
+kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
+kubectl get weaviate -n demo weaviate-sample -w
+```
+
+See the detailed note in [Upgrade Weaviate Version](/docs/guides/weaviate/update-version/versionupgrading/).
+
+## Verify
+
+```bash
+kubectl describe weaviateopsrequest -n demo weaviate-update-version
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviateopsrequest -n demo weaviate-update-version
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/update-version/overview.md
+++ b/docs/guides/weaviate/update-version/overview.md
@@ -14,13 +14,12 @@ section_menu_id: guides
 
 # Updating Weaviate Version
 
-This guide tracks version update documentation for Weaviate.
-
-This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD, so there is no validated update-version manifest to publish yet.
+Update Weaviate engine version using `WeaviateOpsRequest` with `type: UpdateVersion`.
 
 ## Before You Begin
 
 - Ensure Weaviate is `Ready` before submitting the update request.
+- Ensure the target `WeaviateVersion` exists in your cluster.
 - Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/update-version/ops-request.yaml`.
 
 ```bash
@@ -35,12 +34,13 @@ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}
 kubectl get weaviate -n demo weaviate-sample -w
 ```
 
-See the detailed note in [Upgrade Weaviate Version](/docs/guides/weaviate/update-version/versionupgrading/).
+Continue with [Upgrade Weaviate Version](/docs/guides/weaviate/update-version/versionupgrading/).
 
 ## Verify
 
 ```bash
 kubectl describe weaviateopsrequest -n demo weaviate-update-version
+kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.version}{"\n"}'
 ```
 
 ## Cleaning up

--- a/docs/guides/weaviate/update-version/overview.md
+++ b/docs/guides/weaviate/update-version/overview.md
@@ -14,39 +14,34 @@ section_menu_id: guides
 
 # Updating Weaviate Version
 
-Update Weaviate engine version using `WeaviateOpsRequest` with `type: UpdateVersion`.
+This guide will give you an overview of how KubeDB Ops-manager updates the version of a `Weaviate` database.
 
 ## Before You Begin
 
-- Ensure Weaviate is `Ready` before submitting the update request.
-- Ensure the target `WeaviateVersion` exists in your cluster.
-- Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/update-version/ops-request.yaml`.
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
 
-```bash
-kubectl create ns demo
-kubectl get weaviateversions
-```
+## How the Update Process Works
 
-## Deploy Weaviate
+The updating process consists of the following steps:
 
-```bash
-kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
-kubectl get weaviate -n demo weaviate-sample -w
-```
+1. At first, a user creates a `Weaviate` CR.
 
-Continue with [Upgrade Weaviate Version](/docs/guides/weaviate/update-version/versionupgrading/).
+2. `KubeDB-Provisioner` operator watches for the `Weaviate` CR.
 
-## Verify
+3. When it finds one, it creates a `StatefulSet` and related necessary stuff like secrets, services, etc.
 
-```bash
-kubectl describe weaviateopsrequest -n demo weaviate-update-version
-kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.version}{"\n"}'
-```
+4. Then, in order to update the version of the `Weaviate` database, the user creates a `WeaviateOpsRequest` CR with the desired target version.
 
-## Cleaning up
+5. `KubeDB-ops-manager` operator watches for `WeaviateOpsRequest`.
 
-```bash
-kubectl delete weaviateopsrequest -n demo weaviate-update-version
-kubectl delete weaviate -n demo weaviate-sample
-kubectl delete ns demo
-```
+6. When it finds one, it pauses the `Weaviate` object so that the `KubeDB-Provisioner` operator doesn't perform any operations on the `Weaviate` during the updating process.
+
+7. By looking at the target version from the `WeaviateOpsRequest` CR, the `KubeDB-ops-manager` operator updates the images of the `StatefulSet` for the new version.
+
+8. After successful update of the `StatefulSet` and its Pod images, the `KubeDB-ops-manager` updates the image of the `Weaviate` object to reflect the updated cluster state.
+
+9. After successful update of the `Weaviate` object, the `KubeDB` Ops-manager resumes the `Weaviate` object so that the `KubeDB-Provisioner` can resume its usual operations.
+
+In the next doc, we are going to show a step-by-step guide on updating a Weaviate database using the `UpdateVersion` operation.

--- a/docs/guides/weaviate/update-version/versionupgrading/index.md
+++ b/docs/guides/weaviate/update-version/versionupgrading/index.md
@@ -14,20 +14,95 @@ section_menu_id: guides
 
 # Upgrade Weaviate Version
 
-This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD.
+This guide demonstrates how to update Weaviate from one supported version to another using `WeaviateOpsRequest`.
 
-Until that API exists, a correct `UpdateVersion` manifest for Weaviate cannot be generated from this repo.
+## Before You Begin
 
-## Current Recommendation
+- You need a Kubernetes cluster with `kubectl` configured.
+- Install KubeDB and Ops Manager from [setup docs](/docs/setup/README.md).
+- Review [WeaviateVersion](/docs/guides/weaviate/concepts/catalog.md) and [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md).
 
-Upgrade Weaviate by updating `spec.version` in the `Weaviate` custom resource to a supported `WeaviateVersion`.
+Create a namespace for the tutorial:
 
 ```bash
-kubectl get weaviateversions
+$ kubectl create ns demo
+namespace/demo created
 ```
 
-## Check API Status
+## Check Available Versions
+
+List available versions:
 
 ```bash
-kubectl get crd | grep -i weaviateopsrequest
+$ kubectl get weaviateversions
+```
+
+Choose a target version that is present and not deprecated.
+
+## Deploy Weaviate
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
+weaviate.kubedb.com/weaviate-sample created
+
+$ kubectl get weaviate -n demo weaviate-sample -w
+NAME              VERSION   STATUS   AGE
+weaviate-sample   1.33.1    Ready    2m
+```
+
+## Apply UpdateVersion OpsRequest
+
+Use this request:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-update-version
+  namespace: demo
+spec:
+  type: UpdateVersion
+  databaseRef:
+    name: weaviate-sample
+  updateVersion:
+    targetVersion: 1.34.0
+```
+
+Apply from the example file:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/update-version/ops-request.yaml
+weaviateopsrequest.ops.kubedb.com/weaviate-update-version created
+```
+
+## Verify Version Update
+
+Watch request status:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo weaviate-update-version
+NAME                       TYPE            STATUS       AGE
+weaviate-update-version    UpdateVersion   Successful   4m
+```
+
+Confirm resulting database version:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.version}{"\n"}'
+1.34.0
+```
+
+Check pod image and health:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=weaviate-sample
+$ kubectl get weaviate -n demo weaviate-sample
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviateopsrequest -n demo weaviate-update-version
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete ns demo
 ```

--- a/docs/guides/weaviate/update-version/versionupgrading/index.md
+++ b/docs/guides/weaviate/update-version/versionupgrading/index.md
@@ -1,0 +1,33 @@
+---
+title: Upgrade Weaviate Version
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-version-upgrading
+    name: Version Upgrading
+    parent: weaviate-update-version
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Upgrade Weaviate Version
+
+This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD.
+
+Until that API exists, a correct `UpdateVersion` manifest for Weaviate cannot be generated from this repo.
+
+## Current Recommendation
+
+Upgrade Weaviate by updating `spec.version` in the `Weaviate` custom resource to a supported `WeaviateVersion`.
+
+```bash
+kubectl get weaviateversions
+```
+
+## Check API Status
+
+```bash
+kubectl get crd | grep -i weaviateopsrequest
+```

--- a/docs/guides/weaviate/volume-expansion/_index.md
+++ b/docs/guides/weaviate/volume-expansion/_index.md
@@ -1,0 +1,10 @@
+---
+title: Volume Expansion
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-volume-expansion
+    name: Volume Expansion
+    parent: weaviate-guides
+    weight: 25
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/volume-expansion/overview.md
+++ b/docs/guides/weaviate/volume-expansion/overview.md
@@ -1,0 +1,52 @@
+---
+title: Expanding Weaviate Storage
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-volume-expansion-overview
+    name: Overview
+    parent: weaviate-volume-expansion
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Volume Expansion for Weaviate
+
+This guide tracks volume expansion documentation for Weaviate.
+
+This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD, so there is no validated volume expansion manifest to publish yet.
+
+## Before You Begin
+
+- Ensure StorageClass supports volume expansion.
+- Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/volume-expansion/ops-request.yaml`.
+
+```bash
+kubectl create ns demo
+kubectl get storageclass
+```
+
+## Deploy Weaviate
+
+```bash
+kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
+kubectl get weaviate -n demo weaviate-sample -w
+```
+
+See the detailed note in [Expand Weaviate Volume](/docs/guides/weaviate/volume-expansion/volume-expansion.md).
+
+## Verify
+
+```bash
+kubectl describe weaviateopsrequest -n demo weaviate-volume-expand
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviateopsrequest -n demo weaviate-volume-expand
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/volume-expansion/overview.md
+++ b/docs/guides/weaviate/volume-expansion/overview.md
@@ -12,42 +12,38 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-# Volume Expansion for Weaviate
+# Weaviate Volume Expansion
 
-Expand Weaviate persistent volume size using `WeaviateOpsRequest` with `type: VolumeExpansion`.
+This guide will give an overview of how KubeDB Ops-manager expands the volume of a `Weaviate` database.
 
 ## Before You Begin
 
-- Ensure the selected StorageClass supports volume expansion.
-- Ensure the database is healthy before applying the request.
-- Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/volume-expansion/ops-request.yaml`.
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md)
 
-```bash
-kubectl create ns demo
-kubectl get storageclass
-```
+## How Volume Expansion Works
 
-## Deploy Weaviate
+The Volume Expansion process consists of the following steps:
 
-```bash
-kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
-kubectl get weaviate -n demo weaviate-sample -w
-```
+1. At first, a user creates a `Weaviate` Custom Resource (CR).
 
-Continue with [Expand Weaviate Volume](/docs/guides/weaviate/volume-expansion/volume-expansion.md).
+2. `KubeDB-Provisioner` operator watches the `Weaviate` CR.
 
-## Verify
+3. When the operator finds a `Weaviate` CR, it creates a `StatefulSet` and related necessary stuff like pods, PVCs, secrets, services, etc.
 
-```bash
-kubectl describe weaviateopsrequest -n demo weaviate-volume-expand
-kubectl get pvc -n demo
-kubectl get weaviate -n demo weaviate-sample
-```
+4. Each StatefulSet creates a Persistent Volume according to the volume claim template. This Persistent Volume will be expanded by the `KubeDB` Ops-manager operator.
 
-## Cleaning up
+5. Then, in order to expand the volume of the `Weaviate` database, the user creates a `WeaviateOpsRequest` CR with the desired new storage size.
 
-```bash
-kubectl delete weaviateopsrequest -n demo weaviate-volume-expand
-kubectl delete weaviate -n demo weaviate-sample
-kubectl delete ns demo
-```
+6. `KubeDB` Ops-manager operator watches the `WeaviateOpsRequest` CR.
+
+7. When it finds a `WeaviateOpsRequest` CR, it pauses the `Weaviate` object so that the `KubeDB-Provisioner` operator doesn't perform any operations on the `Weaviate` during the volume expansion process.
+
+8. Then the `KubeDB` Ops-manager operator expands the persistent volumes to the expected size defined in the `WeaviateOpsRequest` CR.
+
+9. After the successful expansion of the volumes, the `KubeDB` Ops-manager updates the new volume size in the `Weaviate` object to reflect the updated state.
+
+10. After the successful Volume Expansion, the `KubeDB` Ops-manager resumes the `Weaviate` object so that the `KubeDB-Provisioner` resumes its usual operations.
+
+In the next doc, we are going to show a step-by-step guide on Volume Expansion of a Weaviate database using `WeaviateOpsRequest` CRD.

--- a/docs/guides/weaviate/volume-expansion/overview.md
+++ b/docs/guides/weaviate/volume-expansion/overview.md
@@ -14,13 +14,12 @@ section_menu_id: guides
 
 # Volume Expansion for Weaviate
 
-This guide tracks volume expansion documentation for Weaviate.
-
-This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD, so there is no validated volume expansion manifest to publish yet.
+Expand Weaviate persistent volume size using `WeaviateOpsRequest` with `type: VolumeExpansion`.
 
 ## Before You Begin
 
-- Ensure StorageClass supports volume expansion.
+- Ensure the selected StorageClass supports volume expansion.
+- Ensure the database is healthy before applying the request.
 - Use the example files from `docs/examples/weaviate/quickstart/weaviate.yaml` and `docs/examples/weaviate/volume-expansion/ops-request.yaml`.
 
 ```bash
@@ -35,12 +34,14 @@ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}
 kubectl get weaviate -n demo weaviate-sample -w
 ```
 
-See the detailed note in [Expand Weaviate Volume](/docs/guides/weaviate/volume-expansion/volume-expansion.md).
+Continue with [Expand Weaviate Volume](/docs/guides/weaviate/volume-expansion/volume-expansion.md).
 
 ## Verify
 
 ```bash
 kubectl describe weaviateopsrequest -n demo weaviate-volume-expand
+kubectl get pvc -n demo
+kubectl get weaviate -n demo weaviate-sample
 ```
 
 ## Cleaning up

--- a/docs/guides/weaviate/volume-expansion/volume-expansion.md
+++ b/docs/guides/weaviate/volume-expansion/volume-expansion.md
@@ -1,0 +1,32 @@
+---
+title: Expand Weaviate Volume
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-volume-expansion-cluster
+    name: Cluster
+    parent: weaviate-volume-expansion
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Expand Weaviate Volume
+
+This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD.
+
+Until that API exists, a correct `VolumeExpansion` manifest for Weaviate cannot be generated from this repo.
+
+## Current Recommendation
+
+- Expand PVC size through the storage workflow supported by your `StorageClass`.
+- Update the `Weaviate` resource storage specification as needed.
+
+## Check API Status
+
+```bash
+kubectl get crd | grep -i weaviateopsrequest
+```
+
+If this CRD appears in your installed release, use that release documentation for official volume expansion request manifests.

--- a/docs/guides/weaviate/volume-expansion/volume-expansion.md
+++ b/docs/guides/weaviate/volume-expansion/volume-expansion.md
@@ -14,19 +14,101 @@ section_menu_id: guides
 
 # Expand Weaviate Volume
 
-This repository does not currently contain a `WeaviateOpsRequest` Go type or CRD.
+This guide shows how to increase Weaviate data volume size using a `WeaviateOpsRequest`.
 
-Until that API exists, a correct `VolumeExpansion` manifest for Weaviate cannot be generated from this repo.
+## Before You Begin
 
-## Current Recommendation
+- You need a Kubernetes cluster with `kubectl` configured.
+- StorageClass used by Weaviate must support volume expansion.
+- Install KubeDB and Ops Manager from [setup docs](/docs/setup/README.md).
+- Review [WeaviateOpsRequest](/docs/guides/weaviate/concepts/opsrequest.md).
 
-- Expand PVC size through the storage workflow supported by your `StorageClass`.
-- Update the `Weaviate` resource storage specification as needed.
-
-## Check API Status
+Create namespace:
 
 ```bash
-kubectl get crd | grep -i weaviateopsrequest
+$ kubectl create ns demo
+namespace/demo created
 ```
 
-If this CRD appears in your installed release, use that release documentation for official volume expansion request manifests.
+## Verify Expandable StorageClass
+
+```bash
+$ kubectl get storageclass
+NAME       PROVISIONER               ALLOWVOLUMEEXPANSION   AGE
+longhorn   driver.longhorn.io        true                   5d
+```
+
+Use a storage class where `ALLOWVOLUMEEXPANSION` is `true`.
+
+## Deploy Weaviate
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate.yaml
+weaviate.kubedb.com/weaviate-sample created
+
+$ kubectl get weaviate -n demo weaviate-sample -w
+NAME              VERSION   STATUS   AGE
+weaviate-sample   1.33.1    Ready    2m
+```
+
+Check current PVC size:
+
+```bash
+$ kubectl get pvc -n demo
+```
+
+## Apply VolumeExpansion OpsRequest
+
+Use this request:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-volume-expand
+  namespace: demo
+spec:
+  type: VolumeExpansion
+  databaseRef:
+    name: weaviate-sample
+  volumeExpansion:
+    mode: Online
+    weaviate: 2Gi
+```
+
+Apply the sample file:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/volume-expansion/ops-request.yaml
+weaviateopsrequest.ops.kubedb.com/weaviate-volume-expand created
+```
+
+## Verify Volume Expansion
+
+Watch request status:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo weaviate-volume-expand
+NAME                     TYPE              STATUS       AGE
+weaviate-volume-expand   VolumeExpansion   Successful   3m
+```
+
+Inspect request events and progression:
+
+```bash
+$ kubectl describe weaviateopsrequest -n demo weaviate-volume-expand
+```
+
+Verify PVC size has been updated:
+
+```bash
+$ kubectl get pvc -n demo
+```
+
+## Cleaning up
+
+```bash
+kubectl delete weaviateopsrequest -n demo weaviate-volume-expand
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete ns demo
+```


### PR DESCRIPTION
## Summary
- expand Weaviate guides to match the detailed style used in Postgres docs
- replace brief/stub content with full step-by-step operational walkthroughs
- update Weaviate concept and overview pages to accurately describe day-2 workflows and autoscaling behavior

- Updated example manifests to use latest active catalog version (1.33.1).
## What Was Updated
- operation guides expanded with detailed flow and verification:
  - UpdateVersion
  - Restart
  - VolumeExpansion
  - Reconfigure
  - ReconfigureTLS
  - RotateAuth
  - HorizontalScaling
  - VerticalScaling
- monitoring guides expanded:
  - Builtin Prometheus
  - Prometheus Operator
- autoscaler guides expanded:
  - Compute autoscaling
  - Storage autoscaling
- core docs expanded:
  - quickstart
  - RBAC
  - private registry usage
  - custom RBAC usage
  - configuration via config file
- concepts updated:
  - Weaviate
  - WeaviateVersion catalog
  - WeaviateOpsRequest
  - WeaviateAutoscaler
- overview pages updated across Weaviate guide sections (including backup, ops-request, monitoring, tls, reconfigure, scaling, update-version, rotate-auth, autoscaler)

## Notes
- changes are documentation-focused and intended to make Weaviate docs consistent with existing KubeDB guide depth and structure
- PR remains scoped to Weaviate documentation and related guide index updates


