### PR TITLE
installation link fixed

### DIFF
--- a/docs/guides/cassandra/backup/kubestash/logical/index.md
+++ b/docs/guides/cassandra/backup/kubestash/logical/index.md
@@ -21,7 +21,7 @@ This guide will give you how you can take backup and restore your `Cassandra` da
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore Cassandra databases, please check the following guide [here](/docs/guides/cassandra/backup/kubestash/overview/index.md).
 

--- a/docs/guides/cassandra/backup/kubestash/overview/index.md
+++ b/docs/guides/cassandra/backup/kubestash/overview/index.md
@@ -12,7 +12,7 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
+{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
 
 # Cassandra Backup & Restore Overview
 

--- a/docs/guides/druid/backup/application-level/index.md
+++ b/docs/guides/druid/backup/application-level/index.md
@@ -21,7 +21,7 @@ This guide will give you how you can take application-level backup and restore y
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Now, install KubeDB cli on your workstation and KubeDB operator in your cluster following the steps [here](/docs/setup/README.md) and make sure to include the flags `--set global.featureGates.Druid=true` to ensure **Druid CRD** and `--set global.featureGates.ZooKeeper=true` to ensure **ZooKeeper CRD** as Druid depends on ZooKeeper for external dependency with helm command.
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore Druid databases, please check the following guide [here](/docs/guides/druid/backup/overview/index.md).
 

--- a/docs/guides/druid/backup/auto-backup/index.md
+++ b/docs/guides/druid/backup/auto-backup/index.md
@@ -21,7 +21,7 @@ In this tutorial, we are going to show how you can configure a backup blueprint 
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Now, install KubeDB cli on your workstation and KubeDB operator in your cluster following the steps [here](/docs/setup/README.md) and make sure to include the flags `--set global.featureGates.Druid=true` to ensure **Druid CRD** and `--set global.featureGates.ZooKeeper=true` to ensure **ZooKeeper CRD** as Druid depends on ZooKeeper for external dependency with helm command.
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore Druid databases, please check the following guide [here](/docs/guides/druid/backup/overview/index.md).
 

--- a/docs/guides/druid/backup/cross-ns-dependencies/index.md
+++ b/docs/guides/druid/backup/cross-ns-dependencies/index.md
@@ -23,7 +23,7 @@ This guide will give you how you can take [Application Level Backup](https://git
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Now, install KubeDB cli on your workstation and KubeDB operator in your cluster following the steps [here](/docs/setup/README.md) and make sure to include the flags `--set global.featureGates.Druid=true` to ensure **Druid CRD** and `--set global.featureGates.ZooKeeper=true` to ensure **ZooKeeper CRD** as Druid depends on ZooKeeper for external dependency with helm command.
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore Druid databases, please check the following guide [here](/docs/guides/druid/backup/overview/index.md).
 

--- a/docs/guides/druid/backup/logical/index.md
+++ b/docs/guides/druid/backup/logical/index.md
@@ -21,7 +21,7 @@ This guide will give you how you can take backup and restore your `Druid` databa
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Now, install KubeDB cli on your workstation and KubeDB operator in your cluster following the steps [here](/docs/setup/README.md) and make sure to include the flags `--set global.featureGates.Druid=true` to ensure **Druid CRD** and `--set global.featureGates.ZooKeeper=true` to ensure **ZooKeeper CRD** as Druid depends on ZooKeeper for external dependency with helm command.
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore Druid databases, please check the following guide [here](/docs/guides/druid/backup/overview/index.md).
 

--- a/docs/guides/druid/backup/overview/index.md
+++ b/docs/guides/druid/backup/overview/index.md
@@ -12,7 +12,7 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
+{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
 
 # Druid Backup & Restore Overview
 

--- a/docs/guides/elasticsearch/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/elasticsearch/backup/kubestash/auto-backup/index.md
@@ -21,7 +21,7 @@ In this tutorial, we are going to show how you can configure a backup blueprint 
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore `Elasticsearch` databases, please check the following guide [here](/docs/guides/elasticsearch/backup/kubestash/overview/index.md).
 

--- a/docs/guides/elasticsearch/backup/kubestash/logical/index.md
+++ b/docs/guides/elasticsearch/backup/kubestash/logical/index.md
@@ -22,7 +22,7 @@ This guide will give you an overview how you can take backup and restore your `E
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore Elasticsearch databases, please check the following guide [here](/docs/guides/elasticsearch/backup/kubestash/overview/index.md).
 

--- a/docs/guides/elasticsearch/backup/kubestash/overview/index.md
+++ b/docs/guides/elasticsearch/backup/kubestash/overview/index.md
@@ -12,7 +12,7 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
+{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
 
 # Elasticsearch Backup & Restore Overview
 

--- a/docs/guides/mariadb/backup/kubestash/application-level/index.md
+++ b/docs/guides/mariadb/backup/kubestash/application-level/index.md
@@ -21,7 +21,7 @@ This guide will give you an overview how you can take application-level backup a
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore MariaDB databases, please check the following guide [here](/docs/guides/mariadb/backup/kubestash/overview/index.md).
 

--- a/docs/guides/mariadb/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/mariadb/backup/kubestash/auto-backup/index.md
@@ -21,7 +21,7 @@ In this tutorial, we are going to show how you can configure a backup blueprint 
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore `MariaDB` databases, please check the following guide [here](/docs/guides/mariadb/backup/kubestash/overview/index.md).
 

--- a/docs/guides/mariadb/backup/kubestash/logical/index.md
+++ b/docs/guides/mariadb/backup/kubestash/logical/index.md
@@ -22,7 +22,7 @@ This guide will give you an overview how you can take backup and restore your `M
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore MariaDB databases, please check the following guide [here](/docs/guides/mariadb/backup/kubestash/overview/index.md).
 

--- a/docs/guides/mariadb/backup/kubestash/overview/index.md
+++ b/docs/guides/mariadb/backup/kubestash/overview/index.md
@@ -12,7 +12,7 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
+{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
 
 # MariaDB Backup & Restore Overview
 

--- a/docs/guides/mongodb/backup/kubestash/application-level/index.md
+++ b/docs/guides/mongodb/backup/kubestash/application-level/index.md
@@ -21,7 +21,7 @@ This guide will give you an overview how you can take application-level backup a
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore MongoDB databases, please check the following guide [here](/docs/guides/mongodb/backup/kubestash/overview/index.md).
 

--- a/docs/guides/mongodb/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/mongodb/backup/kubestash/auto-backup/index.md
@@ -21,7 +21,7 @@ In this tutorial, we are going to show how you can configure a backup blueprint 
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore `MongoDB` databases, please check the following guide [here](/docs/guides/mongodb/backup/kubestash/overview/index.md).
 

--- a/docs/guides/mongodb/backup/kubestash/logical/replicaset/index.md
+++ b/docs/guides/mongodb/backup/kubestash/logical/replicaset/index.md
@@ -19,7 +19,7 @@ KubeStash v0.1.0+ supports backup and restoration of MongoDB databases. This gui
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using Minikube.
 - Install KubeDB in your cluster following the steps [here](/docs/setup/README.md).
-- Install KubeStash Enterprise in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash/).
+- Install KubeStash Enterprise in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore MongoDB databases, please check the following guide [here](/docs/guides/mongodb/backup/kubestash/overview/index.md).
 

--- a/docs/guides/mongodb/backup/kubestash/logical/sharding/index.md
+++ b/docs/guides/mongodb/backup/kubestash/logical/sharding/index.md
@@ -19,7 +19,7 @@ KubeStash v0.1.0+ supports backup and restoration of MongoDB databases. This gui
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using Minikube.
 - Install KubeDB in your cluster following the steps [here](/docs/setup/README.md).
-- Install KubeStash Enterprise in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash/).
+- Install KubeStash Enterprise in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore MongoDB databases, please check the following guide [here](/docs/guides/mongodb/backup/kubestash/overview/index.md).
 

--- a/docs/guides/mongodb/backup/kubestash/logical/standalone/index.md
+++ b/docs/guides/mongodb/backup/kubestash/logical/standalone/index.md
@@ -19,7 +19,7 @@ KubeStash v0.1.0+ supports backup and restoration of MongoDB databases. This gui
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using Minikube.
 - Install KubeDB in your cluster following the steps [here](/docs/setup/README.md).
-- Install KubeStash Enterprise in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash/).
+- Install KubeStash Enterprise in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore MongoDB databases, please check the following guide [here](/docs/guides/mongodb/backup/kubestash/overview/index.md).
 

--- a/docs/guides/mongodb/backup/kubestash/overview/index.md
+++ b/docs/guides/mongodb/backup/kubestash/overview/index.md
@@ -12,7 +12,7 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
+{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
 
 # MongoDB Backup & Restore Overview
 

--- a/docs/guides/mongodb/schema-manager/deploy-mongodbdatabase/index.md
+++ b/docs/guides/mongodb/schema-manager/deploy-mongodbdatabase/index.md
@@ -20,7 +20,7 @@ This guide will show you how to create database with MongoDB Schema Manager usin
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
 
-- Install `KubeDB` in your cluster following the steps [here](https://kubedb.com/docs/latest/setup/install/kubedb/).
+- Install `KubeDB` in your cluster following the steps [here](https://kubedb.com/docs/latest/setup/).
 - Install `KubeVault` in your cluster following the steps [here](https://kubevault.com/docs/latest/setup/install/kubevault/).
 
 - You should be familiar with the following concepts:

--- a/docs/guides/mongodb/schema-manager/initializing-with-script/index.md
+++ b/docs/guides/mongodb/schema-manager/initializing-with-script/index.md
@@ -20,7 +20,7 @@ This guide will show you how to to create database and initialize script with Mo
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
 
-- Install `KubeDB` in your cluster following the steps [here](https://kubedb.com/docs/latest/setup/install/kubedb/).
+- Install `KubeDB` in your cluster following the steps [here](https://kubedb.com/docs/latest/setup/).
 - Install `KubeVault` in your cluster following the steps [here](https://kubevault.com/docs/latest/setup/install/kubevault/).
 
 - You should be familiar with the following concepts:

--- a/docs/guides/mongodb/schema-manager/initializing-with-snapshot/index.md
+++ b/docs/guides/mongodb/schema-manager/initializing-with-snapshot/index.md
@@ -20,7 +20,7 @@ This guide will show you how to create database and initialize snapshot with Mon
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
 
-- Install `KubeDB` in your cluster following the steps [here](https://kubedb.com/docs/latest/setup/install/kubedb/).
+- Install `KubeDB` in your cluster following the steps [here](https://kubedb.com/docs/latest/setup/).
 - Install `KubeVault` in your cluster following the steps [here](https://kubevault.com/docs/latest/setup/install/kubevault/).
 
 - You should be familiar with the following concepts:

--- a/docs/guides/mssqlserver/backup/application-level/index.md
+++ b/docs/guides/mssqlserver/backup/application-level/index.md
@@ -22,7 +22,7 @@ This guide will give you an overview how you can take application-level backup a
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore `Microsoft SQL Server` databases, please check the following guide [here](/docs/guides/mssqlserver/backup/overview/index.md).
 

--- a/docs/guides/mssqlserver/backup/auto-backup/index.md
+++ b/docs/guides/mssqlserver/backup/auto-backup/index.md
@@ -21,7 +21,7 @@ In this tutorial, we are going to show how you can configure a backup blueprint 
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore `Microsoft SQL Server` databases, please check the following guide [here](/docs/guides/mssqlserver/backup/overview/index.md).
 

--- a/docs/guides/mssqlserver/backup/logical/index.md
+++ b/docs/guides/mssqlserver/backup/logical/index.md
@@ -21,7 +21,7 @@ This guide will give you an overview how you can take backup and restore your `M
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore Microsoft SQL Server databases, please check the following guide [here](/docs/guides/mssqlserver/backup/overview/index.md).
 

--- a/docs/guides/mssqlserver/backup/overview/index.md
+++ b/docs/guides/mssqlserver/backup/overview/index.md
@@ -12,7 +12,7 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
+{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
 
 # Microsoft SQL Server Backup & Restore Overview
 

--- a/docs/guides/mysql/backup/kubestash/application-level/index.md
+++ b/docs/guides/mysql/backup/kubestash/application-level/index.md
@@ -21,7 +21,7 @@ This guide will give you how you can take application-level backup and restore y
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore MySQL databases, please check the following guide [here](/docs/guides/mysql/backup/kubestash/overview/index.md).
 

--- a/docs/guides/mysql/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/mysql/backup/kubestash/auto-backup/index.md
@@ -21,7 +21,7 @@ In this tutorial, we are going to show how you can configure a backup blueprint 
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore MySQL databases, please check the following guide [here](/docs/guides/mysql/backup/kubestash/overview/index.md).
 

--- a/docs/guides/mysql/backup/kubestash/logical/index.md
+++ b/docs/guides/mysql/backup/kubestash/logical/index.md
@@ -21,7 +21,7 @@ This guide will give you how you can take backup and restore your `MySQL` databa
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore MySQL databases, please check the following guide [here](/docs/guides/mysql/backup/kubestash/overview/index.md).
 

--- a/docs/guides/mysql/backup/kubestash/overview/index.md
+++ b/docs/guides/mysql/backup/kubestash/overview/index.md
@@ -12,7 +12,7 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
+{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
 
 # MySQL Backup & Restore Overview
 

--- a/docs/guides/postgres/backup/kubestash/application-level/index.md
+++ b/docs/guides/postgres/backup/kubestash/application-level/index.md
@@ -21,7 +21,7 @@ This guide will give you an overview how you can take application-level backup a
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore PostgreSQL databases, please check the following guide [here](/docs/guides/postgres/backup/kubestash/overview/index.md).
 

--- a/docs/guides/postgres/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/postgres/backup/kubestash/auto-backup/index.md
@@ -21,7 +21,7 @@ In this tutorial, we are going to show how you can configure a backup blueprint 
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore `PostgreSQL` databases, please check the following guide [here](/docs/guides/postgres/backup/kubestash/overview/index.md).
 

--- a/docs/guides/postgres/backup/kubestash/logical/index.md
+++ b/docs/guides/postgres/backup/kubestash/logical/index.md
@@ -22,7 +22,7 @@ This guide will give you an overview how you can take backup and restore your `P
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore PostgreSQL databases, please check the following guide [here](/docs/guides/postgres/backup/kubestash/overview/index.md).
 

--- a/docs/guides/postgres/backup/kubestash/overview/index.md
+++ b/docs/guides/postgres/backup/kubestash/overview/index.md
@@ -12,7 +12,7 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
+{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
 
 # PostgreSQL Backup & Restore Overview
 

--- a/docs/guides/qdrant/backup/logical/index.md
+++ b/docs/guides/qdrant/backup/logical/index.md
@@ -13,7 +13,7 @@ KubeStash allows you to backup and restore `Qdrant` databases. This guide will s
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore Qdrant databases, please check the following guide [here](/docs/guides/qdrant/backup/overview/index.md).
 

--- a/docs/guides/qdrant/backup/overview/index.md
+++ b/docs/guides/qdrant/backup/overview/index.md
@@ -6,7 +6,7 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
+{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
 
 # Qdrant Backup & Restore Overview
 

--- a/docs/guides/qdrant/backup/volume-snapshot/index.md
+++ b/docs/guides/qdrant/backup/volume-snapshot/index.md
@@ -13,7 +13,7 @@ KubeStash allows you to take volume snapshot backups of Qdrant databases. Volume
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - To install `External-snapshotter`  in your cluster following the steps [here](https://github.com/kubernetes-csi/external-snapshotter/tree/release-5.0).
 
 To keep things isolated, we are going to use a separate namespace called `demo` throughout this tutorial.

--- a/docs/guides/redis/backup/kubestash/application-level/index.md
+++ b/docs/guides/redis/backup/kubestash/application-level/index.md
@@ -21,7 +21,7 @@ This guide will give you an overview how you can take application-level backup a
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore Redis databases, please check the following guide [here](/docs/guides/redis/backup/kubestash/overview/index.md).
 

--- a/docs/guides/redis/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/redis/backup/kubestash/auto-backup/index.md
@@ -21,7 +21,7 @@ In this tutorial, we are going to show how you can configure a backup blueprint 
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore `Redis` databases, please check the following guide [here](/docs/guides/redis/backup/kubestash/overview/index.md).
 

--- a/docs/guides/redis/backup/kubestash/logical/index.md
+++ b/docs/guides/redis/backup/kubestash/logical/index.md
@@ -22,7 +22,7 @@ This guide will give you an overview how you can take backup and restore your `R
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore Redis databases, please check the following guide [here](/docs/guides/redis/backup/kubestash/overview/index.md).
 

--- a/docs/guides/redis/backup/kubestash/overview/index.md
+++ b/docs/guides/redis/backup/kubestash/overview/index.md
@@ -12,7 +12,7 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
+{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
 
 # Redis Backup & Restore Overview
 

--- a/docs/guides/singlestore/backup/kubestash/application-level/index.md
+++ b/docs/guides/singlestore/backup/kubestash/application-level/index.md
@@ -21,7 +21,7 @@ This guide will give you how you can take application-level backup and restore y
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore SingleStore databases, please check the following guide [here](/docs/guides/singlestore/backup/kubestash/overview/index.md).
 

--- a/docs/guides/singlestore/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/singlestore/backup/kubestash/auto-backup/index.md
@@ -21,7 +21,7 @@ In this tutorial, we are going to show how you can configure a backup blueprint 
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore SingleStore databases, please check the following guide [here](/docs/guides/singlestore/backup/kubestash/overview/index.md).
 

--- a/docs/guides/singlestore/backup/kubestash/logical/index.md
+++ b/docs/guides/singlestore/backup/kubestash/logical/index.md
@@ -21,7 +21,7 @@ This guide will give you how you can take backup and restore your `SingleStore` 
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore SingleStore databases, please check the following guide [here](/docs/guides/singlestore/backup/kubestash/overview/index.md).
 

--- a/docs/guides/singlestore/backup/kubestash/overview/index.md
+++ b/docs/guides/singlestore/backup/kubestash/overview/index.md
@@ -12,7 +12,7 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
+{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
 
 # SingleStore Backup & Restore Overview
 

--- a/docs/guides/zookeeper/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/zookeeper/backup/kubestash/auto-backup/index.md
@@ -21,7 +21,7 @@ In this tutorial, we are going to show how you can configure a backup blueprint 
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore `ZooKeeper`, please check the following guide [here](/docs/guides/zookeeper/backup/kubestash/overview/index.md).
 

--- a/docs/guides/zookeeper/backup/kubestash/logical/index.md
+++ b/docs/guides/zookeeper/backup/kubestash/logical/index.md
@@ -22,7 +22,7 @@ This guide will give you an overview how you can take backup and restore your `Z
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using `Minikube` or `Kind`.
 - Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
-- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/install/kubestash).
+- Install `KubeStash` in your cluster following the steps [here](https://kubestash.com/docs/latest/setup/).
 - Install KubeStash `kubectl` plugin following the steps [here](https://kubestash.com/docs/latest/setup/install/kubectl-plugin/).
 - If you are not familiar with how KubeStash backup and restore ZooKeeper, please check the following guide [here](/docs/guides/zookeeper/backup/kubestash/overview/index.md).
 

--- a/docs/guides/zookeeper/backup/kubestash/overview/index.md
+++ b/docs/guides/zookeeper/backup/kubestash/overview/index.md
@@ -12,7 +12,7 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/install/kubestash/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
+{{< notice type="warning" message="Please install [KubeStash](https://kubestash.com/docs/latest/setup/) to try this feature. Database backup with KubeStash is already included in the KubeDB license. So, you don't need a separate license for KubeStash." >}}
 
 # ZooKeeper Backup & Restore Overview
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation and warning links across multiple backup/restore guides to point to the general KubeStash setup documentation (`https://kubestash.com/docs/latest/setup/`) instead of install-specific URLs.
  * Updated KubeDB installation/setup links in related guides to use the top-level setup page.
  * Added a “New to KubeDB? Please start here” link in the MariaDB Backup &amp; Restore (KubeStash) overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->