### PR TITLE
Update cassandra docs examples to latest supported version (5.0.7)

### DIFF
--- a/docs/examples/cassandra/autoscaling/compute/cassandra-autoscale.yaml
+++ b/docs/examples/cassandra/autoscaling/compute/cassandra-autoscale.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-autoscale
   namespace: demo
 spec:
-  version: "5.0.3"
+  version: "5.0.7"
   topology:
     rack:
       - name: r0

--- a/docs/examples/cassandra/autoscaling/storage/cassandra-autoscale.yaml
+++ b/docs/examples/cassandra/autoscaling/storage/cassandra-autoscale.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cassandra-autoscale
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/examples/cassandra/configuration/cassandra-config-file.yaml
+++ b/docs/examples/cassandra/configuration/cassandra-config-file.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cas-custom-config
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   configuration:
     secretName: cas-configuration
   topology:

--- a/docs/examples/cassandra/monitoring/cas-with-monitoring.yaml
+++ b/docs/examples/cassandra/monitoring/cas-with-monitoring.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/examples/cassandra/monitoring/cassandra-builtin-prom.yaml
+++ b/docs/examples/cassandra/monitoring/cassandra-builtin-prom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-builtin-prom
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/examples/cassandra/quickstart/cassandra-quickstart.yaml
+++ b/docs/examples/cassandra/quickstart/cassandra-quickstart.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-quickstart
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/examples/cassandra/reconfigure-tls/cassandra.yaml
+++ b/docs/examples/cassandra/reconfigure-tls/cassandra.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/examples/cassandra/reconfigure/cassandra-topology.yaml
+++ b/docs/examples/cassandra/reconfigure/cassandra-topology.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/examples/cassandra/restart/cassandra.yaml
+++ b/docs/examples/cassandra/restart/cassandra.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   configuration:
     secretName: cas-configuration
   topology:

--- a/docs/examples/cassandra/rotate-auth/cassandra-prod.yaml
+++ b/docs/examples/cassandra/rotate-auth/cassandra-prod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/examples/cassandra/scaling/cassandra-topology.yaml
+++ b/docs/examples/cassandra/scaling/cassandra-topology.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/examples/cassandra/tls/cassandra-prod-tls.yaml
+++ b/docs/examples/cassandra/tls/cassandra-prod-tls.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-prod-tls
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   tls:
     issuerRef:
       apiGroup: "cert-manager.io"

--- a/docs/examples/cassandra/update-version/cassandra.yaml
+++ b/docs/examples/cassandra/update-version/cassandra.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 4.1.8
+  version: 4.1.11
   topology:
     rack:
       - name: r0

--- a/docs/examples/cassandra/update-version/update-version.yaml
+++ b/docs/examples/cassandra/update-version/update-version.yaml
@@ -8,6 +8,6 @@ spec:
   databaseRef:
     name: cass
   updateVersion:
-    targetVersion: 5.0.3
+    targetVersion: 5.0.7
   timeout: 5m
   apply: IfReady

--- a/docs/examples/cassandra/volume-expansion/cassandra.yaml
+++ b/docs/examples/cassandra/volume-expansion/cassandra.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/guides/cassandra/autoscaler/compute/compute-autoscale.md
+++ b/docs/guides/cassandra/autoscaler/compute/compute-autoscale.md
@@ -41,7 +41,7 @@ namespace/demo created
 
 ## Autoscaling of Cassandra
 
-In this section, we are going to deploy a Cassandra with version `5.0.3`  Then, in the next section we will set up autoscaling for this Cassandra using `CassandraAutoscaler` CRD. Below is the YAML of the `Cassandra` CR that we are going to create,
+In this section, we are going to deploy a Cassandra with version `5.0.7`  Then, in the next section we will set up autoscaling for this Cassandra using `CassandraAutoscaler` CRD. Below is the YAML of the `Cassandra` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -50,7 +50,7 @@ metadata:
   name: cassandra-autoscale
   namespace: demo
 spec:
-  version: "5.0.3"
+  version: "5.0.7"
   topology:
     rack:
       - name: r0

--- a/docs/guides/cassandra/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/cassandra/autoscaler/storage/storage-autoscale.md
@@ -71,7 +71,7 @@ metadata:
   name: cassandra-autoscale
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/guides/cassandra/backup/kubestash/logical/examples/cas-sample.yaml
+++ b/docs/guides/cassandra/backup/kubestash/logical/examples/cas-sample.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cas-sample
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/guides/cassandra/backup/kubestash/logical/index.md
+++ b/docs/guides/cassandra/backup/kubestash/logical/index.md
@@ -70,7 +70,7 @@ metadata:
   name: cas-sample
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0
@@ -98,7 +98,7 @@ spec:
 
 Here,
 
