### PR TITLE
Update kafka docs examples to latest supported version (4.2.0)

### DIFF
--- a/docs/examples/kafka/autoscaler/kafka-combined.yaml
+++ b/docs/examples/kafka/autoscaler/kafka-combined.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 3.9.0
+  version: 4.2.0
   podTemplate:
     spec:
       containers:

--- a/docs/examples/kafka/autoscaler/kafka-topology.yaml
+++ b/docs/examples/kafka/autoscaler/kafka-topology.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/examples/kafka/clustering/kf-multinode.yaml
+++ b/docs/examples/kafka/clustering/kf-multinode.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: 3.9.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/kafka/clustering/kf-standalone.yaml
+++ b/docs/examples/kafka/clustering/kf-standalone.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: 3.9.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/kafka/clustering/kf-topology.yaml
+++ b/docs/examples/kafka/clustering/kf-topology.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   enableSSL: true
   tls:
     issuerRef:

--- a/docs/examples/kafka/configuration/kafka-combined.yaml
+++ b/docs/examples/kafka/configuration/kafka-combined.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 3.9.0
+  version: 4.2.0
   configuration:
     secretName: configsecret-combined
   storage:

--- a/docs/examples/kafka/configuration/kafka-topology.yaml
+++ b/docs/examples/kafka/configuration/kafka-topology.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   configuration:
     secretName: configsecret-topology
   topology:

--- a/docs/examples/kafka/connectcluster/connectcluster-quickstart.yaml
+++ b/docs/examples/kafka/connectcluster/connectcluster-quickstart.yaml
@@ -4,10 +4,10 @@ metadata:
   name: connectcluster-quickstart
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   replicas: 3
   connectorPlugins:
-    - mongodb-1.11.0
+    - mongodb-1.14.1
     - mysql-3.0.5.final
     - postgres-3.0.5.final
     - jdbc-3.0.5.final

--- a/docs/examples/kafka/connectcluster/kcc-distributed.yaml
+++ b/docs/examples/kafka/connectcluster/kcc-distributed.yaml
@@ -4,7 +4,7 @@ metadata:
   name: connectcluster-distributed
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   enableSSL: true
   tls:
     issuerRef:

--- a/docs/examples/kafka/migration/mirror-connect.yaml
+++ b/docs/examples/kafka/migration/mirror-connect.yaml
@@ -7,7 +7,7 @@ spec:
   authSecret:
     kind: Secret
     name: mirror-connect-auth
-  version: 3.9.0
+  version: 4.2.0
   replicas: 3
   kafkaRef:
     name: target-kafka

--- a/docs/examples/kafka/migration/source-kafka.yaml
+++ b/docs/examples/kafka/migration/source-kafka.yaml
@@ -8,7 +8,7 @@ spec:
     kind: Secret
     name: source-kafka-auth
   replicas: 2
-  version: 3.9.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/kafka/migration/target-cluster.yaml
+++ b/docs/examples/kafka/migration/target-cluster.yaml
@@ -7,7 +7,7 @@ spec:
   authSecret:
     kind: Secret
     name: target-kafka-auth
-  version: 3.9.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/examples/kafka/monitoring/kafka-builtin-prom.yaml
+++ b/docs/examples/kafka/monitoring/kafka-builtin-prom.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 3.9.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/kafka/monitoring/kf-with-monitoring.yaml
+++ b/docs/examples/kafka/monitoring/kf-with-monitoring.yaml
@@ -11,7 +11,7 @@ spec:
       name: kafka-ca-issuer
       kind: Issuer
   replicas: 3
-  version: 3.9.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/kafka/reconfigure-tls/kafka.yaml
+++ b/docs/examples/kafka/reconfigure-tls/kafka.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/examples/kafka/reconfigure/kafka-combined.yaml
+++ b/docs/examples/kafka/reconfigure/kafka-combined.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 3.9.0
+  version: 4.2.0
   configuration:
     secretName: kf-combined-custom-config
   storage:

--- a/docs/examples/kafka/reconfigure/kafka-topology.yaml
+++ b/docs/examples/kafka/reconfigure/kafka-topology.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   configuration:
     secretName: kf-topology-custom-config
   topology:

--- a/docs/examples/kafka/restart/kafka.yaml
+++ b/docs/examples/kafka/restart/kafka.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/examples/kafka/rotate-auth/kafka-prod.yaml
+++ b/docs/examples/kafka/rotate-auth/kafka-prod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/examples/kafka/scaling/kafka-combined.yaml
+++ b/docs/examples/kafka/scaling/kafka-combined.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 3.9.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/kafka/scaling/kafka-topology.yaml
+++ b/docs/examples/kafka/scaling/kafka-topology.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/examples/kafka/tiered-storage/kafka-azure-tiered.yaml
+++ b/docs/examples/kafka/tiered-storage/kafka-azure-tiered.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod-tiered
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   tieredStorage:
     provider: azure
     azure:

--- a/docs/examples/kafka/tiered-storage/kafka-gcs-tiered.yaml
+++ b/docs/examples/kafka/tiered-storage/kafka-gcs-tiered.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod-tiered
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   tieredStorage:
     provider: gcs
     gcs:

--- a/docs/examples/kafka/tiered-storage/kafka-s3-tiered.yaml
+++ b/docs/examples/kafka/tiered-storage/kafka-s3-tiered.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod-tiered
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   tieredStorage:
     provider: s3
     s3:

--- a/docs/examples/kafka/tls/connectcluster-tls.yaml
+++ b/docs/examples/kafka/tls/connectcluster-tls.yaml
@@ -4,7 +4,7 @@ metadata:
   name: connectcluster-tls
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   enableSSL: true
   tls:
     issuerRef:

--- a/docs/examples/kafka/tls/kafka-dev-tls.yaml
+++ b/docs/examples/kafka/tls/kafka-dev-tls.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-dev-tls
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   enableSSL: true
   tls:
     issuerRef:

--- a/docs/examples/kafka/tls/kafka-prod-tls.yaml
+++ b/docs/examples/kafka/tls/kafka-prod-tls.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod-tls
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   enableSSL: true
   tls:
     issuerRef:

--- a/docs/examples/kafka/update-version/kafka.yaml
+++ b/docs/examples/kafka/update-version/kafka.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 3.8.1
+  version: 4.0.0
   topology:
     broker:
       replicas: 2

--- a/docs/examples/kafka/update-version/update-version-ops.yaml
+++ b/docs/examples/kafka/update-version/update-version-ops.yaml
@@ -8,6 +8,6 @@ spec:
     databaseRef:
         name: kafka-prod
     updateVersion:
-        targetVersion: 3.9.0
+        targetVersion: 4.2.0
     timeout: 5m
     apply: IfReady

--- a/docs/examples/kafka/volume-expansion/kafka-combined.yaml
+++ b/docs/examples/kafka/volume-expansion/kafka-combined.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 3.9.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/kafka/volume-expansion/kafka-topology.yaml
+++ b/docs/examples/kafka/volume-expansion/kafka-topology.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 3.9.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/guides/kafka/autoscaler/compute/combined.md
+++ b/docs/guides/kafka/autoscaler/compute/combined.md
@@ -55,7 +55,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 4.0.0
+  version: 4.2.0
   podTemplate:
     spec:
       containers:

--- a/docs/guides/kafka/autoscaler/compute/topology.md
+++ b/docs/guides/kafka/autoscaler/compute/topology.md
@@ -54,7 +54,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/guides/kafka/autoscaler/storage/kafka-combined.md
+++ b/docs/guides/kafka/autoscaler/storage/kafka-combined.md
@@ -69,7 +69,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 4.0.0
+  version: 4.2.0
   podTemplate:
     spec:
       containers:

--- a/docs/guides/kafka/autoscaler/storage/kafka-topology.md
+++ b/docs/guides/kafka/autoscaler/storage/kafka-topology.md
@@ -68,7 +68,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/guides/kafka/cli/cli.md
+++ b/docs/guides/kafka/cli/cli.md
@@ -133,7 +133,7 @@ spec:
             storage: 1Gi
         storageClassName: standard
       suffix: controller
