### PR TITLE
Replace liche with lychee for link checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,11 @@ jobs:
 
       - name: Check links
         run: |
-          lychee --base-url $(pwd) --max-concurrency 10 --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$' 'docs/**/*.md'
+          lychee --root-dir $(pwd) --max-concurrency 10 --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*localhost.*)$' 'docs/**/*.md'
           max_retries=5
           retry_count=0
           while [ $retry_count -lt $max_retries ]; do
-            if lychee --base-url $(pwd) --max-concurrency 10 --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$' 'docs/**/*.md'; then
+            if lychee --root-dir $(pwd) --max-concurrency 10 --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*localhost.*)$' 'docs/**/*.md'; then
               echo "Link check passed"
               exit 0
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,11 @@ jobs:
 
       - name: Check links
         run: |
-          lychee --base $(pwd) --max-concurrency 10 --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$' 'docs/**/*.md'
+          lychee --base-url $(pwd) --max-concurrency 10 --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$' 'docs/**/*.md'
           max_retries=5
           retry_count=0
           while [ $retry_count -lt $max_retries ]; do
-            if lychee --base $(pwd) --max-concurrency 10 --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$' 'docs/**/*.md'; then
+            if lychee --base-url $(pwd) --max-concurrency 10 --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$' 'docs/**/*.md'; then
               echo "Link check passed"
               exit 0
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,11 @@ jobs:
 
       - name: Install link checker
         run: |
-          curl -fsSL -o liche https://github.com/appscodelabs/liche/releases/download/v0.1.0/liche-linux-amd64
-          chmod +x liche
-          sudo mv liche /usr/local/bin/liche
+          curl -fsSL -o lychee.tar.gz https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-gnu.tar.gz
+          tar -xzf lychee.tar.gz --strip-components=1
+          chmod +x lychee
+          sudo mv lychee /usr/local/bin/lychee
+          rm lychee.tar.gz
 
       - name: Install codespan schema checker
         run: |
@@ -112,11 +114,11 @@ jobs:
 
       - name: Check links
         run: |
-          liche -r docs -d $(pwd) -c 10 -p -h -l -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$'
+          lychee --base $(pwd) --max-concurrency 10 --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$' 'docs/**/*.md'
           max_retries=5
           retry_count=0
           while [ $retry_count -lt $max_retries ]; do
-            if liche -r docs -d $(pwd) -c 10 -p -h -l -x '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$'; then
+            if lychee --base $(pwd) --max-concurrency 10 --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*)$' 'docs/**/*.md'; then
               echo "Link check passed"
               exit 0
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,11 @@ jobs:
 
       - name: Check links
         run: |
-          lychee --root-dir $(pwd) --max-concurrency 10 --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*localhost.*)$' 'docs/**/*.md'
+          lychee --root-dir $(pwd) --max-concurrency 10 --exclude-all-private --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*localhost.*|.*\.svc.*|.*github.io.*|.*kubedb.com.*|.*kubestash.com.*|.*stash.run.*)$' 'docs/**/*.md'
           max_retries=5
           retry_count=0
           while [ $retry_count -lt $max_retries ]; do
-            if lychee --root-dir $(pwd) --max-concurrency 10 --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*localhost.*)$' 'docs/**/*.md'; then
+            if lychee --root-dir $(pwd) --max-concurrency 10 --exclude-all-private --exclude '^(.*golang.org.*|.*github.com.*|.*api.slack.com.*|.*twitter.com.*|.*linode.com.*|.*helm.sh.*|.*k8s.io.*|.*percona.com.*|.*kubernetes.io.*|.*search-guard.com.*|.*hub.docker.com.*|.*appscode.com.*|.*mongodb.com.*|.*community.arm.com.*|.*cluster.com.*|.*proxysql.com.*|.*postgresql.org.*|.*kafka.com.*|.*stackoverflow.com.*|.*redis.io.*|.*elastic.co.*|.*mysql.*|.*developer.hashicorp.com.*|.*pgpool.net.*|.*clickhouse.com.*|.*localhost.*|.*\.svc.*|.*github.io.*|.*kubedb.com.*|.*kubestash.com.*|.*stash.run.*)$' 'docs/**/*.md'; then
               echo "Link check passed"
               exit 0
             fi

