### PR TITLE
docs(guides): update shared guide index and shared concept docs

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -18,25 +18,32 @@ aliases:
 Guides to show you how to perform tasks with KubeDB:
 - [Cassandra](/docs/guides/cassandra/README.md). Shows how to manage Cassandra using KubeDB.
 - [ClickHouse](/docs/guides/clickhouse/README.md). Shows how to manage ClickHouse using KubeDB.
+- [DB2](/docs/guides/db2/README.md). Shows how to manage DB2 using KubeDB.
+- [DocumentDB](/docs/guides/documentdb/README.md). Shows how to manage DocumentDB using KubeDB.
 - [Druid](/docs/guides/druid/README.md). Shows how to manage Druid using KubeDB.
 - [Elasticsearch](/docs/guides/elasticsearch/README.md). Shows how to manage Elasticsearch & OpenSearch using KubeDB.
 - [FerretDB](/docs/guides/ferretdb/README.md). Shows how to manage FerretDB using KubeDB.
+- [HanaDB](/docs/guides/hanadb/README.md). Shows how to manage HanaDB using KubeDB.
 - [Hazelcast](/docs/guides/hazelcast/README.md). Shows how to manage Hazelcast using KubeDB.
 - [Ignite](/docs/guides/ignite/README.md). Shows how to manage Ignite using KubeDB.
 - [Kafka](/docs/guides/kafka/README.md). Shows how to manage Kafka using KubeDB.
 - [MariaDB](/docs/guides/mariadb). Shows how to manage MariaDB using KubeDB.
 - [Memcached](/docs/guides/memcached/README.md). Shows how to manage Memcached using KubeDB.
+- [Milvus](/docs/guides/milvus/README.md). Shows how to manage Milvus using KubeDB.
 - [Microsoft SQL Server](/docs/guides/mssqlserver/README.md). Shows how to manage Microsoft SQL Server using KubeDB.
 - [MongoDB](/docs/guides/mongodb/README.md). Shows how to manage MongoDB using KubeDB.
 - [MySQL](/docs/guides/mysql/README.md). Shows how to manage MySQL using KubeDB.
+- [Neo4j](/docs/guides/neo4j/README.md). Shows how to manage Neo4j using KubeDB.
 - [Oracle](/docs/guides/oracle/README.md). Shows how to manage Oracle using KubeDB.
 - [Percona XtraDB](/docs/guides/percona-xtradb/README.md). Shows how to manage Percona XtraDB using KubeDB.
 - [PgBouncer](/docs/guides/pgbouncer/README.md). Shows how to manage PgBouncer using KubeDB.
 - [Pgpool](/docs/guides/pgpool/README.md). Shows how to manage Pgpool using KubeDB.
 - [PostgreSQL](/docs/guides/postgres/README.md). Shows how to manage PostgreSQL using KubeDB.
 - [ProxySQL](/docs/guides/proxysql/README.md). Shows how to manage ProxySQL using KubeDB.
+- [Qdrant](/docs/guides/qdrant/README.md). Shows how to manage Qdrant using KubeDB.
 - [RabbitMQ](/docs/guides/rabbitmq/README.md). Shows how to manage RabbitMQ using KubeDB.
 - [Redis](/docs/guides/redis/README.md). Shows how to manage Redis using KubeDB.
 - [SingleStore](/docs/guides/singlestore/README.md). Shows how to manage SingleStore using KubeDB.
 - [Solr](/docs/guides/solr/README.md). Shows how to manage Solr using KubeDB.
+- [Weaviate](/docs/guides/weaviate/README.md). Shows how to manage Weaviate using KubeDB.
 - [ZooKeeper](/docs/guides/zookeeper/README.md). Shows how to manage ZooKeeper using KubeDB.

--- a/docs/guides/oracle/README.md
+++ b/docs/guides/oracle/README.md
@@ -38,4 +38,9 @@ aliases:
 
 - [Quickstart Oracle](/docs/guides/oracle/quickstart/guide.md) with KubeDB Operator.
 
+## Concepts
+
+- [Oracle CRD](/docs/guides/oracle/concepts/oracle.md) defines the schema for Oracle custom resource.
+- [OracleVersion CRD](/docs/guides/oracle/concepts/catalog.md) defines the schema for OracleVersion custom resource.
+
 

