### PR TITLE
Wrap resticStats fields under summary key

### DIFF
--- a/docs/guides/druid/backup/application-level/index.md
+++ b/docs/guides/druid/backup/application-level/index.md
@@ -587,10 +587,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: 647a7123a66423a81fa21ac77128e46587ddae3e9c9426537a30ad1c9a8e1843
-          size: 3.807 MiB
-          uploaded: 3.807 MiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: 647a7123a66423a81fa21ac77128e46587ddae3e9c9426537a30ad1c9a8e1843
+            size: 3.807 MiB
+            uploaded: 3.807 MiB
       size: 652.853 KiB
     manifest:
       driver: Restic
@@ -599,10 +600,11 @@ status:
       path: repository/v1/frequent-backup/manifest
       phase: Succeeded
       resticStats:
-        - hostPath: /kubestash-tmp/manifest
-          id: 069ad1c6dae59fd086aa9771289fc4dad6d076afbc11180e3b1cd8083cd01691
-          size: 13.599 KiB
-          uploaded: 4.268 KiB
+        - summary:
+            hostPath: /kubestash-tmp/manifest
+            id: 069ad1c6dae59fd086aa9771289fc4dad6d076afbc11180e3b1cd8083cd01691
+            size: 13.599 KiB
+            uploaded: 4.268 KiB
       size: 12.127 KiB
   conditions:
     - lastTransitionTime: "2024-09-20T11:09:00Z"

--- a/docs/guides/druid/backup/auto-backup/index.md
+++ b/docs/guides/druid/backup/auto-backup/index.md
@@ -472,10 +472,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: 8f2b5f5d8a7a18304917e2d4c5a3636f8927085b15c652c35d5fca4a9988515d
-          size: 3.750 MiB
-          uploaded: 3.751 MiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: 8f2b5f5d8a7a18304917e2d4c5a3636f8927085b15c652c35d5fca4a9988515d
+            size: 3.750 MiB
+            uploaded: 3.751 MiB
       size: 674.017 KiB
 ```
 
@@ -788,10 +789,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: a1061e74f1ad398a9fe85bcbae34f540f2437a97061fd26c5b3e6bde3b5b7642
-          size: 10.859 KiB
-          uploaded: 11.152 KiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: a1061e74f1ad398a9fe85bcbae34f540f2437a97061fd26c5b3e6bde3b5b7642
+            size: 10.859 KiB
+            uploaded: 11.152 KiB
       size: 2.127 KiB
 ```
 

--- a/docs/guides/druid/backup/cross-ns-dependencies/index.md
+++ b/docs/guides/druid/backup/cross-ns-dependencies/index.md
@@ -681,10 +681,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: 647a7123a66423a81fa21ac77128e46587ddae3e9c9426537a30ad1c9a8e1843
-          size: 3.807 MiB
-          uploaded: 3.807 MiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: 647a7123a66423a81fa21ac77128e46587ddae3e9c9426537a30ad1c9a8e1843
+            size: 3.807 MiB
+            uploaded: 3.807 MiB
       size: 652.853 KiB
     manifest:
       driver: Restic
@@ -693,10 +694,11 @@ status:
       path: repository/v1/frequent-backup/manifest
       phase: Succeeded
       resticStats:
-        - hostPath: /kubestash-tmp/manifest
-          id: 069ad1c6dae59fd086aa9771289fc4dad6d076afbc11180e3b1cd8083cd01691
-          size: 13.599 KiB
-          uploaded: 4.268 KiB
+        - summary:
+            hostPath: /kubestash-tmp/manifest
+            id: 069ad1c6dae59fd086aa9771289fc4dad6d076afbc11180e3b1cd8083cd01691
+            size: 13.599 KiB
+            uploaded: 4.268 KiB
       size: 12.127 KiB
   conditions:
     - lastTransitionTime: "2024-09-20T11:09:00Z"

