### PR TITLE
Add recommendation pages for all DBs

### DIFF
--- a/docs/guides/cassandra/recommendation/_index.md
+++ b/docs/guides/cassandra/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: Cassandra Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: cassandra-recommendation
+    name: Recommendation
+    parent: cas-cassandra-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/cassandra/recommendation/recommendation.md
+++ b/docs/guides/cassandra/recommendation/recommendation.md
@@ -155,7 +155,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `5.0.3` to `5.0.4`
+For example: Recommending version update from `5.0.3` to `5.0.7`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/cassandra/recommendation/recommendation.md
+++ b/docs/guides/cassandra/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: Cassandra Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: cassandra-recommendation-overview
+    name: Recommendation Overview
+    parent: cassandra-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Cassandra Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a Cassandra instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `CassandraOpsRequest` and tracks it to completion.
+
+This page is the **Cassandra-specific intro**: which recommendations apply to Cassandra and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [CassandraOpsRequest](/docs/guides/cassandra/concepts/cassandraopsrequest.md)
+- [CassandraRotateAuth](/docs/guides/cassandra/rotate-auth/overview.md)
+- [CassandraReconfigureTLS](/docs/guides/cassandra/tls/overview.md)
+- [CassandraUpdateVersion](/docs/guides/cassandra/update-version/overview.md)
+
+---
+
+## Recommendation types for Cassandra
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to Cassandra
+
+This section shows the minimal Cassandra CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Cassandra
+metadata:
+  name: cassandra-recommendation
+  namespace: demo
+spec:
+  version: "5.0.3"
+  authSecret:
+    kind: Secret
+    name: cassandra-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Cassandra
+metadata:
+  name: cassandra-recommendation
+  namespace: demo
+spec:
+  version: "5.0.3"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: cassandra-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Cassandra
+metadata:
+  name: cassandra-recommendation
+  namespace: demo
+spec:
+  version: "5.0.3"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `5.0.3` to `5.0.4`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Cassandra
+metadata:
+  name: cassandra-recommendation
+  namespace: demo
+spec:
+  version: "5.0.3"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/clickhouse/recommendation/_index.md
+++ b/docs/guides/clickhouse/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: ClickHouse Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: clickhouse-recommendation
+    name: Recommendation
+    parent: ch-clickhouse-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/clickhouse/recommendation/recommendation.md
+++ b/docs/guides/clickhouse/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: ClickHouse Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: clickhouse-recommendation-overview
+    name: Recommendation Overview
+    parent: clickhouse-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# ClickHouse Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a ClickHouse instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `ClickHouseOpsRequest` and tracks it to completion.
+
+This page is the **ClickHouse-specific intro**: which recommendations apply to ClickHouse and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [ClickHouseOpsRequest](/docs/guides/clickhouse/concepts/clickhouseopsrequest.md)
+- [ClickHouseRotateAuth](/docs/guides/clickhouse/rotate-auth/overview.md)
+- [ClickHouseReconfigureTLS](/docs/guides/clickhouse/tls/overview.md)
+- [ClickHouseUpdateVersion](/docs/guides/clickhouse/update-version/overview.md)
+
+---
+
+## Recommendation types for ClickHouse
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to ClickHouse
+
+This section shows the minimal ClickHouse CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: ClickHouse
+metadata:
+  name: clickhouse-recommendation
+  namespace: demo
+spec:
+  version: "24.4.1"
+  authSecret:
+    kind: Secret
+    name: clickhouse-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: ClickHouse
+metadata:
+  name: clickhouse-recommendation
+  namespace: demo
+spec:
+  version: "24.4.1"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: clickhouse-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: ClickHouse
+metadata:
+  name: clickhouse-recommendation
+  namespace: demo
+spec:
+  version: "24.4.1"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `24.4.1` to `24.4.2`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: ClickHouse
+metadata:
+  name: clickhouse-recommendation
+  namespace: demo
+spec:
+  version: "24.4.1"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/clickhouse/recommendation/recommendation.md
+++ b/docs/guides/clickhouse/recommendation/recommendation.md
@@ -155,7 +155,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `24.4.1` to `24.4.2`
+For example: Recommending version update from `24.4.1` to `25.12.3`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/druid/recommendation/_index.md
+++ b/docs/guides/druid/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: Druid Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: druid-recommendation
+    name: Recommendation
+    parent: guides-druid
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/druid/recommendation/recommendation.md
+++ b/docs/guides/druid/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: Druid Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: druid-recommendation-overview
+    name: Recommendation Overview
+    parent: druid-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Druid Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a Druid instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `DruidOpsRequest` and tracks it to completion.
+
+This page is the **Druid-specific intro**: which recommendations apply to Druid and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [DruidOpsRequest](/docs/guides/druid/concepts/druidopsrequest.md)
+- [DruidRotateAuth](/docs/guides/druid/rotate-auth/overview.md)
+- [DruidReconfigureTLS](/docs/guides/druid/tls/overview.md)
+- [DruidUpdateVersion](/docs/guides/druid/update-version/overview.md)
+
+---
+
+## Recommendation types for Druid
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to Druid
+
+This section shows the minimal Druid CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Druid
+metadata:
+  name: druid-recommendation
+  namespace: demo
+spec:
+  version: "28.0.1"
+  authSecret:
+    kind: Secret
+    name: druid-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Druid
+metadata:
+  name: druid-recommendation
+  namespace: demo
+spec:
+  version: "28.0.1"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: druid-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Druid
+metadata:
+  name: druid-recommendation
+  namespace: demo
+spec:
+  version: "28.0.1"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `28.0.1` to `28.0.2`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Druid
+metadata:
+  name: druid-recommendation
+  namespace: demo
+spec:
+  version: "28.0.1"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/druid/recommendation/recommendation.md
+++ b/docs/guides/druid/recommendation/recommendation.md
@@ -65,6 +65,10 @@ metadata:
   namespace: demo
 spec:
   version: "28.0.1"
+  deepStorage:
+    type: s3
+    configSecret:
+      name: deep-storage-config
   authSecret:
     kind: Secret
     name: druid-auth
@@ -99,6 +103,10 @@ metadata:
   namespace: demo
 spec:
   version: "28.0.1"
+  deepStorage:
+    type: s3
+    configSecret:
+      name: deep-storage-config
   tls:
     issuerRef:
       apiGroup: cert-manager.io
@@ -139,6 +147,10 @@ metadata:
   namespace: demo
 spec:
   version: "28.0.1"