--- a/docs/guides/oracle/concepts/catalog.md
+++ b/docs/guides/oracle/concepts/catalog.md
@@ -1,0 +1,45 @@
+---
+title: OracleVersion CRD
+menu:
+  docs_{{ .version }}:
+    identifier: guides-oracle-oracleversion
+    name: OracleVersion
+    parent: guides-oracle-concepts
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+# OracleVersion
+
+## What is OracleVersion
+
+`OracleVersion` is the catalog CRD that defines Oracle engine version metadata and runtime images used by KubeDB.
+
+When you set `spec.version` in an `Oracle` resource, KubeDB resolves that value using an `OracleVersion` object.
+
+## OracleVersion Specification
+
+```yaml
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: OracleVersion
+metadata:
+  name: "21.3.0"
+spec:
+  version: "21.3.0"
+  db:
+    image: ghcr.io/kubedb/oracle-ee:21.3.0
+  deprecated: false
+```
+
+## Key fields
+
+- `metadata.name` is the version key referenced from `Oracle.spec.version`.
+- `spec.version` is the Oracle engine version.
+- `spec.db.image` is the container image KubeDB uses for Oracle database pods.
+- `spec.deprecated` marks whether the version is deprecated for new use.
+
+## Next Steps
+
+- Read the [Oracle CRD concept](/docs/guides/oracle/concepts/oracle.md).
+- Follow the [Oracle quickstart](/docs/guides/oracle/quickstart/guide.md).

--- a/docs/guides/postgres/README.md
+++ b/docs/guides/postgres/README.md
@@ -54,6 +54,7 @@ aliases:
 - Monitor your PostgreSQL database with KubeDB using [`out-of-the-box` Prometheus operator](/docs/guides/postgres/monitoring/using-prometheus-operator.md).
 - Use [private Docker registry](/docs/guides/postgres/private-registry/using-private-registry.md) to deploy PostgreSQL with KubeDB.
 - Detail concepts of [Postgres object](/docs/guides/postgres/concepts/postgres.md).
+- Detail concepts of [PostgresAutoscaler object](/docs/guides/postgres/concepts/autoscaler.md).
 - Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).
 
 

--- a/docs/guides/postgres/concepts/autoscaler.md
+++ b/docs/guides/postgres/concepts/autoscaler.md
@@ -1,0 +1,68 @@
+---
+title: PostgresAutoscaler CRD
+menu:
+  docs_{{ .version }}:
+    identifier: guides-postgres-concepts-autoscaler
+    name: PostgresAutoscaler
+    parent: pg-concepts-postgres
+    weight: 30
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# PostgresAutoscaler
+
+## What is PostgresAutoscaler
+
+`PostgresAutoscaler` is the CRD that enables compute and storage autoscaling workflows for KubeDB-managed PostgreSQL databases.
+
+KubeDB Autoscaler observes this resource and creates appropriate `PostgresOpsRequest` objects when scaling actions are needed.
+
+## Sample PostgresAutoscaler
+
+```yaml
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: PostgresAutoscaler
+metadata:
+  name: pg-as
+  namespace: demo
+spec:
+  databaseRef:
+    name: ha-postgres
+  opsRequestOptions:
+    timeout: 3m
+    apply: IfReady
+  compute:
+    postgres:
+      trigger: "On"
+      minAllowed:
+        cpu: 250m
+        memory: 1Gi
+      maxAllowed:
+        cpu: "1"
+        memory: 2Gi
+      controlledResources: ["cpu", "memory"]
+      containerControlledValues: RequestsAndLimits
+  storage:
+    postgres:
+      trigger: "On"
+      expansionMode: Online
+      usageThreshold: 70
+      scalingThreshold: 50
+      minAllowed: 2Gi
+      maxAllowed: 50Gi
+```
+
+## Key fields
+
+- `spec.databaseRef.name` points to the target `Postgres` database.
+- `spec.compute` configures CPU and memory autoscaling behavior.
+- `spec.storage` configures storage expansion behavior.
+- `spec.opsRequestOptions` configures generated ops request behavior.
+
+## Next Steps
+
+- See [Postgres compute autoscaling overview](/docs/guides/postgres/autoscaler/compute/overview.md).
+- See [Postgres storage autoscaling overview](/docs/guides/postgres/autoscaler/storage/overview.md).


### PR DESCRIPTION
## Summary
- update shared guides index links
- update Oracle guide and add Oracle catalog concept page
- update Postgres guide and add Postgres autoscaler concept page

## Notes
This PR contains only cross-database shared guide updates that were intentionally excluded from per-database PRs.