--- a/docs/guides/druid/backup/logical/index.md
+++ b/docs/guides/druid/backup/logical/index.md
@@ -564,10 +564,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: d10ab158ce2667d03b08cb35573a6f049a2cef9ef2e96be847caed6660bbb904
-          size: 4.322 MiB
-          uploaded: 4.323 MiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: d10ab158ce2667d03b08cb35573a6f049a2cef9ef2e96be847caed6660bbb904
+            size: 4.322 MiB
+            uploaded: 4.323 MiB
       size: 712.824 KiB
   ...
 ```

--- a/docs/guides/elasticsearch/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/elasticsearch/backup/kubestash/auto-backup/index.md
@@ -446,10 +446,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-      - hostPath: /kubestash-interim/data
-        id: 147fa51e71e523631e74ba3195499995696c6ac69560e1c7f4ab1b4222a97a73
-        size: 509 B
-        uploaded: 2.141 KiB
+      - summary:
+          hostPath: /kubestash-interim/data
+          id: 147fa51e71e523631e74ba3195499995696c6ac69560e1c7f4ab1b4222a97a73
+          size: 509 B
+          uploaded: 2.141 KiB
       size: 7.791 KiB
   conditions:
   - lastTransitionTime: "2024-09-19T05:06:01Z"
@@ -791,10 +792,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-      - hostPath: /kubestash-interim/data
-        id: 4e15656770c55e4e08ed6dbfe6a190eb96db979259ca9c3900a5918cac116330
-        size: 11.717 KiB
-        uploaded: 3.835 KiB
+      - summary:
+          hostPath: /kubestash-interim/data
+          id: 4e15656770c55e4e08ed6dbfe6a190eb96db979259ca9c3900a5918cac116330
+          size: 11.717 KiB
+          uploaded: 3.835 KiB
       size: 15.974 KiB
   conditions:
   - lastTransitionTime: "2024-09-19T06:30:01Z"

--- a/docs/guides/elasticsearch/backup/kubestash/logical/index.md
+++ b/docs/guides/elasticsearch/backup/kubestash/logical/index.md
@@ -560,10 +560,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-      - hostPath: /kubestash-interim/data
-        id: 396227e62948a4d9ca865f08b52bfcc3fbca7135b1962373c203df856bd9a260
-        size: 509 B
-        uploaded: 2.641 KiB
+      - summary:
+          hostPath: /kubestash-interim/data
+          id: 396227e62948a4d9ca865f08b52bfcc3fbca7135b1962373c203df856bd9a260
+          size: 509 B
+          uploaded: 2.641 KiB
       size: 1.455 KiB
   conditions:
   - lastTransitionTime: "2024-09-18T10:25:23Z"

--- a/docs/guides/mariadb/backup/kubestash/application-level/index.md
+++ b/docs/guides/mariadb/backup/kubestash/application-level/index.md
@@ -527,10 +527,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: 6a9b3e0ccd380f93ff414157156f4ac9d144fa15c5c3adeea2faa09cf44fb175
-          size: 3.139 KiB
-          uploaded: 3.431 KiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: 6a9b3e0ccd380f93ff414157156f4ac9d144fa15c5c3adeea2faa09cf44fb175
+            size: 3.139 KiB
+            uploaded: 3.431 KiB
       size: 1.277 KiB
     manifest:
       driver: Restic
@@ -539,10 +540,11 @@ status:
       path: repository/v1/frequent-backup/manifest
       phase: Succeeded
       resticStats:
-        - hostPath: /kubestash-tmp/manifest
-          id: 47d89d4149cd59bfc8e701b8171a864d0259486820c477a9c2b3a8c0d80de237
-          size: 2.507 KiB
-          uploaded: 3.939 KiB
+        - summary:
+            hostPath: /kubestash-tmp/manifest
+            id: 47d89d4149cd59bfc8e701b8171a864d0259486820c477a9c2b3a8c0d80de237
+            size: 2.507 KiB
+            uploaded: 3.939 KiB
       size: 1.913 KiB
   conditions:
     - lastTransitionTime: "2024-09-18T09:16:53Z"

--- a/docs/guides/mariadb/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/mariadb/backup/kubestash/auto-backup/index.md
@@ -448,10 +448,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: c4d4c26ad6e03f372b60dfc8bb7901900c4be9b791d44c68564753fb9e9e424c
-          size: 2.206 KiB
-          uploaded: 2.498 KiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: c4d4c26ad6e03f372b60dfc8bb7901900c4be9b791d44c68564753fb9e9e424c
+            size: 2.206 KiB
+            uploaded: 2.498 KiB
       size: 2.190 KiB
   conditions:
     - lastTransitionTime: "2024-09-18T05:34:18Z"
@@ -801,10 +802,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: 6aa144d43ea5d70fd1018390d4d22f98f6ab568c74eee9a386d6a9b29ad21d8b
-          size: 4.887 MiB
-          uploaded: 4.887 MiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: 6aa144d43ea5d70fd1018390d4d22f98f6ab568c74eee9a386d6a9b29ad21d8b
+            size: 4.887 MiB
+            uploaded: 4.887 MiB
       size: 907.341 KiB
   conditions:
     - lastTransitionTime: "2024-09-18T06:23:24Z"

--- a/docs/guides/mariadb/backup/kubestash/logical/index.md
+++ b/docs/guides/mariadb/backup/kubestash/logical/index.md
@@ -520,10 +520,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: 0a6dfb754cb32bdaf17581fa42b20e8915aabd0b48f37c854b72812f53b7e5b6
-          size: 2.206 KiB
-          uploaded: 2.498 KiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: 0a6dfb754cb32bdaf17581fa42b20e8915aabd0b48f37c854b72812f53b7e5b6
+            size: 2.206 KiB
+            uploaded: 2.498 KiB
       size: 1.096 KiB
   conditions:
     - lastTransitionTime: "2024-09-17T10:43:04Z"

--- a/docs/guides/mongodb/backup/kubestash/application-level/index.md
+++ b/docs/guides/mongodb/backup/kubestash/application-level/index.md
@@ -501,10 +501,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dump
-          id: 67a2f5bd65ef78cd5cece9906dadd0d62523decae71db05d9f895140aabe9ec0
-          size: 3.340 KiB
-          uploaded: 3.624 KiB
+        - summary:
+            hostPath: dump
+            id: 67a2f5bd65ef78cd5cece9906dadd0d62523decae71db05d9f895140aabe9ec0
+            size: 3.340 KiB
+            uploaded: 3.624 KiB
       size: 1.524 KiB
     manifest:
       driver: Restic
@@ -513,10 +514,11 @@ status:
       path: repository/v1/frequent-backup/manifest
       phase: Succeeded
       resticStats:
-        - hostPath: /kubestash-tmp/manifest
-          id: b5660a5a38532f6817769ff693c0c317730148f02b24e7acfc6ac7d8464a9518
-          size: 3.866 KiB
-          uploaded: 5.299 KiB
+        - summary:
+            hostPath: /kubestash-tmp/manifest
+            id: b5660a5a38532f6817769ff693c0c317730148f02b24e7acfc6ac7d8464a9518
+            size: 3.866 KiB
+            uploaded: 5.299 KiB
       size: 2.345 KiB
   conditions:
     - lastTransitionTime: "2024-09-17T06:53:43Z"

--- a/docs/guides/mysql/backup/kubestash/application-level/index.md
+++ b/docs/guides/mysql/backup/kubestash/application-level/index.md
@@ -541,10 +541,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-      - hostPath: dumpfile.sql
-        id: f2ffd1bdb98563e15c46d8927d7239873ce7094132d959e12134688e06984736
-        size: 3.657 MiB
-        uploaded: 706.081 KiB
+      - summary:
+          hostPath: dumpfile.sql
+          id: f2ffd1bdb98563e15c46d8927d7239873ce7094132d959e12134688e06984736
+          size: 3.657 MiB
+          uploaded: 706.081 KiB
       size: 893.009 KiB
     manifest:
       driver: Restic
@@ -553,10 +554,11 @@ status:
       path: repository/v1/frequent-backup/manifest
       phase: Succeeded
       resticStats:
-      - hostPath: /kubestash-tmp/manifest
-        id: ff99eb7ea769a365f7cdc83a252df610c262fc934ec0a3475499bbbb35ca6931
-        size: 2.883 KiB
-        uploaded: 1.440 KiB
+      - summary:
+          hostPath: /kubestash-tmp/manifest
+          id: ff99eb7ea769a365f7cdc83a252df610c262fc934ec0a3475499bbbb35ca6931
+          size: 2.883 KiB
+          uploaded: 1.440 KiB
       size: 3.788 KiB
   conditions:
   - lastTransitionTime: "2024-09-03T10:25:00Z"

--- a/docs/guides/mysql/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/mysql/backup/kubestash/auto-backup/index.md
@@ -403,10 +403,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: b83d7a5577940d1c8f5bcda0630592c7d5a04168c272c0e7560bf7dacfe35ea8
-          size: 3.657 MiB
-          uploaded: 121.343 KiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: b83d7a5577940d1c8f5bcda0630592c7d5a04168c272c0e7560bf7dacfe35ea8
+            size: 3.657 MiB
+            uploaded: 121.343 KiB
       size: 772.958 KiB
   integrity: true
   phase: Succeeded
@@ -704,10 +705,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: b83d7a5577940d1c8f5bcda0630592c7d5a04168c272c0e7560bf7dacfe35ea8
-          size: 3.657 MiB
-          uploaded: 121.343 KiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: b83d7a5577940d1c8f5bcda0630592c7d5a04168c272c0e7560bf7dacfe35ea8
+            size: 3.657 MiB
+            uploaded: 121.343 KiB
       size: 772.958 KiB
   integrity: true
   phase: Succeeded

--- a/docs/guides/mysql/backup/kubestash/logical/index.md
+++ b/docs/guides/mysql/backup/kubestash/logical/index.md
@@ -538,10 +538,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-      - hostPath: dumpfile.sql
-        id: fbab3af5c38f51b7aa9096799d8ce4b71ea0092dd8297526fed0adbd9f62f3f1
-        size: 3.657 MiB
-        uploaded: 1.036 MiB
+      - summary:
+          hostPath: dumpfile.sql
+          id: fbab3af5c38f51b7aa9096799d8ce4b71ea0092dd8297526fed0adbd9f62f3f1
+          size: 3.657 MiB
+          uploaded: 1.036 MiB
       size: 1.456 MiB
   ...
 ```

