### PR TITLE
Update clickhouse docs examples to latest supported version (26.2.6)

### DIFF
--- a/docs/examples/clickhouse/autoscaling/compute/clickhouse-autoscale.yaml
+++ b/docs/examples/clickhouse/autoscaling/compute/clickhouse-autoscale.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/examples/clickhouse/autoscaling/storage/clickhouse-autoscale.yaml
+++ b/docs/examples/clickhouse/autoscaling/storage/clickhouse-autoscale.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/examples/clickhouse/custom-config/ch-custom-config-cluster.yaml
+++ b/docs/examples/clickhouse/custom-config/ch-custom-config-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ch-cluster
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   configuration:
     secretName: ch-configuration
   clusterTopology:

--- a/docs/examples/clickhouse/custom-config/ch-custom-config-standalone.yaml
+++ b/docs/examples/clickhouse/custom-config/ch-custom-config-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ch-standalone
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   configuration:
     secretName: clickhouse-configuration
   replicas: 1

--- a/docs/examples/clickhouse/monitoring/builtin-prom-clickhouse.yaml
+++ b/docs/examples/clickhouse/monitoring/builtin-prom-clickhouse.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-builtin-prom
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/examples/clickhouse/monitoring/coreos-prom-clickhouse.yaml
+++ b/docs/examples/clickhouse/monitoring/coreos-prom-clickhouse.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/examples/clickhouse/quickstart/demo-standalone.yaml
+++ b/docs/examples/clickhouse/quickstart/demo-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ch
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   replicas: 1
   storage:
     accessModes:

--- a/docs/examples/clickhouse/reconfigure-tls/clickhouse-cluster.yaml
+++ b/docs/examples/clickhouse/reconfigure-tls/clickhouse-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/examples/clickhouse/reconfigure-tls/clickhouse-standalone.yaml
+++ b/docs/examples/clickhouse/reconfigure-tls/clickhouse-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ch
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   replicas: 1
   storage:
     accessModes:

--- a/docs/examples/clickhouse/reconfigure/clickhouse-cluster.yaml
+++ b/docs/examples/clickhouse/reconfigure/clickhouse-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   configuration:
     secretName: ch-custom-config
   clusterTopology:

--- a/docs/examples/clickhouse/reconfigure/clickhouse-standalone.yaml
+++ b/docs/examples/clickhouse/reconfigure/clickhouse-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   configuration:
     secretName: ch-custom-config
   replicas: 1

--- a/docs/examples/clickhouse/restart/clickhouse-cluster.yaml
+++ b/docs/examples/clickhouse/restart/clickhouse-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/examples/clickhouse/rotate-auth/clickhouse-cluster.yaml
+++ b/docs/examples/clickhouse/rotate-auth/clickhouse-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse
   namespace: demo
 spec:
-  version: 25.7.1
+  version: 26.2.6
   replicas: 1
   storage:
     accessModes:

--- a/docs/examples/clickhouse/rotate-auth/clickhouse-standalone.yaml
+++ b/docs/examples/clickhouse/rotate-auth/clickhouse-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ch
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   replicas: 1
   storage:
     accessModes:

--- a/docs/examples/clickhouse/scaling/clickhouse-cluster.yaml
+++ b/docs/examples/clickhouse/scaling/clickhouse-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/examples/clickhouse/scaling/clickhouse-standalone.yaml
+++ b/docs/examples/clickhouse/scaling/clickhouse-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   replicas: 1
   storage:
     accessModes:

--- a/docs/examples/clickhouse/tls/clickhouse-cluster-tls.yaml
+++ b/docs/examples/clickhouse/tls/clickhouse-cluster-tls.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-prod-tls
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/examples/clickhouse/tls/clickhouse-standalone-tls.yaml
+++ b/docs/examples/clickhouse/tls/clickhouse-standalone-tls.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ch
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   replicas: 1
   storage:
     accessModes:

--- a/docs/examples/clickhouse/update-version/clickhouse-cluster.yaml
+++ b/docs/examples/clickhouse/update-version/clickhouse-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 25.12.3
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/examples/clickhouse/update-version/clickhouse-standalone.yaml
+++ b/docs/examples/clickhouse/update-version/clickhouse-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ch
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 25.12.3
   replicas: 1
   storage:
     accessModes:

--- a/docs/examples/clickhouse/update-version/update-version.yaml
+++ b/docs/examples/clickhouse/update-version/update-version.yaml
@@ -8,6 +8,6 @@ spec:
   databaseRef:
     name: clickhouse-prod
   updateVersion:
-    targetVersion: 25.7.1
+    targetVersion: 26.2.6
   timeout: 5m
   apply: IfReady

--- a/docs/examples/clickhouse/volume-expansion/clickhouse-cluster.yaml
+++ b/docs/examples/clickhouse/volume-expansion/clickhouse-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/examples/clickhouse/volume-expansion/clickhouse-standalone.yaml
+++ b/docs/examples/clickhouse/volume-expansion/clickhouse-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ch
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   replicas: 1
   storage:
     storageClassName: standard

--- a/docs/guides/clickhouse/README.md
+++ b/docs/guides/clickhouse/README.md
@@ -33,6 +33,8 @@ aliases:
 KubeDB supports the following ClickHouse Versions.
 - `24.4.1`
 - `25.7.1`
+- `25.12.3`
+- `26.2.6`
 
 ## Life Cycle of a ClickHouse Object
 

--- a/docs/guides/clickhouse/autoscaler/compute/compute-autoscale.md
+++ b/docs/guides/clickhouse/autoscaler/compute/compute-autoscale.md
@@ -41,7 +41,7 @@ namespace/demo created
 
 ## Autoscaling of ClickHouse
 
-In this section, we are going to deploy a ClickHouse with version `24.4.1`  Then, in the next section we will set up autoscaling for this ClickHouse using `ClickHouseAutoscaler` CRD. Below is the YAML of the `ClickHouse` CR that we are going to create,
+In this section, we are going to deploy a ClickHouse with version `26.2.6`  Then, in the next section we will set up autoscaling for this ClickHouse using `ClickHouseAutoscaler` CRD. Below is the YAML of the `ClickHouse` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -50,7 +50,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/guides/clickhouse/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/clickhouse/autoscaler/storage/storage-autoscale.md
@@ -68,7 +68,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/guides/clickhouse/concepts/appbinding.md
+++ b/docs/guides/clickhouse/concepts/appbinding.md
@@ -67,7 +67,7 @@ spec:
   secret:
     name: ch-cluster-auth
   type: kubedb.com/clickhouse