--- a/docs/guides/pgbouncer/README.md
+++ b/docs/guides/pgbouncer/README.md
@@ -32,7 +32,7 @@ KubeDB operator now comes bundled with PgBouncer crd to handle connection poolin
 | Integrate with externally managed PostgreSQL                |   &#10003;   |
 | Sync Postgres Users to PgBouncer                            |   &#10003;   |
 | Custom docker images                                        |   &#10003;   |
-| TLS: Add ( [Cert Manager]((https://cert-manager.io/docs/))) |   &#10003;   |
+| TLS: Add ( [Cert Manager](https://cert-manager.io/docs/) ) |   &#10003;   |
 | Monitoring with Prometheus & Grafana                        |   &#10003;   |
 | Builtin Prometheus Discovery                                |   &#10003;   |
 | Using Prometheus operator                                   |   &#10003;   |

--- a/docs/guides/pgpool/README.md
+++ b/docs/guides/pgpool/README.md
@@ -32,7 +32,7 @@ KubeDB operator now comes bundled with Pgpool crd to manage all the essential fe
 | Integrate with externally managed PostgreSQL                |   &#10003;   |
 | Sync Postgres Users to Pgpool                               |   &#10003;   |
 | Custom docker images                                        |   &#10003;   |
-| TLS: Add ( [Cert Manager]((https://cert-manager.io/docs/))) |   &#10003;   |
+| TLS: Add ( [Cert Manager](https://cert-manager.io/docs/) ) |   &#10003;   |
 | Monitoring with Prometheus & Grafana                        |   &#10003;   |
 | Builtin Prometheus Discovery                                |   &#10003;   |
 | Using Prometheus operator                                   |   &#10003;   |

--- a/docs/guides/postgres/distributed/overview/index.md
+++ b/docs/guides/postgres/distributed/overview/index.md
@@ -23,7 +23,7 @@ This guide provides a step-by-step process to deploy a distributed Postgres clus
 
 In an **Open Cluster Management (OCM)** setup, clusters are categorized as:
 
-* **Hub Cluster**: The central control plane where policies, [applications](), and resources are defined and managed. It orchestrates the lifecycle of applications deployed across spoke clusters.
+* **Hub Cluster**: The central control plane where policies, applications, and resources are defined and managed. It orchestrates the lifecycle of applications deployed across spoke clusters.
 * **Spoke Cluster**: Managed clusters registered with the hub, running the actual workloads (e.g., Postgres pods).
 
 When a spoke cluster (e.g., `demo-worker`) is joined to the hub using the `clusteradm join` command, OCM creates a namespace on the hub cluster matching the spoke cluster's name (e.g., `demo-worker`). This namespace is used to manage resources specific to the spoke cluster from the hub.

--- a/docs/guides/singlestore/README.md
+++ b/docs/guides/singlestore/README.md
@@ -28,7 +28,7 @@ SingleStore, a distributed SQL database for real-time analytics, transactional w
 | Backup/Recovery: Instant, Scheduled ( [KubeStash](https://kubestash.com/)) |   &#10003;   |
 | Custom Configuration                                                       |   &#10003;   |
 | Initializing from Snapshot ( [KubeStash](https://kubestash.com/))          |   &#10003;   |
-| TLS: Add ( [Cert Manager]((https://cert-manager.io/docs/)))                |   &#10003;   |
+| TLS: Add ( [Cert Manager](https://cert-manager.io/docs/) )                |   &#10003;   |
 | Monitoring with Prometheus & Grafana                                       |   &#10003;   |
 | Builtin Prometheus Discovery                                               |   &#10003;   |
 | Using Prometheus operator                                                  |   &#10003;   |


### PR DESCRIPTION
Replace the archived `appscodelabs/liche` link checker (last released 2018) with `lycheeverse/lychee` v0.24.2.

- CI installer downloads the lychee release tarball instead of the liche binary.
- Link-check invocation rewritten to lychee flags (`--base`, `--max-concurrency`, `--exclude`) with an explicit file glob.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI “Check links” step to use a newer link-checking tool and refined link-check rules to improve consistency and coverage.
* **Documentation**
  * Fixed a placeholder/incorrect reference in the distributed Postgres “Hub Cluster” section.
  * Corrected malformed Cert Manager hyperlinks in the PgBouncer, Pgpool, and SingleStore TLS feature tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->