--- a/docs/guides/postgres/backup/kubestash/application-level/index.md
+++ b/docs/guides/postgres/backup/kubestash/application-level/index.md
@@ -560,10 +560,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-      - hostPath: dumpfile.sql
-        id: 4b820700710f9f7b6a8d5b052367b51875e68dcd9052c749a686506db6a66374
-        size: 3.345 KiB
-        uploaded: 3.634 KiB
+      - summary:
+          hostPath: dumpfile.sql
+          id: 4b820700710f9f7b6a8d5b052367b51875e68dcd9052c749a686506db6a66374
+          size: 3.345 KiB
+          uploaded: 3.634 KiB
       size: 1.135 KiB
     manifest:
       driver: Restic
@@ -572,10 +573,11 @@ status:
       path: repository/v1/frequent-backup/manifest
       phase: Succeeded
       resticStats:
-      - hostPath: /kubestash-tmp/manifest
-        id: 9da4d1b7df6dd946e15a8a0d2a2a3c14776351e27926156770530ca03f6f8002
-        size: 3.064 KiB
-        uploaded: 1.443 KiB
+      - summary:
+          hostPath: /kubestash-tmp/manifest
+          id: 9da4d1b7df6dd946e15a8a0d2a2a3c14776351e27926156770530ca03f6f8002
+          size: 3.064 KiB
+          uploaded: 1.443 KiB
       size: 2.972 KiB
   conditions:
   - lastTransitionTime: "2024-09-05T09:08:03Z"