+  deepStorage:
+    type: s3
+    configSecret:
+      name: deep-storage-config
 ```
 
 In this configuration:
@@ -175,6 +187,10 @@ metadata:
   namespace: demo
 spec:
   version: "28.0.1"
+  deepStorage:
+    type: s3
+    configSecret:
+      name: deep-storage-config
 ```
 
 In this configuration:

--- a/docs/guides/druid/recommendation/recommendation.md
+++ b/docs/guides/druid/recommendation/recommendation.md
@@ -167,7 +167,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `28.0.1` to `36.0.0`
+For example: Recommending version update from `28.0.1` to `30.0.1`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/druid/recommendation/recommendation.md
+++ b/docs/guides/druid/recommendation/recommendation.md
@@ -167,7 +167,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `28.0.1` to `28.0.2`
+For example: Recommending version update from `28.0.1` to `36.0.0`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/hazelcast/recommendation/_index.md
+++ b/docs/guides/hazelcast/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: Hazelcast Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: hazelcast-recommendation
+    name: Recommendation
+    parent: hz-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hazelcast/recommendation/recommendation.md
+++ b/docs/guides/hazelcast/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: Hazelcast Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: hazelcast-recommendation-overview
+    name: Recommendation Overview
+    parent: hazelcast-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Hazelcast Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a Hazelcast instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `HazelcastOpsRequest` and tracks it to completion.
+
+This page is the **Hazelcast-specific intro**: which recommendations apply to Hazelcast and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [HazelcastOpsRequest](/docs/guides/hazelcast/concepts/hazelcast-opsrequest.md)
+- [HazelcastRotateAuth](/docs/guides/hazelcast/rotate-auth/overview.md)
+- [HazelcastReconfigureTLS](/docs/guides/hazelcast/tls/overview.md)
+- [HazelcastUpdateVersion](/docs/guides/hazelcast/update-version/overview.md)
+
+---
+
+## Recommendation types for Hazelcast
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to Hazelcast
+
+This section shows the minimal Hazelcast CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Hazelcast
+metadata:
+  name: hazelcast-recommendation
+  namespace: demo
+spec:
+  version: "5.5.2"
+  authSecret:
+    kind: Secret
+    name: hazelcast-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Hazelcast
+metadata:
+  name: hazelcast-recommendation
+  namespace: demo
+spec:
+  version: "5.5.2"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: hazelcast-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Hazelcast
+metadata:
+  name: hazelcast-recommendation
+  namespace: demo
+spec:
+  version: "5.5.2"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `5.5.2` to `5.5.3`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Hazelcast
+metadata:
+  name: hazelcast-recommendation
+  namespace: demo
+spec:
+  version: "5.5.2"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/hazelcast/recommendation/recommendation.md
+++ b/docs/guides/hazelcast/recommendation/recommendation.md
@@ -155,7 +155,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `5.5.2` to `5.5.3`
+For example: Recommending version update from `5.5.2` to `5.5.6`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/kafka/recommendation/_index.md
+++ b/docs/guides/kafka/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: Kafka Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: kafka-recommendation
+    name: Recommendation
+    parent: kf-kafka-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/kafka/recommendation/recommendation.md
+++ b/docs/guides/kafka/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: Kafka Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: kafka-recommendation-overview
+    name: Recommendation Overview
+    parent: kafka-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Kafka Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a Kafka instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `KafkaOpsRequest` and tracks it to completion.
+
+This page is the **Kafka-specific intro**: which recommendations apply to Kafka and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [KafkaOpsRequest](/docs/guides/kafka/concepts/kafkaopsrequest.md)
+- [KafkaRotateAuth](/docs/guides/kafka/rotate-auth/overview.md)
+- [KafkaReconfigureTLS](/docs/guides/kafka/tls/overview.md)
+- [KafkaUpdateVersion](/docs/guides/kafka/update-version/overview.md)
+
+---
+
+## Recommendation types for Kafka
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to Kafka
+
+This section shows the minimal Kafka CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Kafka
+metadata:
+  name: kafka-recommendation
+  namespace: demo
+spec:
+  version: "4.0.0"
+  authSecret:
+    kind: Secret
+    name: kafka-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Kafka
+metadata:
+  name: kafka-recommendation
+  namespace: demo
+spec:
+  version: "4.0.0"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: kafka-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Kafka
+metadata:
+  name: kafka-recommendation
+  namespace: demo
+spec:
+  version: "4.0.0"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `4.0.0` to `4.0.1`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Kafka
+metadata:
+  name: kafka-recommendation
+  namespace: demo
+spec:
+  version: "4.0.0"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/kafka/recommendation/recommendation.md
+++ b/docs/guides/kafka/recommendation/recommendation.md
@@ -155,7 +155,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `4.0.0` to `4.0.1`
+For example: Recommending version update from `4.0.0` to `4.2.0`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/mariadb/recommendation/_index.md
+++ b/docs/guides/mariadb/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: MariaDB Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: mariadb-recommendation
+    name: Recommendation
+    parent: guides-mariadb
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/mariadb/recommendation/recommendation.md
+++ b/docs/guides/mariadb/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: MariaDB Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: mariadb-recommendation-overview
+    name: Recommendation Overview
+    parent: mariadb-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# MariaDB Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a MariaDB instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `MariaDBOpsRequest` and tracks it to completion.
+
+This page is the **MariaDB-specific intro**: which recommendations apply to MariaDB and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [MariaDBOpsRequest](/docs/guides/mariadb/concepts/opsrequest/index.md)
+- [MariaDBRotateAuth](/docs/guides/mariadb/rotate-auth/overview.md)
+- [MariaDBReconfigureTLS](/docs/guides/mariadb/tls/overview/index.md)
+- [MariaDBUpdateVersion](/docs/guides/mariadb/update-version/overview/index.md)
+
+---
+
+## Recommendation types for MariaDB
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to MariaDB
+
+This section shows the minimal MariaDB CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: MariaDB
+metadata:
+  name: mariadb-recommendation
+  namespace: demo
+spec:
+  version: "10.5.23"
+  authSecret:
+    kind: Secret
+    name: mariadb-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: MariaDB
+metadata:
+  name: mariadb-recommendation
+  namespace: demo
+spec:
+  version: "10.5.23"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: mariadb-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: MariaDB
+metadata:
+  name: mariadb-recommendation
+  namespace: demo
+spec:
+  version: "10.5.23"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `10.5.23` to `10.5.24`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: MariaDB
+metadata:
+  name: mariadb-recommendation
+  namespace: demo
+spec:
+  version: "10.5.23"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/mariadb/recommendation/recommendation.md
+++ b/docs/guides/mariadb/recommendation/recommendation.md
@@ -155,7 +155,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `10.5.23` to `10.5.24`
+For example: Recommending version update from `10.5.23` to `10.6.16`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/memcached/recommendation/_index.md
+++ b/docs/guides/memcached/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: Memcached Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: memcached-recommendation
+    name: Recommendation
+    parent: mc-memcached-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/memcached/recommendation/recommendation.md
+++ b/docs/guides/memcached/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: Memcached Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: memcached-recommendation-overview
+    name: Recommendation Overview
+    parent: memcached-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Memcached Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a Memcached instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `MemcachedOpsRequest` and tracks it to completion.
+
+This page is the **Memcached-specific intro**: which recommendations apply to Memcached and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [MemcachedOpsRequest](/docs/guides/memcached/concepts/memcached-opsrequest.md)
+- [MemcachedRotateAuth](/docs/guides/memcached/rotate-auth/overview.md)
+- [MemcachedReconfigureTLS](/docs/guides/memcached/tls/overview.md)
+- [MemcachedUpdateVersion](/docs/guides/memcached/update-version/overview.md)
+
+---
+
+## Recommendation types for Memcached
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to Memcached
+
+This section shows the minimal Memcached CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Memcached
+metadata:
+  name: memcached-recommendation
+  namespace: demo
+spec:
+  version: "1.6.22"
+  authSecret:
+    kind: Secret
+    name: memcached-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Memcached
+metadata:
+  name: memcached-recommendation
+  namespace: demo
+spec:
+  version: "1.6.22"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: memcached-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Memcached
+metadata:
+  name: memcached-recommendation
+  namespace: demo
+spec:
+  version: "1.6.22"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `1.6.22` to `1.6.23`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Memcached
+metadata:
+  name: memcached-recommendation
+  namespace: demo
+spec:
+  version: "1.6.22"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/memcached/recommendation/recommendation.md
+++ b/docs/guides/memcached/recommendation/recommendation.md
@@ -155,7 +155,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `1.6.22` to `1.6.23`
+For example: Recommending version update from `1.6.22` to `1.6.29`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/mssqlserver/recommendation/_index.md
+++ b/docs/guides/mssqlserver/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: MSSQLServer Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: mssqlserver-recommendation
+    name: Recommendation
+    parent: guides-mssqlserver
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/mssqlserver/recommendation/recommendation.md
+++ b/docs/guides/mssqlserver/recommendation/recommendation.md
@@ -65,6 +65,12 @@ metadata:
   namespace: demo
 spec:
   version: "2022-cu12"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: mssqlserver-ca-issuer