-  version: 4.0.0
+  version: 4.2.0
 status:
   conditions:
     - lastTransitionTime: "2023-03-29T07:01:29Z"

--- a/docs/guides/kafka/clustering/combined-cluster/index.md
+++ b/docs/guides/kafka/clustering/combined-cluster/index.md
@@ -47,7 +47,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: 4.0.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce
@@ -116,7 +116,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: 4.0.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/kafka/clustering/topology-cluster/index.md
+++ b/docs/guides/kafka/clustering/topology-cluster/index.md
@@ -89,7 +89,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   enableSSL: true
   tls:
     issuerRef:

--- a/docs/guides/kafka/concepts/appbinding.md
+++ b/docs/guides/kafka/concepts/appbinding.md
@@ -70,7 +70,7 @@ spec:
   tlsSecret:
     name: kafka-client-cert
   type: kubedb.com/kafka
-  version: 4.0.0
+  version: 4.2.0
 ```
 
 Here, we are going to describe the sections of an `AppBinding` crd.

--- a/docs/guides/kafka/concepts/connectcluster.md
+++ b/docs/guides/kafka/concepts/connectcluster.md
@@ -29,7 +29,7 @@ metadata:
   name: connectcluster
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   healthChecker:
     failureThreshold: 3
     periodSeconds: 20

--- a/docs/guides/kafka/concepts/kafka.md
+++ b/docs/guides/kafka/concepts/kafka.md
@@ -128,7 +128,7 @@ spec:
         labels:
           release: prometheus
         interval: 10s
-  version: 4.0.0
+  version: 4.2.0
 ```
 
 ### spec.version

--- a/docs/guides/kafka/concepts/kafkaversion.md
+++ b/docs/guides/kafka/concepts/kafkaversion.md
@@ -55,7 +55,7 @@ spec:
     databasePolicyName: kafka-db
   securityContext:
     runAsUser: 1001
-  version: 4.0.0
+  version: 3.9.0
 ```
 
 ### metadata.name

--- a/docs/guides/kafka/configuration/kafka-combined.md
+++ b/docs/guides/kafka/configuration/kafka-combined.md
@@ -88,7 +88,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 4.0.0
+  version: 4.2.0
   configuration:
     secretName: configsecret-combined
   storage:

--- a/docs/guides/kafka/configuration/kafka-topology.md
+++ b/docs/guides/kafka/configuration/kafka-topology.md
@@ -97,7 +97,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   configuration:
     secretName: configsecret-topology
   topology:

--- a/docs/guides/kafka/connectcluster/connectcluster.md
+++ b/docs/guides/kafka/connectcluster/connectcluster.md
@@ -92,7 +92,7 @@ metadata:
   name: connectcluster-distributed
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   enableSSL: true
   tls:
     issuerRef:

--- a/docs/guides/kafka/connectcluster/quickstart.md
+++ b/docs/guides/kafka/connectcluster/quickstart.md
@@ -116,7 +116,7 @@ metadata:
   name: connectcluster-quickstart
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   replicas: 3
   connectorPlugins:
     - mongodb-1.14.1

--- a/docs/guides/kafka/gitops/topology.md
+++ b/docs/guides/kafka/gitops/topology.md
@@ -762,7 +762,7 @@ kafkaopsrequest.ops.kubedb.com/kafka-gitops-volumeexpansion-9e85tf     VolumeExp
 
 List Kafka versions using `kubectl get kafkaversion` and choose desired version that is compatible for upgrade from current version. Check the version constraints and ops request [here](/docs/guides/kafka/update-version/update-version.md).
 
-Let's choose `4.0.0` in this example.
+Let's choose `4.2.0` in this example.
 
 Update the `Kafka.yaml` with the following,
 ```yaml
@@ -772,7 +772,7 @@ metadata:
   name: kafka-gitops
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   authSecret:
     kind: Secret
     name: kf-rotate-auth