--- a/docs/guides/postgres/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/postgres/backup/kubestash/auto-backup/index.md
@@ -455,10 +455,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: a30f8ec138e24cbdbcce088a73e5b9d73a58750c38793ef05ff7d570148ddd2c
-          size: 3.345 KiB
-          uploaded: 3.637 KiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: a30f8ec138e24cbdbcce088a73e5b9d73a58750c38793ef05ff7d570148ddd2c
+            size: 3.345 KiB
+            uploaded: 3.637 KiB
       size: 1.132 KiB
   conditions:
     - lastTransitionTime: "2024-09-05T10:53:59Z"
@@ -813,10 +814,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: 74d82943e0d676321e989edb503f5e2d6fe5cf4f4be72d386e492ec533358c26
-          size: 1.220 KiB
-          uploaded: 296 B
+        - summary:
+            hostPath: dumpfile.sql
+            id: 74d82943e0d676321e989edb503f5e2d6fe5cf4f4be72d386e492ec533358c26
+            size: 1.220 KiB
+            uploaded: 296 B
       size: 1.873 KiB
   conditions:
     - lastTransitionTime: "2024-09-06T04:30:00Z"

--- a/docs/guides/postgres/backup/kubestash/logical/index.md
+++ b/docs/guides/postgres/backup/kubestash/logical/index.md
@@ -559,10 +559,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-      - hostPath: dumpfile.sql
-        id: 008eb87193e7db112e9ad8f42c9302c851a1fbacb7165a5cb3aa2d27dd210764
-        size: 3.345 KiB
-        uploaded: 299 B
+      - summary:
+          hostPath: dumpfile.sql
+          id: 008eb87193e7db112e9ad8f42c9302c851a1fbacb7165a5cb3aa2d27dd210764
+          size: 3.345 KiB
+          uploaded: 299 B
       size: 2.202 KiB
   conditions:
   - lastTransitionTime: "2024-09-04T11:30:00Z"