+    clientTLS: false
   authSecret:
     kind: Secret
     name: mssqlserver-auth
@@ -139,6 +145,12 @@ metadata:
   namespace: demo
 spec:
   version: "2022-cu12"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: mssqlserver-ca-issuer
+    clientTLS: false
 ```
 
 In this configuration:
@@ -175,6 +187,12 @@ metadata:
   namespace: demo
 spec:
   version: "2022-cu12"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: mssqlserver-ca-issuer
+    clientTLS: false
 ```
 
 In this configuration:

--- a/docs/guides/mssqlserver/recommendation/recommendation.md
+++ b/docs/guides/mssqlserver/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: MSSQLServer Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: mssqlserver-recommendation-overview
+    name: Recommendation Overview
+    parent: mssqlserver-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# MSSQLServer Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a MSSQLServer instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `MSSQLServerOpsRequest` and tracks it to completion.
+
+This page is the **MSSQLServer-specific intro**: which recommendations apply to MSSQLServer and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [MSSQLServerOpsRequest](/docs/guides/mssqlserver/concepts/opsrequest.md)
+- [MSSQLServerRotateAuth](/docs/guides/mssqlserver/rotate-auth/overview.md)
+- [MSSQLServerReconfigureTLS](/docs/guides/mssqlserver/tls/overview.md)
+- [MSSQLServerUpdateVersion](/docs/guides/mssqlserver/update-version/overview.md)
+
+---
+
+## Recommendation types for MSSQLServer
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to MSSQLServer
+
+This section shows the minimal MSSQLServer CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: MSSQLServer
+metadata:
+  name: mssqlserver-recommendation
+  namespace: demo
+spec:
+  version: "2022-cu12"
+  authSecret:
+    kind: Secret
+    name: mssqlserver-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: MSSQLServer
+metadata:
+  name: mssqlserver-recommendation
+  namespace: demo
+spec:
+  version: "2022-cu12"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: mssqlserver-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: MSSQLServer
+metadata:
+  name: mssqlserver-recommendation
+  namespace: demo
+spec:
+  version: "2022-cu12"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `2022-cu12` to `2022-cu14`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: MSSQLServer
+metadata:
+  name: mssqlserver-recommendation
+  namespace: demo
+spec:
+  version: "2022-cu12"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/mysql/recommendation/_index.md
+++ b/docs/guides/mysql/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: MySQL Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: mysql-recommendation
+    name: Recommendation
+    parent: guides-mysql
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/mysql/recommendation/recommendation.md
+++ b/docs/guides/mysql/recommendation/recommendation.md
@@ -155,7 +155,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `8.4.8` to `8.4.9`
+For example: Recommending version update from `8.4.8` to `9.0.1`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/mysql/recommendation/recommendation.md
+++ b/docs/guides/mysql/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: MySQL Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: mysql-recommendation-overview
+    name: Recommendation Overview
+    parent: mysql-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# MySQL Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a MySQL instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `MySQLOpsRequest` and tracks it to completion.
+
+This page is the **MySQL-specific intro**: which recommendations apply to MySQL and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [MySQLOpsRequest](/docs/guides/mysql/concepts/opsrequest/index.md)
+- [MySQLRotateAuth](/docs/guides/mysql/rotate-auth/overview.md)
+- [MySQLReconfigureTLS](/docs/guides/mysql/tls/overview/index.md)
+- [MySQLUpdateVersion](/docs/guides/mysql/update-version/overview/index.md)
+
+---
+
+## Recommendation types for MySQL
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to MySQL
+
+This section shows the minimal MySQL CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: MySQL
+metadata:
+  name: mysql-recommendation
+  namespace: demo
+spec:
+  version: "8.4.8"
+  authSecret:
+    kind: Secret
+    name: mysql-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: MySQL
+metadata:
+  name: mysql-recommendation
+  namespace: demo
+spec:
+  version: "8.4.8"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: mysql-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: MySQL
+metadata:
+  name: mysql-recommendation
+  namespace: demo
+spec:
+  version: "8.4.8"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `8.4.8` to `8.4.9`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: MySQL
+metadata:
+  name: mysql-recommendation
+  namespace: demo
+spec:
+  version: "8.4.8"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/neo4j/recommendation/_index.md
+++ b/docs/guides/neo4j/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: Neo4j Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: neo4j-recommendation
+    name: Recommendation
+    parent: neo4j-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/neo4j/recommendation/recommendation.md
+++ b/docs/guides/neo4j/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: Neo4j Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: neo4j-recommendation-overview
+    name: Recommendation Overview
+    parent: neo4j-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Neo4j Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a Neo4j instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `Neo4jOpsRequest` and tracks it to completion.
+
+This page is the **Neo4j-specific intro**: which recommendations apply to Neo4j and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [Neo4jOpsRequest](/docs/guides/neo4j/concepts/opsrequest.md)
+- [Neo4jRotateAuth](/docs/guides/neo4j/rotate-auth/overview.md)
+- [Neo4jReconfigureTLS](/docs/guides/neo4j/tls/overview/index.md)
+- [Neo4jUpdateVersion](/docs/guides/neo4j/update-version/overview.md)
+
+---
+
+## Recommendation types for Neo4j
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to Neo4j
+
+This section shows the minimal Neo4j CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Neo4j
+metadata:
+  name: neo4j-recommendation
+  namespace: demo
+spec:
+  version: "2025.12.1"
+  authSecret:
+    kind: Secret
+    name: neo4j-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Neo4j
+metadata:
+  name: neo4j-recommendation
+  namespace: demo
+spec:
+  version: "2025.12.1"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: neo4j-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Neo4j
+metadata:
+  name: neo4j-recommendation
+  namespace: demo
+spec:
+  version: "2025.12.1"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `2025.12.1` to `2025.12.2`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Neo4j
+metadata:
+  name: neo4j-recommendation
+  namespace: demo
+spec:
+  version: "2025.12.1"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/percona-xtradb/recommendation/_index.md
+++ b/docs/guides/percona-xtradb/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: PerconaXtraDB Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: percona-xtradb-recommendation
+    name: Recommendation
+    parent: guides-perconaxtradb
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/percona-xtradb/recommendation/recommendation.md
+++ b/docs/guides/percona-xtradb/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: PerconaXtraDB Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: percona-xtradb-recommendation-overview
+    name: Recommendation Overview
+    parent: percona-xtradb-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# PerconaXtraDB Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a PerconaXtraDB instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `PerconaXtraDBOpsRequest` and tracks it to completion.
+
+This page is the **PerconaXtraDB-specific intro**: which recommendations apply to PerconaXtraDB and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [PerconaXtraDBOpsRequest](/docs/guides/percona-xtradb/concepts/opsrequest/index.md)
+- [PerconaXtraDBRotateAuth](/docs/guides/percona-xtradb/rotateauth/overview.md)
+- [PerconaXtraDBReconfigureTLS](/docs/guides/percona-xtradb/tls/overview/index.md)
+- [PerconaXtraDBUpdateVersion](/docs/guides/percona-xtradb/update-version/overview/index.md)
+
+---
+
+## Recommendation types for PerconaXtraDB
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to PerconaXtraDB
+
+This section shows the minimal PerconaXtraDB CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: PerconaXtraDB
+metadata:
+  name: percona-xtradb-recommendation
+  namespace: demo
+spec:
+  version: "8.0.40"
+  authSecret:
+    kind: Secret
+    name: percona-xtradb-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: PerconaXtraDB
+metadata:
+  name: percona-xtradb-recommendation
+  namespace: demo
+spec:
+  version: "8.0.40"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: percona-xtradb-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: PerconaXtraDB
+metadata:
+  name: percona-xtradb-recommendation
+  namespace: demo
+spec:
+  version: "8.0.40"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `8.0.40` to `8.0.41`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: PerconaXtraDB
+metadata:
+  name: percona-xtradb-recommendation
+  namespace: demo
+spec:
+  version: "8.0.40"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/percona-xtradb/recommendation/recommendation.md
+++ b/docs/guides/percona-xtradb/recommendation/recommendation.md
@@ -155,7 +155,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `8.0.40` to `8.0.41`
+For example: Recommending version update from `8.0.40` to `8.4.3`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/pgbouncer/recommendation/_index.md
+++ b/docs/guides/pgbouncer/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: PgBouncer Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: pgbouncer-recommendation
+    name: Recommendation
+    parent: pb-pgbouncer-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/pgbouncer/recommendation/recommendation.md
+++ b/docs/guides/pgbouncer/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: PgBouncer Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: pgbouncer-recommendation-overview
+    name: Recommendation Overview
+    parent: pgbouncer-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# PgBouncer Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a PgBouncer instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `PgBouncerOpsRequest` and tracks it to completion.
+
+This page is the **PgBouncer-specific intro**: which recommendations apply to PgBouncer and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [PgBouncerOpsRequest](/docs/guides/pgbouncer/concepts/opsrequest.md)
+- [PgBouncerRotateAuth](/docs/guides/pgbouncer/rotateauth/overview.md)
+- [PgBouncerReconfigureTLS](/docs/guides/pgbouncer/tls/overview.md)
+- [PgBouncerUpdateVersion](/docs/guides/pgbouncer/update-version/overview.md)
+
+---
+
+## Recommendation types for PgBouncer
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to PgBouncer
+
+This section shows the minimal PgBouncer CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: PgBouncer
+metadata:
+  name: pgbouncer-recommendation
+  namespace: demo
+spec:
+  version: "1.18.0"
+  authSecret:
+    kind: Secret
+    name: pgbouncer-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: PgBouncer
+metadata:
+  name: pgbouncer-recommendation
+  namespace: demo
+spec:
+  version: "1.18.0"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: pgbouncer-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: PgBouncer
+metadata:
+  name: pgbouncer-recommendation
+  namespace: demo
+spec:
+  version: "1.18.0"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `1.18.0` to `1.18.1`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: PgBouncer
+metadata:
+  name: pgbouncer-recommendation
+  namespace: demo
+spec:
+  version: "1.18.0"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/pgbouncer/recommendation/recommendation.md
+++ b/docs/guides/pgbouncer/recommendation/recommendation.md
@@ -65,6 +65,12 @@ metadata:
   namespace: demo
 spec:
   version: "1.18.0"