-  version: 24.4.1
+  version: 26.2.6
 ```
 Here, we are going to describe the sections of an `AppBinding` crd.
 

--- a/docs/guides/clickhouse/concepts/clickhouse.md
+++ b/docs/guides/clickhouse/concepts/clickhouse.md
@@ -29,7 +29,7 @@ metadata:
   name: ch
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   authSecret:
     kind: Secret
     name: clickhouse-auth
@@ -98,6 +98,8 @@ spec:
 
 - `24.4.1`
 - `25.7.1`
+- `25.12.3`
+- `26.2.6`
 
 ### spec.replicas
 

--- a/docs/guides/clickhouse/configuration/using-config-file.md
+++ b/docs/guides/clickhouse/configuration/using-config-file.md
@@ -89,7 +89,7 @@ metadata:
   name: ch-standalone
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   configuration:
     secretName: clickhouse-configuration
   replicas: 1

--- a/docs/guides/clickhouse/monitoring/overview.md
+++ b/docs/guides/clickhouse/monitoring/overview.md
@@ -53,7 +53,7 @@ metadata:
   name: coreos-prom-clickhouse
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/guides/clickhouse/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/clickhouse/monitoring/using-builtin-prometheus.md
@@ -49,7 +49,7 @@ metadata:
   name: clickhouse-builtin-prom
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/guides/clickhouse/monitoring/using-prometheus-operator.md
+++ b/docs/guides/clickhouse/monitoring/using-prometheus-operator.md
@@ -195,7 +195,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/guides/clickhouse/quickstart/guide/quickstart.md
+++ b/docs/guides/clickhouse/quickstart/guide/quickstart.md
@@ -65,7 +65,7 @@ metadata:
   name: clickhouse-quickstart
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   replicas: 1
   storage:
     accessModes:
@@ -83,7 +83,7 @@ clickhouse.kubedb.com/clickhouse-quickstart created
 
 Here,
 
-- `spec.version` is the name of the ClickHouseVersion CRD where the docker images are specified. In this tutorial, a ClickHouse `24.4.1` database is going to be created.
+- `spec.version` is the name of the ClickHouseVersion CRD where the docker images are specified. In this tutorial, a ClickHouse `26.2.6` database is going to be created.
 - `spec.storageType` specifies the type of storage that will be used for ClickHouse database. It can be `Durable` or `Ephemeral`. Default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create ClickHouse database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the StatefulSet created by KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests.
 - `spec.terminationPolicy` or `spec.deletionPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `ClickHouse` crd or which resources KubeDB should keep or delete when you delete `ClickHouse` crd. If admission webhook is enabled, It prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`. Learn details of all `TerminationPolicy` [here](/docs/guides/mysql/concepts/database/index.md#specterminationpolicy)
@@ -291,7 +291,7 @@ spec:
       requests:
         storage: 1Gi
   storageType: Durable
-  version: 24.4.1
+  version: 26.2.6
 status:
   conditions:
     - lastTransitionTime: "2025-09-03T10:06:06Z"

--- a/docs/guides/clickhouse/quickstart/yamls/quickstart-v1alpha2.yaml
+++ b/docs/guides/clickhouse/quickstart/yamls/quickstart-v1alpha2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: clickhouse-quickstart
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   replicas: 1
   storage:
     accessModes:

--- a/docs/guides/clickhouse/reconfigure-tls/clickhouse.md
+++ b/docs/guides/clickhouse/reconfigure-tls/clickhouse.md
@@ -48,7 +48,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/guides/clickhouse/reconfigure/reconfigure.md
+++ b/docs/guides/clickhouse/reconfigure/reconfigure.md
@@ -40,7 +40,7 @@ Now, we are going to deploy a  `ClickHouse` cluster using a supported version by
 
 ### Prepare ClickHouse Cluster
 
-Now, we are going to deploy a `ClickHouse` topology cluster with version `24.4.1`.
+Now, we are going to deploy a `ClickHouse` topology cluster with version `26.2.6`.
 
 ### Deploy ClickHouse
 
@@ -87,7 +87,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   configuration:
     secretName: ch-custom-config
   clusterTopology:

--- a/docs/guides/clickhouse/restart/restart.md
+++ b/docs/guides/clickhouse/restart/restart.md
@@ -42,7 +42,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/guides/clickhouse/rotate-auth/rotateauth.md
+++ b/docs/guides/clickhouse/rotate-auth/rotateauth.md
@@ -46,7 +46,7 @@ metadata:
   name: clickhouse
   namespace: demo
 spec:
-  version: 25.7.1
+  version: 26.2.6
   replicas: 1
   storage:
     accessModes:

--- a/docs/guides/clickhouse/scaling/horizontal-scaling/cluster.md
+++ b/docs/guides/clickhouse/scaling/horizontal-scaling/cluster.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `ClickHouse` cluster using a supported version by
 
 ### Prepare ClickHouse cluster
 
-Now, we are going to deploy a `ClickHouse` cluster with version `24.4.1`.
+Now, we are going to deploy a `ClickHouse` cluster with version `26.2.6`.
 
 ### Deploy ClickHouse Cluster
 
@@ -55,7 +55,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/guides/clickhouse/scaling/vertical-scaling/cluster.md
+++ b/docs/guides/clickhouse/scaling/vertical-scaling/cluster.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `ClickHouse` cluster using a supported version by
 
 ### Prepare ClickHouse Cluster
 
-Now, we are going to deploy a `ClickHouse` cluster database with version `24.4.1`.
+Now, we are going to deploy a `ClickHouse` cluster database with version `26.2.6`.
 
 ### Deploy ClickHouse Cluster
 
@@ -55,7 +55,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/guides/clickhouse/scaling/vertical-scaling/standalone.md
+++ b/docs/guides/clickhouse/scaling/vertical-scaling/standalone.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `ClickHouse` cluster using a supported version by
 
 ### Prepare ClickHouse Standalone
 
-Now, we are going to deploy a `ClickHouse` cluster database with version `24.4.1`.
+Now, we are going to deploy a `ClickHouse` cluster database with version `26.2.6`.
 
 ### Deploy ClickHouse Standalone
 
@@ -55,7 +55,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   replicas: 1
   storage:
     accessModes:

--- a/docs/guides/clickhouse/tls/cluster.md
+++ b/docs/guides/clickhouse/tls/cluster.md
@@ -96,7 +96,7 @@ metadata:
   name: clickhouse-prod-tls
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false

--- a/docs/guides/clickhouse/update-version/update-version.md
+++ b/docs/guides/clickhouse/update-version/update-version.md
@@ -38,7 +38,7 @@ namespace/demo created
 
 ## Prepare ClickHouse
 
-Now, we are going to deploy a `ClickHouse` replicaset database with version `24.4.1`.
+Now, we are going to deploy a `ClickHouse` replicaset database with version `25.12.3`.
 
 ### Deploy ClickHouse
 
@@ -51,7 +51,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 25.12.3
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false
@@ -118,7 +118,7 @@ We are now ready to apply the `ClickHouseOpsRequest` CR to update.
 
 ### update ClickHouse Version
 
-Here, we are going to update `ClickHouse` from `24.4.1` to `25.7.1`.
+Here, we are going to update `ClickHouse` from `25.12.3` to `26.2.6`.
 
 #### Create ClickHouseOpsRequest:
 
@@ -135,7 +135,7 @@ spec:
   databaseRef:
     name: clickhouse-prod
   updateVersion:
-    targetVersion: 25.7.1
+    targetVersion: 26.2.6
   timeout: 5m
   apply: IfReady
 ```