@@ -827,7 +827,7 @@ spec:
   deletionPolicy: WipeOut
 ```
 
-Update the `version` field to `4.0.0`. Commit the changes and push to your Git repository. Your repository is synced with `ArgoCD` and the `Kafka` CR is updated in your cluster.
+Update the `version` field to `4.2.0`. Commit the changes and push to your Git repository. Your repository is synced with `ArgoCD` and the `Kafka` CR is updated in your cluster.
 
 Now, `gitops` operator will detect the version changes and create a `VersionUpdate` KafkaOpsRequest to update the `Kafka` database version. List the resources created by `gitops` operator in the `demo` namespace.
 
@@ -877,7 +877,7 @@ metadata:
   name: kafka-gitops
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   authSecret:
     kind: Secret
     name: kf-rotate-auth

--- a/docs/guides/kafka/migration/migration.md
+++ b/docs/guides/kafka/migration/migration.md
@@ -101,7 +101,7 @@ spec:
     kind: Secret
     name: source-kafka-auth
   replicas: 2
-  version: 4.0.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce
@@ -279,7 +279,7 @@ spec:
   authSecret:
     kind: Secret
     name: target-kafka-auth
-  version: 4.0.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2
@@ -363,7 +363,7 @@ spec:
   authSecret:
     kind: Secret
     name: mirror-connect-auth
-  version: 4.0.0
+  version: 4.2.0
   replicas: 3
   kafkaRef:
     name: target-kafka

--- a/docs/guides/kafka/monitoring/overview.md
+++ b/docs/guides/kafka/monitoring/overview.md
@@ -60,7 +60,7 @@ spec:
       name: kafka-ca-issuer
       kind: Issuer
   replicas: 3
-  version: 4.0.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/kafka/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/kafka/monitoring/using-builtin-prometheus.md
@@ -50,7 +50,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 4.0.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/kafka/monitoring/using-prometheus-operator.md
+++ b/docs/guides/kafka/monitoring/using-prometheus-operator.md
@@ -167,7 +167,7 @@ spec:
       name: kafka-ca-issuer
       kind: Issuer
   replicas: 3
-  version: 4.0.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/kafka/quickstart/kafka/index.md
+++ b/docs/guides/kafka/quickstart/kafka/index.md
@@ -89,7 +89,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: 4.0.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce
@@ -114,7 +114,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: 4.0.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/kafka/quickstart/kafka/yamls/kafka-v1.yaml
+++ b/docs/guides/kafka/quickstart/kafka/yamls/kafka-v1.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: 4.0.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/kafka/quickstart/kafka/yamls/kafka-v1alpha2.yaml
+++ b/docs/guides/kafka/quickstart/kafka/yamls/kafka-v1alpha2.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: 4.0.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/kafka/reconfigure-tls/kafka.md
+++ b/docs/guides/kafka/reconfigure-tls/kafka.md
@@ -48,7 +48,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/guides/kafka/reconfigure/kafka-combined.md
+++ b/docs/guides/kafka/reconfigure/kafka-combined.md
@@ -82,7 +82,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 4.0.0
+  version: 4.2.0
   configuration:
     secretName: kf-combined-custom-config
   storage:

--- a/docs/guides/kafka/reconfigure/kafka-topology.md
+++ b/docs/guides/kafka/reconfigure/kafka-topology.md
@@ -92,7 +92,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   configuration:
     secretName: kf-topology-custom-config
   topology:

--- a/docs/guides/kafka/restart/restart.md
+++ b/docs/guides/kafka/restart/restart.md
@@ -42,7 +42,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/guides/kafka/rotate-auth/kafka.md
+++ b/docs/guides/kafka/rotate-auth/kafka.md
@@ -46,7 +46,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/guides/kafka/scaling/horizontal-scaling/combined.md
+++ b/docs/guides/kafka/scaling/horizontal-scaling/combined.md
@@ -57,7 +57,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 4.0.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/kafka/scaling/horizontal-scaling/topology.md
+++ b/docs/guides/kafka/scaling/horizontal-scaling/topology.md
@@ -56,7 +56,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/guides/kafka/scaling/vertical-scaling/combined.md
+++ b/docs/guides/kafka/scaling/vertical-scaling/combined.md
@@ -57,7 +57,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 4.0.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/kafka/scaling/vertical-scaling/topology.md
+++ b/docs/guides/kafka/scaling/vertical-scaling/topology.md
@@ -56,7 +56,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2

--- a/docs/guides/kafka/tiered-storage/tiered-storage.md
+++ b/docs/guides/kafka/tiered-storage/tiered-storage.md
@@ -71,7 +71,7 @@ metadata:
   name: kafka-prod-tiered
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   tieredStorage:
     provider: s3
     s3:
@@ -240,7 +240,7 @@ metadata:
   name: kafka-prod-tiered
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   tieredStorage:
     provider: azure
     azure:
@@ -307,7 +307,7 @@ metadata:
   name: kafka-prod-tiered
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   tieredStorage:
     provider: gcs
     gcs:

--- a/docs/guides/kafka/tls/combined.md
+++ b/docs/guides/kafka/tls/combined.md
@@ -97,7 +97,7 @@ metadata:
   name: kafka-dev-tls
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   enableSSL: true
   tls:
     issuerRef:

--- a/docs/guides/kafka/tls/connectcluster.md
+++ b/docs/guides/kafka/tls/connectcluster.md
@@ -99,7 +99,7 @@ metadata:
   name: connectcluster-distributed
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   enableSSL: true
   tls:
     issuerRef:

--- a/docs/guides/kafka/tls/topology.md
+++ b/docs/guides/kafka/tls/topology.md
@@ -97,7 +97,7 @@ metadata:
   name: kafka-prod-tls
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   enableSSL: true
   tls:
     issuerRef:

--- a/docs/guides/kafka/update-version/update-version.md
+++ b/docs/guides/kafka/update-version/update-version.md
@@ -38,7 +38,7 @@ namespace/demo created
 
 ## Prepare Kafka
 
-Now, we are going to deploy a `Kafka` replicaset database with version `3.6.8`.
+Now, we are going to deploy a `Kafka` replicaset database with version `4.0.0`.
 
 ### Deploy Kafka
 
@@ -116,7 +116,7 @@ We are now ready to apply the `KafkaOpsRequest` CR to update.
 
 ### update Kafka Version
 
-Here, we are going to update `Kafka` from `3.8.1` to `3.9.0`.
+Here, we are going to update `Kafka` from `4.0.0` to `4.2.0`.
 
 #### Create KafkaOpsRequest:
 
@@ -133,7 +133,7 @@ spec:
   databaseRef:
     name: kafka-prod
   updateVersion:
-    targetVersion: 3.9.0
+    targetVersion: 4.2.0
   timeout: 5m
   apply: IfReady
 ```
@@ -142,7 +142,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `kafka-prod` Kafka.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `3.9.0`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `4.2.0`.
 
 > **Note:** If you want to update combined Kafka, you just refer to the `Kafka` combined object name in `spec.databaseRef.name`. To create a combined Kafka, you can refer to the [Kafka Combined](/docs/guides/kafka/clustering/combined-cluster/index.md) guide.
 

--- a/docs/guides/kafka/volume-expansion/combined.md
+++ b/docs/guides/kafka/volume-expansion/combined.md
@@ -69,7 +69,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: 4.0.0
+  version: 4.2.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/kafka/volume-expansion/topology.md
+++ b/docs/guides/kafka/volume-expansion/topology.md
@@ -68,7 +68,7 @@ metadata:
   name: kafka-prod
   namespace: demo
 spec:
-  version: 4.0.0
+  version: 4.2.0
   topology:
     broker:
       replicas: 2


### PR DESCRIPTION
Bumps the **kafka** example and guide manifests to the latest supported version (`4.2.0`) per the installer `active_versions.json`.

- General "deploy a kafka" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.