--- a/docs/guides/redis/backup/kubestash/application-level/index.md
+++ b/docs/guides/redis/backup/kubestash/application-level/index.md
@@ -490,10 +490,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.resp
-          id: 73cf596a525bcdb439e87812045e7a25c6bd82574513351ab434793c134fc817
-          size: 184 B
-          uploaded: 483 B
+        - summary:
+            hostPath: dumpfile.resp
+            id: 73cf596a525bcdb439e87812045e7a25c6bd82574513351ab434793c134fc817
+            size: 184 B
+            uploaded: 483 B
       size: 380 B
   conditions:
     - lastTransitionTime: "2024-09-18T13:04:35Z"

--- a/docs/guides/redis/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/redis/backup/kubestash/auto-backup/index.md
@@ -448,10 +448,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.resp
-          id: afce1d29a21d2b05a2aadfb5bdd08f0d5b7c2b2e70fc1d5d77843ebbbef258c1
-          size: 184 B
-          uploaded: 483 B
+        - summary:
+            hostPath: dumpfile.resp
+            id: afce1d29a21d2b05a2aadfb5bdd08f0d5b7c2b2e70fc1d5d77843ebbbef258c1
+            size: 184 B
+            uploaded: 483 B
       size: 381 B
   conditions:
     - lastTransitionTime: "2024-09-18T12:15:38Z"
@@ -794,10 +795,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.resp
-          id: 73cf596a525bcdb439e87812045e7a25c6bd82574513351ab434793c134fc817
-          size: 184 B
-          uploaded: 483 B
+        - summary:
+            hostPath: dumpfile.resp
+            id: 73cf596a525bcdb439e87812045e7a25c6bd82574513351ab434793c134fc817
+            size: 184 B
+            uploaded: 483 B
       size: 380 B
   conditions:
     - lastTransitionTime: "2024-09-18T13:04:35Z"