@@ -144,7 +144,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `clickhouse-prod` ClickHouse.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `25.7.1`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `26.2.6`.
 
 Let's create the `ClickHouseOpsRequest` CR we have shown above,
 

--- a/docs/guides/clickhouse/volume-expansion/cluster.md
+++ b/docs/guides/clickhouse/volume-expansion/cluster.md
@@ -56,7 +56,7 @@ longhorn-static        driver.longhorn.io      Delete          Immediate        
 
 We can see from the output the `longhorn` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We can use it.
 
-Now, we are going to deploy a `ClickHouse` combined cluster with version `24.4.1`.
+Now, we are going to deploy a `ClickHouse` combined cluster with version `26.2.6`.
 
 ### Deploy ClickHouse
 
@@ -69,7 +69,7 @@ metadata:
   name: clickhouse-prod
   namespace: demo
 spec:
-  version: 24.4.1
+  version: 26.2.6
   clusterTopology:
     clickHouseKeeper:
       externallyManaged: false


### PR DESCRIPTION
Bumps the **clickhouse** example and guide manifests to the latest supported version (`26.2.6`) per the installer `active_versions.json`.

- General "deploy a clickhouse" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ClickHouse examples and guides to reflect newer versions, mainly moving from `24.4.1` to `26.2.6`.
  * Refreshed version references in quickstart, scaling, reconfigure, restart, TLS, monitoring, autoscaling, and volume expansion docs.
  * Expanded supported versions lists and aligned version update walkthroughs, including upgrade paths using `25.12.3` and `26.2.6`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->