+  database:
+    syncUsers: true
+    databaseName: "postgres"
+    databaseRef:
+      name: "quick-postgres"
+      namespace: demo
   authSecret:
     kind: Secret
     name: pgbouncer-auth
@@ -99,6 +105,12 @@ metadata:
   namespace: demo
 spec:
   version: "1.18.0"
+  database:
+    syncUsers: true
+    databaseName: "postgres"
+    databaseRef:
+      name: "quick-postgres"
+      namespace: demo
   tls:
     issuerRef:
       apiGroup: cert-manager.io
@@ -139,6 +151,12 @@ metadata:
   namespace: demo
 spec:
   version: "1.18.0"
+  database:
+    syncUsers: true
+    databaseName: "postgres"
+    databaseRef:
+      name: "quick-postgres"
+      namespace: demo
 ```
 
 In this configuration:
@@ -175,6 +193,12 @@ metadata:
   namespace: demo
 spec:
   version: "1.18.0"
+  database:
+    syncUsers: true
+    databaseName: "postgres"
+    databaseRef:
+      name: "quick-postgres"
+      namespace: demo
 ```
 
 In this configuration:

--- a/docs/guides/pgbouncer/recommendation/recommendation.md
+++ b/docs/guides/pgbouncer/recommendation/recommendation.md
@@ -173,7 +173,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `1.18.0` to `1.18.1`
+For example: Recommending version update from `1.18.0` to `1.23.1`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/pgpool/recommendation/_index.md
+++ b/docs/guides/pgpool/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: Pgpool Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: pgpool-recommendation
+    name: Recommendation
+    parent: pp-pgpool-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/pgpool/recommendation/recommendation.md
+++ b/docs/guides/pgpool/recommendation/recommendation.md
@@ -164,7 +164,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `4.5.0` to `4.5.1`
+For example: Recommending version update from `4.5.0` to `4.5.3`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/pgpool/recommendation/recommendation.md
+++ b/docs/guides/pgpool/recommendation/recommendation.md
@@ -65,6 +65,9 @@ metadata:
   namespace: demo
 spec:
   version: "4.5.0"