--- a/docs/guides/redis/backup/kubestash/logical/index.md
+++ b/docs/guides/redis/backup/kubestash/logical/index.md
@@ -522,10 +522,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.resp
-          id: dc0c7e16ffea238d80f2f0e23b94d5eee1a598a4b5b9bc3f9edc2e9059e1d9e2
-          size: 381 B
-          uploaded: 680 B
+        - summary:
+            hostPath: dumpfile.resp
+            id: dc0c7e16ffea238d80f2f0e23b94d5eee1a598a4b5b9bc3f9edc2e9059e1d9e2
+            size: 381 B
+            uploaded: 680 B
       size: 416 B
   conditions:
     - lastTransitionTime: "2024-09-18T09:28:07Z"

--- a/docs/guides/singlestore/backup/kubestash/application-level/index.md
+++ b/docs/guides/singlestore/backup/kubestash/application-level/index.md
@@ -615,10 +615,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-      - hostPath: dumpfile.sql
-        id: f2ffd1bdb98563e15c46d8927d7239873ce7094132d959e12134688e06984736
-        size: 3.657 MiB
-        uploaded: 706.081 KiB
+      - summary:
+          hostPath: dumpfile.sql
+          id: f2ffd1bdb98563e15c46d8927d7239873ce7094132d959e12134688e06984736
+          size: 3.657 MiB
+          uploaded: 706.081 KiB
       size: 893.009 KiB
     manifest:
       driver: Restic
@@ -627,10 +628,11 @@ status:
       path: repository/v1/frequent-backup/manifest
       phase: Succeeded
       resticStats:
-      - hostPath: /kubestash-tmp/manifest
-        id: ff99eb7ea769a365f7cdc83a252df610c262fc934ec0a3475499bbbb35ca6931
-        size: 2.883 KiB
-        uploaded: 1.440 KiB
+      - summary:
+          hostPath: /kubestash-tmp/manifest
+          id: ff99eb7ea769a365f7cdc83a252df610c262fc934ec0a3475499bbbb35ca6931
+          size: 2.883 KiB
+          uploaded: 1.440 KiB
       size: 3.788 KiB
   conditions:
   - lastTransitionTime: "2024-09-03T10:25:00Z"

--- a/docs/guides/singlestore/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/singlestore/backup/kubestash/auto-backup/index.md
@@ -448,10 +448,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: b83d7a5577940d1c8f5bcda0630592c7d5a04168c272c0e7560bf7dacfe35ea8
-          size: 3.657 MiB
-          uploaded: 121.343 KiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: b83d7a5577940d1c8f5bcda0630592c7d5a04168c272c0e7560bf7dacfe35ea8
+            size: 3.657 MiB
+            uploaded: 121.343 KiB
       size: 772.958 KiB
   integrity: true
   phase: Succeeded
@@ -780,10 +781,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: dumpfile.sql
-          id: b83d7a5577940d1c8f5bcda0630592c7d5a04168c272c0e7560bf7dacfe35ea8
-          size: 3.657 MiB
-          uploaded: 121.343 KiB
+        - summary:
+            hostPath: dumpfile.sql
+            id: b83d7a5577940d1c8f5bcda0630592c7d5a04168c272c0e7560bf7dacfe35ea8
+            size: 3.657 MiB
+            uploaded: 121.343 KiB
       size: 772.958 KiB
   integrity: true
   phase: Succeeded