-- `spec.version` is the name of the CassandraVersion CRD where the docker images are specified. In this tutorial, a Cassandra `5.0.3` database is going to be created.
+- `spec.version` is the name of the CassandraVersion CRD where the docker images are specified. In this tutorial, a Cassandra `5.0.7` database is going to be created.
 - `spec.topology` specifies that it will be used as cluster mode. If this field is nil it will be work as standalone mode.
 - `spec.storageType` specifies the type of storage that will be used for Cassandra database. It can be `Durable` or `Ephemeral`. Default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create Cassandra database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.deletionPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `Cassandra` crd or which resources KubeDB should keep or delete when you delete `Cassandra` crd. If admission webhook is enabled, It prevents users from deleting the database as long as the `spec.deletionPolicy` is set to `DoNotTerminate`. Learn details of all `DeletionPolicy` [here](/docs/guides/cassandra/concepts/cassandra.md#specdeletionpolicy)
@@ -190,7 +190,7 @@ spec:
   secret:
     name: cas-sample-auth
   type: kubedb.com/cassandra
-  version: 5.0.3
+  version: 5.0.7
 ```
 
 KubeStash uses the `AppBinding` CR to connect with the target database. It requires the following two fields to set in AppBinding's `.spec` section.
@@ -475,7 +475,7 @@ apiVersion: storage.kubestash.com/v1alpha1
 kind: Snapshot
 metadata:
   annotations:
-    kubedb.com/db-version: 5.0.3
+    kubedb.com/db-version: 5.0.7
   creationTimestamp: "2025-07-28T06:03:08Z"
   finalizers:
     - kubestash.com/cleanup

--- a/docs/guides/cassandra/concepts/cassandra.md
+++ b/docs/guides/cassandra/concepts/cassandra.md
@@ -85,7 +85,7 @@ spec:
         labels:
           release: prometheus
         interval: 10s
-  version: 5.0.3
+  version: 5.0.7
 ```
 
 ### spec.version

--- a/docs/guides/cassandra/concepts/cassandraopsrequest.md
+++ b/docs/guides/cassandra/concepts/cassandraopsrequest.md
@@ -38,7 +38,7 @@ spec:
   databaseRef:
     name: cassandra-prod
   updateVersion:
-    targetVersion: 5.0.3
+    targetVersion: 5.0.7
 status:
   conditions:
     - lastTransitionTime: "2025-07-25T18:22:38Z"

--- a/docs/guides/cassandra/configuration/using-config-file.md
+++ b/docs/guides/cassandra/configuration/using-config-file.md
@@ -88,7 +88,7 @@ metadata:
   name: cas-custom-config
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   configuration:
     secretName: cas-configuration
   topology:

--- a/docs/guides/cassandra/monitoring/overview.md
+++ b/docs/guides/cassandra/monitoring/overview.md
@@ -53,7 +53,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/guides/cassandra/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/cassandra/monitoring/using-builtin-prometheus.md
@@ -49,7 +49,7 @@ metadata:
   name: cassandra-builtin-prom
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/guides/cassandra/monitoring/using-prometheus-operator.md
+++ b/docs/guides/cassandra/monitoring/using-prometheus-operator.md
@@ -195,7 +195,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/guides/cassandra/quickstart/guide/quickstart.md
+++ b/docs/guides/cassandra/quickstart/guide/quickstart.md
@@ -62,7 +62,7 @@ NAME    VERSION   DB_IMAGE                                             DEPRECATE
 5.0.3   5.0.3     ghcr.io/appscode-images/cassandra-management:5.0.3                3m50s
 ```
 
-In this tutorial, we will use `5.0.3` CassandraVersion CR to create a Cassandra cluster.
+In this tutorial, we will use `5.0.7` CassandraVersion CR to create a Cassandra cluster.
 
 ## Create a Cassandra Cluster
 
@@ -77,7 +77,7 @@ metadata:
   name: cassandra-quickstart
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0
@@ -93,7 +93,7 @@ spec:
 ```
 
 Here,
-- `spec.version` - is the name of the CassandraVersion CR. Here, a Cassandra of version `5.0.3` will be created.
+- `spec.version` - is the name of the CassandraVersion CR. Here, a Cassandra of version `5.0.7` will be created.
 - `spec.topology` - is the definition of the topology that will be deployed. This contains an array of racks definition.
 - `spec.deletionPolicy` specifies what KubeDB should do when a user try to delete Cassandra CR. Deletion policy `Delete` will delete the database pods and PVC when the Cassandra CR is deleted.
 

--- a/docs/guides/cassandra/reconfigure-tls/cassandra.md
+++ b/docs/guides/cassandra/reconfigure-tls/cassandra.md
@@ -48,7 +48,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/guides/cassandra/reconfigure/cassandra-topology.md
+++ b/docs/guides/cassandra/reconfigure/cassandra-topology.md
@@ -40,7 +40,7 @@ Now, we are going to deploy a  `Cassandra` Topology cluster using a supported ve
 
 ### Prepare Cassandra Topology Cluster
 
-Now, we are going to deploy a `Cassandra` topology cluster with version `5.0.3`.
+Now, we are going to deploy a `Cassandra` topology cluster with version `5.0.7`.
 
 ### Deploy Cassandra
 
@@ -84,7 +84,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   configuration:
     secretName: cas-topology-custom-config
   topology:

--- a/docs/guides/cassandra/restart/restart.md
+++ b/docs/guides/cassandra/restart/restart.md
@@ -42,7 +42,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   configuration:
     secretName: cas-configuration
   topology:

--- a/docs/guides/cassandra/rotate-auth/cassandra.md
+++ b/docs/guides/cassandra/rotate-auth/cassandra.md
@@ -46,7 +46,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/guides/cassandra/scaling/horizontal-scaling/topology.md
+++ b/docs/guides/cassandra/scaling/horizontal-scaling/topology.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `Cassandra` topology cluster using a supported ve
 
 ### Prepare Cassandra Topology cluster
 
-Now, we are going to deploy a `Cassandra` topology cluster with version `5.0.3`.
+Now, we are going to deploy a `Cassandra` topology cluster with version `5.0.7`.
 
 ### Deploy Cassandra topology cluster
 
@@ -55,7 +55,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/guides/cassandra/scaling/vertical-scaling/topology.md
+++ b/docs/guides/cassandra/scaling/vertical-scaling/topology.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `Cassandra` topology cluster using a supported ve
 
 ### Prepare Cassandra Topology Cluster
 
-Now, we are going to deploy a `Cassandra` topology cluster database with version `5.0.3`.
+Now, we are going to deploy a `Cassandra` topology cluster database with version `5.0.7`.
 
 ### Deploy Cassandra Topology Cluster
 
@@ -55,7 +55,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0

--- a/docs/guides/cassandra/tls/topology.md
+++ b/docs/guides/cassandra/tls/topology.md
@@ -96,7 +96,7 @@ metadata:
   name: cassandra-prod-tls
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   tls:
     issuerRef:
       apiGroup: "cert-manager.io"

--- a/docs/guides/cassandra/update-version/update-version.md
+++ b/docs/guides/cassandra/update-version/update-version.md
@@ -38,7 +38,7 @@ namespace/demo created
 
 ## Prepare Cassandra
 
-Now, we are going to deploy a `Cassandra` replicaset database with version `4.1.8`.
+Now, we are going to deploy a `Cassandra` replicaset database with version `4.1.11`.
 
 ### Deploy Cassandra
 
@@ -51,7 +51,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 4.1.8
+  version: 4.1.11
   topology:
     rack:
       - name: r0
@@ -101,7 +101,7 @@ We are now ready to apply the `CassandraOpsRequest` CR to update.
 
 ### update Cassandra Version
 
-Here, we are going to update `Cassandra` from `4.1.8` to `5.0.3`.
+Here, we are going to update `Cassandra` from `4.1.11` to `5.0.7`.
 
 #### Create CassandraOpsRequest:
 
@@ -118,7 +118,7 @@ spec:
   databaseRef:
     name: cass
   updateVersion:
-    targetVersion: 5.0.3
+    targetVersion: 5.0.7
   timeout: 5m
   apply: IfReady
 ```
@@ -127,7 +127,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `cassandra-prod` Cassandra.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `5.0.3`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `5.0.7`.
 
 Let's create the `CassandraOpsRequest` CR we have shown above,
 

--- a/docs/guides/cassandra/volume-expansion/topology.md
+++ b/docs/guides/cassandra/volume-expansion/topology.md
@@ -57,7 +57,7 @@ longhorn-static        driver.longhorn.io      Delete          Immediate        
 
 We can see from the output the `longhorn` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We can use it.
 
-Now, we are going to deploy a `Cassandra` combined cluster with version `5.0.3`.
+Now, we are going to deploy a `Cassandra` combined cluster with version `5.0.7`.
 
 ### Deploy Cassandra
 
@@ -70,7 +70,7 @@ metadata:
   name: cassandra-prod
   namespace: demo
 spec:
-  version: 5.0.3
+  version: 5.0.7
   topology:
     rack:
       - name: r0


### PR DESCRIPTION
Bumps the **cassandra** example and guide manifests to the latest supported version (`5.0.7`) per the installer `active_versions.json`.

- General "deploy a cassandra" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cassandra examples and guides to reflect the newer Cassandra release version `5.0.7` in setup steps, manifests, and explanatory text.
  * Aligned upgrade/version-change walkthroughs and sample outputs with the latest target version.
  * Updated one example deployment to use Cassandra `4.1.11` in the prepare step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->