+  postgresRef:
+    name: quick-postgres
+    namespace: demo
   authSecret:
     kind: Secret
     name: pgpool-auth
@@ -99,6 +102,9 @@ metadata:
   namespace: demo
 spec:
   version: "4.5.0"
+  postgresRef:
+    name: quick-postgres
+    namespace: demo
   tls:
     issuerRef:
       apiGroup: cert-manager.io
@@ -139,6 +145,9 @@ metadata:
   namespace: demo
 spec:
   version: "4.5.0"
+  postgresRef:
+    name: quick-postgres
+    namespace: demo
 ```
 
 In this configuration:
@@ -175,6 +184,9 @@ metadata:
   namespace: demo
 spec:
   version: "4.5.0"
+  postgresRef:
+    name: quick-postgres
+    namespace: demo
 ```
 
 In this configuration:

--- a/docs/guides/pgpool/recommendation/recommendation.md
+++ b/docs/guides/pgpool/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: Pgpool Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: pgpool-recommendation-overview
+    name: Recommendation Overview
+    parent: pgpool-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Pgpool Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a Pgpool instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `PgpoolOpsRequest` and tracks it to completion.
+
+This page is the **Pgpool-specific intro**: which recommendations apply to Pgpool and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [PgpoolOpsRequest](/docs/guides/pgpool/concepts/opsrequest.md)
+- [PgpoolRotateAuth](/docs/guides/pgpool/rotateauth/overview.md)
+- [PgpoolReconfigureTLS](/docs/guides/pgpool/tls/overview.md)
+- [PgpoolUpdateVersion](/docs/guides/pgpool/update-version/overview.md)
+
+---
+
+## Recommendation types for Pgpool
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to Pgpool
+
+This section shows the minimal Pgpool CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Pgpool
+metadata:
+  name: pgpool-recommendation
+  namespace: demo
+spec:
+  version: "4.5.0"
+  authSecret:
+    kind: Secret
+    name: pgpool-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Pgpool
+metadata:
+  name: pgpool-recommendation
+  namespace: demo
+spec:
+  version: "4.5.0"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: pgpool-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Pgpool
+metadata:
+  name: pgpool-recommendation
+  namespace: demo
+spec:
+  version: "4.5.0"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `4.5.0` to `4.5.1`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Pgpool
+metadata:
+  name: pgpool-recommendation
+  namespace: demo
+spec:
+  version: "4.5.0"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/postgres/recommendation/_index.md
+++ b/docs/guides/postgres/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: Postgres Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: postgres-recommendation
+    name: Recommendation
+    parent: pg-postgres-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/postgres/recommendation/recommendation.md
+++ b/docs/guides/postgres/recommendation/recommendation.md
@@ -155,7 +155,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `13.13` to `13.16`
+For example: Recommending version update from `13.13` to `13.18`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/postgres/recommendation/recommendation.md
+++ b/docs/guides/postgres/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: Postgres Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: postgres-recommendation-overview
+    name: Recommendation Overview
+    parent: postgres-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Postgres Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a Postgres instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `PostgresOpsRequest` and tracks it to completion.
+
+This page is the **Postgres-specific intro**: which recommendations apply to Postgres and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [PostgresOpsRequest](/docs/guides/postgres/concepts/opsrequest.md)
+- [PostgresRotateAuth](/docs/guides/postgres/rotate-authentication/overview.md)
+- [PostgresReconfigureTLS](/docs/guides/postgres/tls/overview/index.md)
+- [PostgresUpdateVersion](/docs/guides/postgres/update-version/overview/index.md)
+
+---
+
+## Recommendation types for Postgres
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to Postgres
+
+This section shows the minimal Postgres CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Postgres
+metadata:
+  name: postgres-recommendation
+  namespace: demo
+spec:
+  version: "13.13"
+  authSecret:
+    kind: Secret
+    name: postgres-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Postgres
+metadata:
+  name: postgres-recommendation
+  namespace: demo
+spec:
+  version: "13.13"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: postgres-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Postgres
+metadata:
+  name: postgres-recommendation
+  namespace: demo
+spec:
+  version: "13.13"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `13.13` to `13.16`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Postgres
+metadata:
+  name: postgres-recommendation
+  namespace: demo
+spec:
+  version: "13.13"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/proxysql/recommendation/_index.md
+++ b/docs/guides/proxysql/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: ProxySQL Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: proxysql-recommendation
+    name: Recommendation
+    parent: guides-proxysql
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/proxysql/recommendation/recommendation.md
+++ b/docs/guides/proxysql/recommendation/recommendation.md
@@ -119,7 +119,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `2.4.4-debian` to `2.6.6-debian`
+For example: Recommending version update from `2.4.4-debian` to `2.6.3-debian`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/proxysql/recommendation/recommendation.md
+++ b/docs/guides/proxysql/recommendation/recommendation.md
@@ -1,0 +1,162 @@
+---
+title: ProxySQL Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: proxysql-recommendation-overview
+    name: Recommendation Overview
+    parent: proxysql-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# ProxySQL Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a ProxySQL instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `ProxySQLOpsRequest` and tracks it to completion.
+
+This page is the **ProxySQL-specific intro**: which recommendations apply to ProxySQL and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [ProxySQLOpsRequest](/docs/guides/proxysql/concepts/opsrequest/index.md)
+- [ProxySQLReconfigureTLS](/docs/guides/proxysql/tls/overview/index.md)
+- [ProxySQLUpdateVersion](/docs/guides/proxysql/update-version/overview/index.md)
+
+---
+
+## Recommendation types for ProxySQL
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+
+---
+
+## Triggers specific to ProxySQL
+
+This section shows the minimal ProxySQL CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: ProxySQL
+metadata:
+  name: proxysql-recommendation
+  namespace: demo
+spec:
+  version: "2.4.4-debian"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: proxysql-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: ProxySQL
+metadata:
+  name: proxysql-recommendation
+  namespace: demo
+spec:
+  version: "2.4.4-debian"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `2.4.4-debian` to `2.6.6-debian`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: ProxySQL
+metadata:
+  name: proxysql-recommendation
+  namespace: demo
+spec:
+  version: "2.4.4-debian"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/qdrant/recommendation/_index.md
+++ b/docs/guides/qdrant/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: Qdrant Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: qdrant-recommendation
+    name: Recommendation
+    parent: qdrant-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/qdrant/recommendation/recommendation.md
+++ b/docs/guides/qdrant/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: Qdrant Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: qdrant-recommendation-overview
+    name: Recommendation Overview
+    parent: qdrant-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Qdrant Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a Qdrant instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `QdrantOpsRequest` and tracks it to completion.
+
+This page is the **Qdrant-specific intro**: which recommendations apply to Qdrant and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [QdrantOpsRequest](/docs/guides/qdrant/concepts/opsrequest.md)
+- [QdrantRotateAuth](/docs/guides/qdrant/rotate-auth/overview.md)
+- [QdrantReconfigureTLS](/docs/guides/qdrant/tls/overview.md)
+- [QdrantUpdateVersion](/docs/guides/qdrant/update-version/overview.md)
+
+---
+
+## Recommendation types for Qdrant
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to Qdrant
+
+This section shows the minimal Qdrant CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Qdrant
+metadata:
+  name: qdrant-recommendation
+  namespace: demo
+spec:
+  version: "1.17.0"
+  authSecret:
+    kind: Secret
+    name: qdrant-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Qdrant
+metadata:
+  name: qdrant-recommendation
+  namespace: demo
+spec:
+  version: "1.17.0"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: qdrant-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Qdrant
+metadata:
+  name: qdrant-recommendation
+  namespace: demo
+spec:
+  version: "1.17.0"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `1.17.0` to `1.17.1`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Qdrant
+metadata:
+  name: qdrant-recommendation
+  namespace: demo
+spec:
+  version: "1.17.0"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/rabbitmq/recommendation/_index.md
+++ b/docs/guides/rabbitmq/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: RabbitMQ Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: rabbitmq-recommendation
+    name: Recommendation
+    parent: rm-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/rabbitmq/recommendation/recommendation.md
+++ b/docs/guides/rabbitmq/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: RabbitMQ Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: rabbitmq-recommendation-overview
+    name: Recommendation Overview
+    parent: rabbitmq-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# RabbitMQ Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a RabbitMQ instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `RabbitMQOpsRequest` and tracks it to completion.
+
+This page is the **RabbitMQ-specific intro**: which recommendations apply to RabbitMQ and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [RabbitMQOpsRequest](/docs/guides/rabbitmq/concepts/opsrequest.md)
+- [RabbitMQRotateAuth](/docs/guides/rabbitmq/rotate-auth/overview.md)
+- [RabbitMQReconfigureTLS](/docs/guides/rabbitmq/tls/overview.md)
+- [RabbitMQUpdateVersion](/docs/guides/rabbitmq/update-version/overview.md)
+
+---
+
+## Recommendation types for RabbitMQ
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to RabbitMQ
+
+This section shows the minimal RabbitMQ CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: RabbitMQ
+metadata:
+  name: rabbitmq-recommendation
+  namespace: demo
+spec:
+  version: "3.13.2"
+  authSecret:
+    kind: Secret
+    name: rabbitmq-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: RabbitMQ
+metadata:
+  name: rabbitmq-recommendation
+  namespace: demo
+spec:
+  version: "3.13.2"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: rabbitmq-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: RabbitMQ
+metadata:
+  name: rabbitmq-recommendation
+  namespace: demo
+spec:
+  version: "3.13.2"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `3.13.2` to `3.13.3`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: RabbitMQ
+metadata:
+  name: rabbitmq-recommendation
+  namespace: demo
+spec:
+  version: "3.13.2"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/rabbitmq/recommendation/recommendation.md
+++ b/docs/guides/rabbitmq/recommendation/recommendation.md
@@ -155,7 +155,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `3.13.2` to `3.13.3`
+For example: Recommending version update from `3.13.2` to `4.0.4`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/redis/recommendation/_index.md
+++ b/docs/guides/redis/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: Redis Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: redis-recommendation
+    name: Recommendation
+    parent: rd-redis-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/redis/recommendation/recommendation.md
+++ b/docs/guides/redis/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: Redis Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: redis-recommendation-overview
+    name: Recommendation Overview
+    parent: redis-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Redis Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a Redis instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `RedisOpsRequest` and tracks it to completion.
+
+This page is the **Redis-specific intro**: which recommendations apply to Redis and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [RedisOpsRequest](/docs/guides/redis/concepts/redisopsrequest.md)
+- [RedisRotateAuth](/docs/guides/redis/rotateauth/overview.md)
+- [RedisReconfigureTLS](/docs/guides/redis/tls/overview.md)
+- [RedisUpdateVersion](/docs/guides/redis/update-version/overview.md)
+
+---
+
+## Recommendation types for Redis
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to Redis
+
+This section shows the minimal Redis CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Redis
+metadata:
+  name: redis-recommendation
+  namespace: demo
+spec:
+  version: "6.2.14"
+  authSecret:
+    kind: Secret
+    name: redis-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Redis
+metadata:
+  name: redis-recommendation
+  namespace: demo
+spec:
+  version: "6.2.14"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: redis-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Redis
+metadata:
+  name: redis-recommendation
+  namespace: demo
+spec:
+  version: "6.2.14"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `6.2.14` to `6.2.16`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1
+kind: Redis
+metadata:
+  name: redis-recommendation
+  namespace: demo
+spec:
+  version: "6.2.14"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/singlestore/recommendation/_index.md
+++ b/docs/guides/singlestore/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: Singlestore Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: singlestore-recommendation
+    name: Recommendation
+    parent: guides-singlestore
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/singlestore/recommendation/recommendation.md
+++ b/docs/guides/singlestore/recommendation/recommendation.md
@@ -64,6 +64,7 @@ metadata:
 spec:
   version: "8.5.7"
   licenseSecret:
+    kind: Secret
     name: license-secret
   tls:
     issuerRef:
@@ -106,6 +107,7 @@ metadata:
 spec:
   version: "8.5.7"
   licenseSecret:
+    kind: Secret
     name: license-secret
 ```
 
@@ -144,6 +146,7 @@ metadata:
 spec:
   version: "8.5.7"
   licenseSecret:
+    kind: Secret
     name: license-secret
 ```
 

--- a/docs/guides/singlestore/recommendation/recommendation.md
+++ b/docs/guides/singlestore/recommendation/recommendation.md
@@ -125,7 +125,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `8.5.7` to `8.5.8`
+For example: Recommending version update from `8.5.7` to `8.7.10`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 

--- a/docs/guides/singlestore/recommendation/recommendation.md
+++ b/docs/guides/singlestore/recommendation/recommendation.md
@@ -1,0 +1,162 @@
+---
+title: Singlestore Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: singlestore-recommendation-overview
+    name: Recommendation Overview
+    parent: singlestore-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Singlestore Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a Singlestore instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `SinglestoreOpsRequest` and tracks it to completion.
+
+This page is the **Singlestore-specific intro**: which recommendations apply to Singlestore and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [SinglestoreOpsRequest](/docs/guides/singlestore/concepts/opsrequest.md)
+- [SinglestoreReconfigureTLS](/docs/guides/singlestore/tls/overview/index.md)
+- [SinglestoreUpdateVersion](/docs/guides/singlestore/update-version/overview/index.md)
+
+---
+
+## Recommendation types for Singlestore
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+
+---
+
+## Triggers specific to Singlestore
+
+This section shows the minimal Singlestore CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Singlestore
+metadata:
+  name: singlestore-recommendation
+  namespace: demo
+spec:
+  version: "8.5.7"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: singlestore-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Singlestore
+metadata:
+  name: singlestore-recommendation
+  namespace: demo
+spec:
+  version: "8.5.7"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `8.5.7` to `8.5.8`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Singlestore
+metadata:
+  name: singlestore-recommendation
+  namespace: demo
+spec:
+  version: "8.5.7"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/singlestore/recommendation/recommendation.md
+++ b/docs/guides/singlestore/recommendation/recommendation.md
@@ -63,6 +63,8 @@ metadata:
   namespace: demo
 spec:
   version: "8.5.7"