--- a/docs/guides/singlestore/backup/kubestash/logical/index.md
+++ b/docs/guides/singlestore/backup/kubestash/logical/index.md
@@ -611,10 +611,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-      - hostPath: dumpfile.sql
-        id: fbab3af5c38f51b7aa9096799d8ce4b71ea0092dd8297526fed0adbd9f62f3f1
-        size: 3.657 MiB
-        uploaded: 1.036 MiB
+      - summary:
+          hostPath: dumpfile.sql
+          id: fbab3af5c38f51b7aa9096799d8ce4b71ea0092dd8297526fed0adbd9f62f3f1
+          size: 3.657 MiB
+          uploaded: 1.036 MiB
       size: 1.456 MiB
   ...
 ```

--- a/docs/guides/zookeeper/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/zookeeper/backup/kubestash/auto-backup/index.md
@@ -450,10 +450,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: /kubestash-interim/data
-          id: 280cbe5908773859259f0921d89e677f4c0ab40c3e4bedee6b95ab2c9ef474e9
-          size: 718 B
-          uploaded: 1.075 KiB
+        - summary:
+            hostPath: /kubestash-interim/data
+            id: 280cbe5908773859259f0921d89e677f4c0ab40c3e4bedee6b95ab2c9ef474e9
+            size: 718 B
+            uploaded: 1.075 KiB
       size: 1.835 KiB
   conditions:
     - lastTransitionTime: "2024-09-19T08:55:01Z"
@@ -799,10 +800,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-        - hostPath: /kubestash-interim/data
-          id: 5356f92f84ad9b1ce170a99796eee91983e6df62e224d592d85fb0811a2fbb38
-          size: 719 B
-          uploaded: 1.075 KiB
+        - summary:
+            hostPath: /kubestash-interim/data
+            id: 5356f92f84ad9b1ce170a99796eee91983e6df62e224d592d85fb0811a2fbb38
+            size: 719 B
+            uploaded: 1.075 KiB
       size: 1.839 KiB
   conditions:
     - lastTransitionTime: "2024-09-19T10:40:01Z"

--- a/docs/guides/zookeeper/backup/kubestash/logical/index.md
+++ b/docs/guides/zookeeper/backup/kubestash/logical/index.md
@@ -492,10 +492,11 @@ status:
       path: repository/v1/frequent-backup/dump
       phase: Succeeded
       resticStats:
-      - hostPath: /kubestash-interim/data
-        id: cd20fca1a2bf6a97e669cb9eacdc74a312a08266da92b9d687aad88841e1205d
-        size: 3.345 KiB
-        uploaded: 299 B
+      - summary:
+          hostPath: /kubestash-interim/data
+          id: cd20fca1a2bf6a97e669cb9eacdc74a312a08266da92b9d687aad88841e1205d
+          size: 3.345 KiB
+          uploaded: 299 B
       size: 2.202 KiB
   conditions:
   - lastTransitionTime: "2024-09-04T11:30:00Z"


### PR DESCRIPTION
## What

The Snapshot CRD schema now nests `resticStats[*]` fields (`hostPath`, `id`, `size`, `uploaded`, plus `startTime`/`endTime` where present) under a `summary:` key. CI was failing with validation errors like:

```
ValidationError(Snapshot.status.components.dump.resticStats[0]): unknown field "hostPath" in com.kubestash.storage.v1alpha1.Snapshot.status.components.resticStats
```

This updates all backup docs to match the new schema, applying the same fix as kubestash/docs#86.

```yaml
# before
resticStats:
  - hostPath: dumpfile.sql
    id: ...
    size: ...
    uploaded: ...

# after
resticStats:
  - summary:
      hostPath: dumpfile.sql
      id: ...
      size: ...
      uploaded: ...
```

## Scope

24 files across mariadb, mysql, postgres, redis, mongodb, zookeeper, elasticsearch, singlestore, and druid backup guides (logical / application-level / auto-backup / cross-ns-dependencies).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example `Snapshot` YAML outputs across all backup guides (Druid, Elasticsearch, MariaDB, MongoDB, MySQL, PostgreSQL, Redis, SingleStore, ZooKeeper) to reflect changes in backup status structure. The `resticStats` fields (`hostPath`, `id`, `size`, `uploaded`) are now nested under a `summary` object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->