### PR TITLE
Update hazelcast docs examples to latest supported version (5.5.6)

### DIFF
--- a/docs/examples/hazelcast/autoscaler/hazelcast.yaml
+++ b/docs/examples/hazelcast/autoscaler/hazelcast.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 5.5.2
+  version: 5.5.6
   licenseSecret:
     name: hz-license-key
   podTemplate:

--- a/docs/examples/hazelcast/configuration/hazelcast-config.yaml
+++ b/docs/examples/hazelcast/configuration/hazelcast-config.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 5.5.2
+  version: 5.5.6
   licenseSecret:
     name: hz-license-key
   configuration:

--- a/docs/examples/hazelcast/monitoring/hazelcast-builtin.yaml
+++ b/docs/examples/hazelcast/monitoring/hazelcast-builtin.yaml
@@ -15,7 +15,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/hazelcast/monitoring/hazelcast-operator.yaml
+++ b/docs/examples/hazelcast/monitoring/hazelcast-operator.yaml
@@ -15,7 +15,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/hazelcast/reconfigure-tls/hazelcast.yaml
+++ b/docs/examples/hazelcast/reconfigure-tls/hazelcast.yaml
@@ -8,7 +8,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/hazelcast/scalling/horizontal-scaling/hazelcast.yaml
+++ b/docs/examples/hazelcast/scalling/horizontal-scaling/hazelcast.yaml
@@ -8,7 +8,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/hazelcast/scalling/vertical-scaling/hazelcast.yaml
+++ b/docs/examples/hazelcast/scalling/vertical-scaling/hazelcast.yaml
@@ -8,7 +8,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/hazelcast/tls/hazelcast.yaml
+++ b/docs/examples/hazelcast/tls/hazelcast.yaml
@@ -31,7 +31,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/hazelcast/volume-expansion/hazelcast.yaml
+++ b/docs/examples/hazelcast/volume-expansion/hazelcast.yaml
@@ -8,7 +8,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 2
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/hazelcast/autoscaler/compute/hazelcast-compute.md
+++ b/docs/guides/hazelcast/autoscaler/compute/hazelcast-compute.md
@@ -52,7 +52,7 @@ Here, we are going to deploy a `Hazelcast`  Cluster using a supported version by
 
 #### Deploy Hazelcast  Cluster
 
-In this section, we are going to deploy a Hazelcast Topology database with version `5.5.2`.  Then, in the next section we will set up autoscaling for this database using `HazelcastAutoscaler` CRD. Below is the YAML of the `Hazelcast` CR that we are going to create,
+In this section, we are going to deploy a Hazelcast Topology database with version `5.5.6`.  Then, in the next section we will set up autoscaling for this database using `HazelcastAutoscaler` CRD. Below is the YAML of the `Hazelcast` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -62,7 +62,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 5.5.2
+  version: 5.5.6
   licenseSecret:
     name: hz-license-key
   podTemplate:

--- a/docs/guides/hazelcast/autoscaler/storage/hazelcast-storage.md
+++ b/docs/guides/hazelcast/autoscaler/storage/hazelcast-storage.md
@@ -59,7 +59,7 @@ Now, we are going to deploy a `Hazelcast`  using a supported version by `KubeDB`
 
 #### Deploy Hazelcast 
 
-In this section, we are going to deploy a Hazelcast  cluster with version `5.5.2`.  Then, in the next section we will set up autoscaling for this cluster using `HazelcastAutoscaler` CRD. Below is the YAML of the `Hazelcast` CR that we are going to create,
+In this section, we are going to deploy a Hazelcast  cluster with version `5.5.6`.  Then, in the next section we will set up autoscaling for this cluster using `HazelcastAutoscaler` CRD. Below is the YAML of the `Hazelcast` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -69,7 +69,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 5.5.2
+  version: 5.5.6
   licenseSecret:
     name: hz-license-key
   podTemplate:

--- a/docs/guides/hazelcast/concepts/appbinding.md
+++ b/docs/guides/hazelcast/concepts/appbinding.md
@@ -67,7 +67,7 @@ spec:
   secret:
     name: hazelcast-sample-auth
   type: kubedb.com/hazelcast
-  version: 5.5.2
+  version: 5.5.6
 
 ```
 

--- a/docs/guides/hazelcast/concepts/hazelcast.md
+++ b/docs/guides/hazelcast/concepts/hazelcast.md
@@ -142,7 +142,7 @@ spec:
       apiGroup: cert-manager.io
       kind: ClusterIssuer
       name: self-signed-issuer
-  version: 5.5.2
+  version: 5.5.6
 ```
 
 

--- a/docs/guides/hazelcast/configuration/hazelcast-config.md
+++ b/docs/guides/hazelcast/configuration/hazelcast-config.md
@@ -102,7 +102,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 5.5.2
+  version: 5.5.6
   licenseSecret:
     name: hz-license-key
   configuration:

--- a/docs/guides/hazelcast/monitoring/prometheus-builtin.md
+++ b/docs/guides/hazelcast/monitoring/prometheus-builtin.md
@@ -64,7 +64,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/hazelcast/monitoring/prometheus-operator.md
+++ b/docs/guides/hazelcast/monitoring/prometheus-operator.md
@@ -206,7 +206,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/hazelcast/quickstart/overview/index.md
+++ b/docs/guides/hazelcast/quickstart/overview/index.md
@@ -65,9 +65,9 @@ NAME    VERSION   DB_IMAGE                               DEPRECATED   AGE
 
 Notice the `DEPRECATED` column. Here, `true` means that this HazelcastVersion is deprecated for the current KubeDB version. KubeDB will not work for deprecated HazelcastVersion.
 
-In this tutorial, we will use `5.5.2` HazelcastVersion CR to create a Hazelcast cluster.
+In this tutorial, we will use `5.5.6` HazelcastVersion CR to create a Hazelcast cluster.
 
-> Note: An image with a higher modification tag will have more features and fixes than an image with a lower modification tag. Hence, it is recommended to use HazelcastVersion CRD with the highest modification tag to take advantage of the latest features. For example, use `5.5.2`.
+> Note: An image with a higher modification tag will have more features and fixes than an image with a lower modification tag. Hence, it is recommended to use HazelcastVersion CRD with the highest modification tag to take advantage of the latest features. For example, use `5.5.6`.
 
 ## Create a Hazelcast Cluster
 
@@ -95,7 +95,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce
@@ -108,7 +108,7 @@ spec:
 
 Here,
 
-- `spec.version` - is the name of the HazelcastVersion CR. Here, a Hazelcast of version `5.5.2` will be created.
+- `spec.version` - is the name of the HazelcastVersion CR. Here, a Hazelcast of version `5.5.6` will be created.
 - `spec.replicas` - specifies the number of Hazelcast nodes.
 - `spec.licenseSecret` - specifies the license created for hazelcast enterprise version.
 - `spec.storageType` - specifies the type of storage that will be used for Hazelcast database. It can be `Durable` or `Ephemeral`. The default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create the Hazelcast database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.

--- a/docs/guides/hazelcast/quickstart/overview/yamls/hazelcast.yaml
+++ b/docs/guides/hazelcast/quickstart/overview/yamls/hazelcast.yaml
@@ -8,7 +8,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/hazelcast/reconfigure-tls/hazelcast.md
+++ b/docs/guides/hazelcast/reconfigure-tls/hazelcast.md
@@ -60,7 +60,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/hazelcast/restart/hazelcast.md
+++ b/docs/guides/hazelcast/restart/hazelcast.md
@@ -54,7 +54,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/hazelcast/rotate-auth/hazelcast.md
+++ b/docs/guides/hazelcast/rotate-auth/hazelcast.md
@@ -71,7 +71,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 2
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/hazelcast/scaling/horizontal-scaling/horizontal-scaling.md
+++ b/docs/guides/hazelcast/scaling/horizontal-scaling/horizontal-scaling.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `Hazelcast` database using a supported version by
 
 ### Prepare Hazelcast Database
 
-Now, we are going to deploy a `Hazelcast` database with version `5.5.2`.
+Now, we are going to deploy a `Hazelcast` database with version `5.5.6`.
 
 ### Deploy Hazelcast
 
@@ -67,7 +67,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/hazelcast/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/hazelcast/scaling/vertical-scaling/vertical-scaling.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `Hazelcast` database using a supported version by
 
 ### Prepare Hazelcast Database
 
-Now, we are going to deploy a `Hazelcast` database with version `5.5.2`.
+Now, we are going to deploy a `Hazelcast` database with version `5.5.6`.
 
 ### Deploy Hazelcast
 

--- a/docs/guides/hazelcast/tls/hazelcast.md
+++ b/docs/guides/hazelcast/tls/hazelcast.md
@@ -125,7 +125,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 3
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/hazelcast/update-version/hazelcast.md
+++ b/docs/guides/hazelcast/update-version/hazelcast.md
@@ -38,7 +38,7 @@ namespace/demo created
 
 ### Prepare Hazelcast Database
 
-Now, we are going to deploy a `Hazelcast` database with version `5.2.2`.
+Now, we are going to deploy a `Hazelcast` database with version `5.5.2`.
 
 ### Deploy Hazelcast:
 
@@ -91,7 +91,7 @@ We are now ready to apply the `HazelcastOpsRequest` CR to update this database.
 
 ### Update Hazelcast Version
 
-Here, we are going to update `Hazelcast` from `5.2.2` to `5.5.6`.
+Here, we are going to update `Hazelcast` from `5.5.2` to `5.5.6`.
 
 #### Create HazelcastOpsRequest:
 

--- a/docs/guides/hazelcast/volume-expansion/volume-expansion.md
+++ b/docs/guides/hazelcast/volume-expansion/volume-expansion.md
@@ -57,7 +57,7 @@ spec:
   licenseSecret:
     name: hz-license-key
   replicas: 2
-  version: 5.5.2
+  version: 5.5.6
   storage:
     accessModes:
       - ReadWriteOnce


### PR DESCRIPTION
Bumps the **hazelcast** example and guide manifests to the latest supported version (`5.5.6`) per the installer `active_versions.json`.

- General "deploy a hazelcast" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.