+  licenseSecret:
+    name: license-secret
   tls:
     issuerRef:
       apiGroup: cert-manager.io
@@ -103,6 +105,8 @@ metadata:
   namespace: demo
 spec:
   version: "8.5.7"
+  licenseSecret:
+    name: license-secret
 ```
 
 In this configuration:
@@ -139,6 +143,8 @@ metadata:
   namespace: demo
 spec:
   version: "8.5.7"
+  licenseSecret:
+    name: license-secret
 ```
 
 In this configuration:

--- a/docs/guides/solr/recommendation/_index.md
+++ b/docs/guides/solr/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: Solr Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: solr-recommendation
+    name: Recommendation
+    parent: sl-solr-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/solr/recommendation/recommendation.md
+++ b/docs/guides/solr/recommendation/recommendation.md
@@ -1,0 +1,198 @@
+---
+title: Solr Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: solr-recommendation-overview
+    name: Recommendation Overview
+    parent: solr-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Solr Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a Solr instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `SolrOpsRequest` and tracks it to completion.
+
+This page is the **Solr-specific intro**: which recommendations apply to Solr and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [SolrOpsRequest](/docs/guides/solr/concepts/solropsrequests.md)
+- [SolrRotateAuth](/docs/guides/solr/rotateauth/overview.md)
+- [SolrReconfigureTLS](/docs/guides/solr/tls/overview.md)
+- [SolrUpdateVersion](/docs/guides/solr/update-version/overview.md)
+
+---
+
+## Recommendation types for Solr
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+| **Authentication Secret Rotation** | The auth secret is approaching its `rotateAfter` deadline                         | [Authentication Secret Rotation Recommendation](/docs/operatormanual/recommendation/rotate-auth-recommendation.md) |
+
+---
+
+## Triggers specific to Solr
+
+This section shows the minimal Solr CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### Authentication Secret Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Solr
+metadata:
+  name: solr-recommendation
+  namespace: demo
+spec:
+  version: "9.4.1"
+  authSecret:
+    kind: Secret
+    name: solr-auth
+    rotateAfter: 1h
+```
+
+In this configuration:
+
+* The `rotateAfter` field defines how long the authentication secret remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateAuth Recommendation based on the following conditions:
+
+* If the secret lifespan is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the secret lifespan is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to rotate the credentials automatically, ensuring:
+
+* No expired credentials
+
+* Improved security posture
+
+* Reduced manual intervention
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Solr
+metadata:
+  name: solr-recommendation
+  namespace: demo
+spec:
+  version: "9.4.1"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: solr-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Solr
+metadata:
+  name: solr-recommendation
+  namespace: demo
+spec:
+  version: "9.4.1"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `9.4.1` to `9.6.1`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Solr
+metadata:
+  name: solr-recommendation
+  namespace: demo
+spec:
+  version: "9.4.1"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/zookeeper/recommendation/_index.md
+++ b/docs/guides/zookeeper/recommendation/_index.md
@@ -1,0 +1,10 @@
+---
+title: ZooKeeper Recommendation
+menu:
+  docs_{{ .version }}:
+    identifier: zookeeper-recommendation
+    name: Recommendation
+    parent: zk-zookeeper-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/zookeeper/recommendation/recommendation.md
+++ b/docs/guides/zookeeper/recommendation/recommendation.md
@@ -1,0 +1,162 @@
+---
+title: ZooKeeper Recommendation Overview
+menu:
+  docs_{{ .version }}:
+    identifier: zookeeper-recommendation-overview
+    name: Recommendation Overview
+    parent: zookeeper-recommendation
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# ZooKeeper Recommendation
+
+## Overview
+
+A `Recommendation` is a Kubernetes-native CRD created by the **KubeDB Ops-Manager** and reconciled by the **KubeDB Supervisor**. For a ZooKeeper instance managed by KubeDB, the Ops-Manager watches the database's state and emits a Recommendation whenever it detects an action you should take — a newer version, an expiring TLS certificate, or an authentication secret nearing its rotation deadline.
+
+Nothing runs until the Recommendation is approved — either by you (`status.approvalStatus: Approved`) or automatically through an `ApprovalPolicy` bound to a `MaintenanceWindow`. Once approved, the Supervisor creates the corresponding `ZooKeeperOpsRequest` and tracks it to completion.
+
+This page is the **ZooKeeper-specific intro**: which recommendations apply to ZooKeeper and which spec fields trigger them. For prerequisites, Helm flags that control generation timing, and the full Recommendation lifecycle, see:
+
+- [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) — prerequisites, Supervisor CRD install, and all Helm flags.
+- [Recommendation Overview](/docs/operatormanual/recommendation) — architecture and lifecycle walkthrough.
+
+<p align="center">
+  <img alt="Recommendation Lifecycle" src="/docs/operatormanual/recommendation/images/recommendation-generation.png">
+</p>
+
+---
+
+## Relevant KubeDB concepts
+
+- [ZooKeeperOpsRequest](/docs/guides/zookeeper/concepts/opsrequest.md)
+- [ZooKeeperReconfigureTLS](/docs/guides/zookeeper/tls/overview.md)
+- [ZooKeeperUpdateVersion](/docs/guides/zookeeper/update-version/overview.md)
+
+---
+
+## Recommendation types for ZooKeeper
+
+| Type                              | Triggered when                                                                    | Walkthrough                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Version Update**                | A newer major, minor, or patch version becomes available                          | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **Same-Version Update**           | The container image for your *current* version is refreshed (e.g. security patch) | [Version Update Recommendation](/docs/operatormanual/recommendation/version-update-recommendation.md)        |
+| **TLS Certificate Rotation**      | An issued certificate is approaching its expiry threshold                         | [TLS Certificate Rotation Recommendation](/docs/operatormanual/recommendation/rotate-tls-recommendation.md)  |
+
+---
+
+## Triggers specific to ZooKeeper
+
+This section shows the minimal ZooKeeper CR fields that cause each recommendation to be generated. For deeper, end-to-end walkthroughs use the links in the table above.
+
+### TLS Certificate Rotation
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: ZooKeeper
+metadata:
+  name: zookeeper-recommendation
+  namespace: demo
+spec:
+  version: "3.9.1"
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: zookeeper-ca-issuer
+    certificates:
+      - alias: client
+        duration: 1h20m
+      - alias: server
+        duration: 2h10m
+```
+
+In this configuration:
+
+* The `spec.tls.certificates.duration` field defines how long each certificate remains valid
+
+KubeDB monitors the configured lifecycle and generates a RotateTLS Recommendation based on the following conditions:
+
+* If the certificate duration is greater than one month, a recommendation is generated when less than one month of validity remains
+
+* If the certificate duration is less than one month, a recommendation is generated when approximately one-third of its validity remains
+
+Once approved, KubeDB creates an opsrequest to reconfigure TLS automatically, ensuring:
+
+* Continuous secure communication
+
+* No unexpected certificate expiry
+
+* Seamless certificate renewal
+
+### Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: ZooKeeper
+metadata:
+  name: zookeeper-recommendation
+  namespace: demo
+spec:
+  version: "3.9.1"
+```
+
+In this configuration:
+
+* KubeDB monitors the running version of the database
+
+KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommendation based on the following conditions:
+
+* If a newer container image is available for the current version, a recommendation is generated
+
+* If a patch version is released, a recommendation is generated
+
+* If a newer minor or major version becomes available, a recommendation is generated
+
+* If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
+
+For example: Recommending version update from `3.9.1` to `3.9.2`
+
+Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
+
+* Timely adoption of security patches and fixes
+
+* Access to new features and improvements
+
+* Consistent performance and stability across deployments
+
+### Same-Version Update
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: ZooKeeper
+metadata:
+  name: zookeeper-recommendation
+  namespace: demo
+spec:
+  version: "3.9.1"
+```
+
+In this configuration:
+
+* KubeDB monitors the container image of the current database version
+
+KubeDB monitors the configured lifecycle and generates a SameVersionUpdate Recommendation based on the following conditions:
+
+* If the container image backing the current version is updated (e.g., security patches or rebuilds without a version change), a recommendation is generated
+
+Once approved, KubeDB creates an opsrequest to update the running workload automatically, ensuring:
+
+* Security patches are applied without requiring a version upgrade
+
+* Consistency with the latest available container image
+
+* Improved reliability and maintainability
+
+---
+
+For prerequisites, Helm configuration flags, and the full cross-database Recommendation lifecycle, see the [Recommendation Configuration](/docs/operatormanual/recommendation/configuration.md) and [Recommendation Overview](/docs/operatormanual/recommendation) in the operator manual.

--- a/docs/guides/zookeeper/recommendation/recommendation.md
+++ b/docs/guides/zookeeper/recommendation/recommendation.md
@@ -62,7 +62,7 @@ metadata:
   name: zookeeper-recommendation
   namespace: demo
 spec:
-  version: "3.9.1"
+  version: "3.8.3"
   tls:
     issuerRef:
       apiGroup: cert-manager.io
@@ -102,7 +102,7 @@ metadata:
   name: zookeeper-recommendation
   namespace: demo
 spec:
-  version: "3.9.1"
+  version: "3.8.3"
 ```
 
 In this configuration:
@@ -119,7 +119,7 @@ KubeDB monitors the configured lifecycle and generates a VersionUpdate Recommend
 
 * If changes are introduced in the existing version image (e.g., security fixes or image updates without a version bump), a recommendation is generated
 
-For example: Recommending version update from `3.9.1` to `3.9.2`
+For example: Recommending version update from `3.8.3` to `3.9.1`
 
 Once approved, KubeDB creates an opsrequest to perform the version upgrade automatically, ensuring:
 
@@ -138,7 +138,7 @@ metadata:
   name: zookeeper-recommendation
   namespace: demo
 spec:
-  version: "3.9.1"
+  version: "3.8.3"
 ```
 
 In this configuration:


### PR DESCRIPTION
Note: All DBs still dont have the recommendation support. 
https://github.com/kubedb/ops-manager/pulls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new recommendation guide pages for many databases, including Cassandra, ClickHouse, Druid, Hazelcast, Kafka, MariaDB, Memcached, MSSQLServer, MySQL, Neo4j, PerconaXtraDB, PgBouncer, Pgpool, Postgres, ProxySQL, Qdrant, RabbitMQ, Redis, Singlestore, Solr, and ZooKeeper.
  * Added navigation entries for each guide in the versioned docs menu.
  * Expanded each guide with recommendation overviews, approval flow details, trigger conditions, YAML examples, and links to related lifecycle/configuration references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->