### PR TITLE
Update mariadb docs examples to latest supported version (12.1.2)

### DIFF
--- a/docs/examples/mariadb/initialization/git-sync-public.yaml
+++ b/docs/examples/mariadb/initialization/git-sync-public.yaml
@@ -14,7 +14,7 @@ spec:
           - --root=/root
           # terminate after one successful sync
           - --one-time
-  version: "11.8.5"
+  version: "12.1.2"
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/mariadb/restart/MariaDB.yaml
+++ b/docs/examples/mariadb/restart/MariaDB.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/examples/mariadb/scaling/md-replication.yaml
+++ b/docs/examples/mariadb/scaling/md-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: md-replication
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   topology:
     mode: MariaDBReplication

--- a/docs/examples/mariadb/volume-expansion/md-replication.yaml
+++ b/docs/examples/mariadb/volume-expansion/md-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: md-replication
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   topology:
     mode: MariaDBReplication

--- a/docs/guides/mariadb/autoscaler/compute/cluster/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/autoscaler/compute/cluster/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/autoscaler/compute/cluster/index.md
+++ b/docs/guides/mariadb/autoscaler/compute/cluster/index.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `MariaDB` Cluster using a supported version by `K
 
 #### Deploy MariaDB Cluster
 
-In this section, we are going to deploy a MariaDB Cluster with version `11.8.5`. Then, in the next section we will set up autoscaling for this database using `MariaDBAutoscaler` CRD. Below is the YAML of the `MariaDB` CR that we are going to create,
+In this section, we are going to deploy a MariaDB Cluster with version `12.1.2`. Then, in the next section we will set up autoscaling for this database using `MariaDBAutoscaler` CRD. Below is the YAML of the `MariaDB` CR that we are going to create,
 > If you want to autoscale MariaDB `Standalone`, Just remove the `spec.Replicas` from the below yaml and rest of the steps are same.
 
 ```yaml
@@ -52,7 +52,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/autoscaler/storage/cluster/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/autoscaler/storage/cluster/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mariadb/autoscaler/storage/cluster/index.md
@@ -58,7 +58,7 @@ Now, we are going to deploy a `MariaDB` replicaset using a supported version by 
 
 #### Deploy MariaDB Cluster
 
-In this section, we are going to deploy a MariaDB replicaset database with version `11.8.5`.  Then, in the next section we will set up autoscaling for this database using `MariaDBAutoscaler` CRD. Below is the YAML of the `MariaDB` CR that we are going to create,
+In this section, we are going to deploy a MariaDB replicaset database with version `12.1.2`.  Then, in the next section we will set up autoscaling for this database using `MariaDBAutoscaler` CRD. Below is the YAML of the `MariaDB` CR that we are going to create,
 
 > If you want to autoscale MariaDB `Standalone`, Just remove the `spec.Replicas` from the below yaml and rest of the steps are same.
 
@@ -69,7 +69,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/kubestash/application-level/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/backup/kubestash/application-level/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: 11.1.3
+  version: 12.1.2
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/kubestash/application-level/index.md
+++ b/docs/guides/mariadb/backup/kubestash/application-level/index.md
@@ -65,7 +65,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: 11.1.3
+  version: 12.1.2
   replicas: 3
   storageType: Durable
   storage:
@@ -184,7 +184,7 @@ items:
         
         
       type: kubedb.com/mariadb
-      version: 11.1.3
+      version: 12.1.2
 kind: List
 metadata:
   resourceVersion: ""

--- a/docs/guides/mariadb/backup/kubestash/auto-backup/examples/sample-mariadb-2.yaml
+++ b/docs/guides/mariadb/backup/kubestash/auto-backup/examples/sample-mariadb-2.yaml
@@ -12,7 +12,7 @@ metadata:
     variables.kubestash.com/targetName: sample-mariadb-2
     variables.kubestash.com/targetedDatabase: mysql
 spec:
-  version: 11.1.3
+  version: 12.1.2
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/kubestash/auto-backup/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/backup/kubestash/auto-backup/examples/sample-mariadb.yaml
@@ -7,7 +7,7 @@ metadata:
     blueprint.kubestash.com/name: mariadb-default-backup-blueprint
     blueprint.kubestash.com/namespace: demo
 spec:
-  version: 11.1.3
+  version: 12.1.2
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/mariadb/backup/kubestash/auto-backup/index.md
@@ -218,7 +218,7 @@ metadata:
     blueprint.kubestash.com/name: mariadb-default-backup-blueprint
     blueprint.kubestash.com/namespace: demo
 spec:
-  version: 11.1.3
+  version: 12.1.2
   replicas: 3
   storageType: Durable
   storage:
@@ -571,7 +571,7 @@ metadata:
     variables.kubestash.com/targetName: sample-mariadb-2
     variables.kubestash.com/targetedDatabase: mysql
 spec:
-  version: 11.1.3
+  version: 12.1.2
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/kubestash/customization/common/sample-mariadb.yaml
+++ b/docs/guides/mariadb/backup/kubestash/customization/common/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: 11.1.3
+  version: 12.1.2
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/kubestash/logical/examples/restored-mariadb.yaml
+++ b/docs/guides/mariadb/backup/kubestash/logical/examples/restored-mariadb.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   init:
     waitForInitialRestore: true
-  version: 11.1.3
+  version: 12.1.2
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/kubestash/logical/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/backup/kubestash/logical/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: 11.1.3
+  version: 12.1.2
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/kubestash/logical/index.md
+++ b/docs/guides/mariadb/backup/kubestash/logical/index.md
@@ -68,7 +68,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: 11.1.3
+  version: 12.1.2
   replicas: 3
   storageType: Durable
   storage:
@@ -181,7 +181,7 @@ spec:
   secret:
     name: sample-mariadb-auth
   type: kubedb.com/mariadb
-  version: 11.1.3
+  version: 12.1.2
 ```
 
 KubeStash uses the `AppBinding` CR to connect with the target database. It requires the following two fields to set in AppBinding's `.spec` section.
@@ -569,7 +569,7 @@ metadata:
 spec:
   init:
     waitForInitialRestore: true
-  version: 11.1.3
+  version: 12.1.2
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/stash/auto-backup/examples/sample-mariadb-2.yaml
+++ b/docs/guides/mariadb/backup/stash/auto-backup/examples/sample-mariadb-2.yaml
@@ -7,7 +7,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mariadb-backup-template
     stash.appscode.com/schedule: "*/3 * * * *"
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/stash/auto-backup/examples/sample-mariadb-3.yaml
+++ b/docs/guides/mariadb/backup/stash/auto-backup/examples/sample-mariadb-3.yaml
@@ -7,7 +7,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mariadb-backup-template
     params.stash.appscode.com/args: --databases mysql
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/stash/auto-backup/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/backup/stash/auto-backup/examples/sample-mariadb.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     stash.appscode.com/backup-blueprint: mariadb-backup-template
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/stash/auto-backup/index.md
+++ b/docs/guides/mariadb/backup/stash/auto-backup/index.md
@@ -128,7 +128,7 @@ metadata:
   annotations:
     stash.appscode.com/backup-blueprint: mariadb-backup-template
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 1
   storageType: Durable
   storage:
@@ -297,7 +297,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mariadb-backup-template
     stash.appscode.com/schedule: "*/3 * * * *"
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 1
   storageType: Durable
   storage:
@@ -478,7 +478,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mariadb-backup-template
     params.stash.appscode.com/args: --databases mysql
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/stash/customization/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/backup/stash/customization/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/stash/logical/cluster/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/backup/stash/logical/cluster/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/stash/logical/cluster/index.md
+++ b/docs/guides/mariadb/backup/stash/logical/cluster/index.md
@@ -54,7 +54,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/stash/logical/standalone/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/backup/stash/logical/standalone/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/backup/stash/logical/standalone/index.md
+++ b/docs/guides/mariadb/backup/stash/logical/standalone/index.md
@@ -54,7 +54,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/clustering/galera-cluster/examples/demo-1.yaml
+++ b/docs/guides/mariadb/clustering/galera-cluster/examples/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   topology:
     mode: GaleraCluster

--- a/docs/guides/mariadb/clustering/galera-cluster/index.md
+++ b/docs/guides/mariadb/clustering/galera-cluster/index.md
@@ -46,7 +46,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   topology:
     mode: GaleraCluster
@@ -104,7 +104,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   deletionPolicy: WipeOut
-  version: 11.8.5
+  version: 12.1.2
 status:
   conditions:
   - lastTransitionTime: "2021-03-16T09:39:01Z"

--- a/docs/guides/mariadb/clustering/mariadb-replication/examples/demo-1.yaml
+++ b/docs/guides/mariadb/clustering/mariadb-replication/examples/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   topology:
     mode: MariaDBReplication

--- a/docs/guides/mariadb/clustering/mariadb-replication/index.md
+++ b/docs/guides/mariadb/clustering/mariadb-replication/index.md
@@ -46,7 +46,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   topology:
     mode: MariaDBReplication
@@ -220,7 +220,7 @@ spec:
             storage: 50Mi
       storageType: Durable
     mode: MariaDBReplication
-  version: 11.8.5
+  version: 12.1.2
 status:
   conditions:
   ...

--- a/docs/guides/mariadb/concepts/appbinding/index.md
+++ b/docs/guides/mariadb/concepts/appbinding/index.md
@@ -49,7 +49,7 @@ spec:
   secret:
     name: sample-mariadb-auth
   type: kubedb.com/mariadb
-  version: 11.8.5
+  version: 12.1.2
 ```
 
 Here, we are going to describe the sections of an `AppBinding` crd.

--- a/docs/guides/mariadb/concepts/mariadb/index.md
+++ b/docs/guides/mariadb/concepts/mariadb/index.md
@@ -86,14 +86,14 @@ spec:
       apiGroup: cert-manager.io
       kind: Issuer
       name: md-issuer
-  version: 11.8.5
+  version: 12.1.2
 ```
 
 ### spec.version
 
 `spec.version` is a required field specifying the name of the [MariaDBVersion](/docs/guides/mariadb/concepts/mariadb-version) crd where the docker images are specified. Currently, when you install KubeDB, it creates the following `MariaDBVersion` resources,
 
-- `11.8.5`, `10.4.32`
+- `12.1.2`, `10.4.32`
 
 ### spec.authSecret
 
@@ -162,7 +162,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: 11.8.5
+  version: 12.1.2
   init:
     script:
       configMap:
@@ -359,7 +359,7 @@ KubeDB allows following fields to set in `spec.serviceTemplates`:
 
 ```bash
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   serviceTemplates:
     - alias: primary
       metadata:

--- a/docs/guides/mariadb/configuration/using-config-file/examples/md-custom.yaml
+++ b/docs/guides/mariadb/configuration/using-config-file/examples/md-custom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   configuration:
     secretName: md-configuration
   storageType: Durable

--- a/docs/guides/mariadb/configuration/using-config-file/index.md
+++ b/docs/guides/mariadb/configuration/using-config-file/index.md
@@ -103,7 +103,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.5.23"
+  version: "12.1.2"
   configuration:
     secretName: md-configuration
   storageType: Durable

--- a/docs/guides/mariadb/configuration/using-pod-template/examples/md-misc-config.yaml
+++ b/docs/guides/mariadb/configuration/using-pod-template/examples/md-misc-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mariadb/configuration/using-pod-template/index.md
+++ b/docs/guides/mariadb/configuration/using-pod-template/index.md
@@ -68,7 +68,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mariadb/custom-rbac/using-custom-rbac/examples/md-custom-db-2.yaml
+++ b/docs/guides/mariadb/custom-rbac/using-custom-rbac/examples/md-custom-db-2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: another-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/mariadb/custom-rbac/using-custom-rbac/examples/md-custom-db.yaml
+++ b/docs/guides/mariadb/custom-rbac/using-custom-rbac/examples/md-custom-db.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/mariadb/custom-rbac/using-custom-rbac/index.md
+++ b/docs/guides/mariadb/custom-rbac/using-custom-rbac/index.md
@@ -135,7 +135,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storageType: Durable
   podTemplate:
     spec:
@@ -197,7 +197,7 @@ metadata:
   name: another-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/mariadb/distributed/autoscaler/compute/cluster/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/distributed/autoscaler/compute/cluster/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.5.2"
+  version: "12.1.2"
   distributed: true
   replicas: 3
   storageType: Durable

--- a/docs/guides/mariadb/distributed/autoscaler/compute/cluster/index.md
+++ b/docs/guides/mariadb/distributed/autoscaler/compute/cluster/index.md
@@ -91,7 +91,7 @@ placementpolicy.apps.k8s.appscode.com/distributed-mariadb created
 
 ### Deploy Distributed MariaDB Cluster
 
-In this section, we are going to deploy a distributed MariaDB Galera cluster with version `11.5.2`. Then, in the next section we will set up autoscaling for this database using `MariaDBAutoscaler` CRD.
+In this section, we are going to deploy a distributed MariaDB Galera cluster with version `12.1.2`. Then, in the next section we will set up autoscaling for this database using `MariaDBAutoscaler` CRD.
 
 Below is the YAML of the `MariaDB` CR that we are going to create. Note that `spec.distributed` is set to `true` and the `PlacementPolicy` is referenced via `spec.podTemplate.spec.podPlacementPolicy`:
 
@@ -102,7 +102,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.5.2"
+  version: "12.1.2"
   distributed: true
   replicas: 3
   storageType: Durable

--- a/docs/guides/mariadb/distributed/autoscaler/storage/cluster/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/distributed/autoscaler/storage/cluster/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.5.2"
+  version: "12.1.2"
   distributed: true
   replicas: 3
   storageType: Durable

--- a/docs/guides/mariadb/distributed/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mariadb/distributed/autoscaler/storage/cluster/index.md
@@ -126,7 +126,7 @@ placementpolicy.apps.k8s.appscode.com/distributed-mariadb created
 
 ### Deploy Distributed MariaDB Cluster
 
-In this section, we are going to deploy a distributed MariaDB replicaset database with version `11.5.2`. Then, in the next section we will set up autoscaling for this database using `MariaDBAutoscaler` CRD.
+In this section, we are going to deploy a distributed MariaDB replicaset database with version `12.1.2`. Then, in the next section we will set up autoscaling for this database using `MariaDBAutoscaler` CRD.
 
 Below is the YAML of the `MariaDB` CR that we are going to create. Note that `spec.distributed` is set to `true` and the `PlacementPolicy` is referenced via `spec.podTemplate.spec.podPlacementPolicy`:
 
@@ -137,7 +137,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.5.2"
+  version: "12.1.2"
   distributed: true
   replicas: 3
   storageType: Durable

--- a/docs/guides/mariadb/distributed/opsrequest/examples/mariadb.yaml
+++ b/docs/guides/mariadb/distributed/opsrequest/examples/mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mariadb
   namespace: demo
 spec:
-  version: "11.5.2"
+  version: "12.1.2"
   distributed: true
   replicas: 3
   storageType: Durable

--- a/docs/guides/mariadb/distributed/opsrequest/horizontal_scale.md
+++ b/docs/guides/mariadb/distributed/opsrequest/horizontal_scale.md
@@ -96,7 +96,7 @@ placementpolicy.apps.k8s.appscode.com/distributed-mariadb created
 
 ### Deploy Distributed MariaDB Cluster
 
-In this section, we are going to deploy a distributed MariaDB Galera cluster with version `11.5.2`. Note that `spec.distributed` is set to `true` and `spec.replicas` is `3`  which is less than the five indices defined in the `PlacementPolicy`. The operator will only create pods for indices `0`, `1`, and `2`.
+In this section, we are going to deploy a distributed MariaDB Galera cluster with version `12.1.2`. Note that `spec.distributed` is set to `true` and `spec.replicas` is `3`  which is less than the five indices defined in the `PlacementPolicy`. The operator will only create pods for indices `0`, `1`, and `2`.
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -105,7 +105,7 @@ metadata:
   name: mariadb
   namespace: demo
 spec:
-  version: "11.5.2"
+  version: "12.1.2"
   distributed: true
   replicas: 3
   storageType: Durable

--- a/docs/guides/mariadb/distributed/overview/index.md
+++ b/docs/guides/mariadb/distributed/overview/index.md
@@ -749,7 +749,7 @@ spec:
       requests:
         storage: 500Mi
   storageType: Durable
-  version: 11.5.2
+  version: 12.1.2
   podTemplate:
     spec:
       podPlacementPolicy:

--- a/docs/guides/mariadb/distributed/overview/yamls/mariadb.yaml
+++ b/docs/guides/mariadb/distributed/overview/yamls/mariadb.yaml
@@ -14,7 +14,7 @@ spec:
       requests:
         storage: 500Mi
   storageType: Durable
-  version: 11.5.2
+  version: 12.1.2
   podTemplate:
     spec:
       podPlacementPolicy:

--- a/docs/guides/mariadb/failover/guide.md
+++ b/docs/guides/mariadb/failover/guide.md
@@ -71,7 +71,7 @@ metadata:
   name: ha-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   topology:
     mode: MariaDBReplication

--- a/docs/guides/mariadb/initialization/git-sync.md
+++ b/docs/guides/mariadb/initialization/git-sync.md
@@ -52,7 +52,7 @@ spec:
        - --root=/root
        # terminate after one successful sync
        - --one-time 
-  version: "11.8.5"
+  version: "12.1.2"
   storage:
     accessModes:
     - ReadWriteOnce
@@ -175,7 +175,7 @@ spec:
        # run as git sync user 
        securityContext:
          runAsUser: 65533
-  version: "11.8.5"
+  version: "12.1.2"
   storage:
     accessModes:
     - ReadWriteOnce
@@ -229,7 +229,7 @@ spec:
        # run as git sync user 
        securityContext:
          runAsUser: 65533
-  version: "11.8.5"
+  version: "12.1.2"
   storage:
     accessModes:
     - ReadWriteOnce

--- a/docs/guides/mariadb/initialization/using-script/example/demo-1.yaml
+++ b/docs/guides/mariadb/initialization/using-script/example/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mariadb/initialization/using-script/index.md
+++ b/docs/guides/mariadb/initialization/using-script/index.md
@@ -59,7 +59,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storage:
     storageClassName: "standard"
     accessModes:
@@ -113,7 +113,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   deletionPolicy: WipeOut
-  version: 11.8.5
+  version: 12.1.2
 status:
   ...
   phase: Ready

--- a/docs/guides/mariadb/monitoring/builtin-prometheus/examples/builtin-prom-md.yaml
+++ b/docs/guides/mariadb/monitoring/builtin-prometheus/examples/builtin-prom-md.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-md
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mariadb/monitoring/builtin-prometheus/index.md
+++ b/docs/guides/mariadb/monitoring/builtin-prometheus/index.md
@@ -49,7 +49,7 @@ metadata:
   name: builtin-prom-md
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mariadb/monitoring/overview/index.md
+++ b/docs/guides/mariadb/monitoring/overview/index.md
@@ -53,7 +53,7 @@ metadata:
   name: coreos-prom-md
   namespace: demo
 spec:
-  version: "11.5.2"
+  version: "12.1.2"
   deletionPolicy: WipeOut
   storage:
     accessModes:

--- a/docs/guides/mariadb/monitoring/prometheus-operator/examples/prom-operator-md.yaml
+++ b/docs/guides/mariadb/monitoring/prometheus-operator/examples/prom-operator-md.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coreos-prom-md
   namespace: demo
 spec:
-  version: "11.5.2"
+  version: "12.1.2"
   deletionPolicy: WipeOut
   storage:
     accessModes:

--- a/docs/guides/mariadb/monitoring/prometheus-operator/index.md
+++ b/docs/guides/mariadb/monitoring/prometheus-operator/index.md
@@ -109,7 +109,7 @@ metadata:
   name: coreos-prom-md
   namespace: demo
 spec:
-  version: "10.5.23"
+  version: "12.1.2"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mariadb/pitr/nfs/index.md
+++ b/docs/guides/mariadb/pitr/nfs/index.md
@@ -355,7 +355,7 @@ metadata:
   labels:
     archiver: "true"
 spec:
-  version: "11.1.3"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:
@@ -512,7 +512,7 @@ spec:
         name: mariadb-full
         namespace: demo
       recoveryTimestamp: "2024-09-17T05:28:26Z"
-  version: "11.1.3"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/pitr/nfs/yamls/mariadb.yaml
+++ b/docs/guides/mariadb/pitr/nfs/yamls/mariadb.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     archiver: "true"
 spec:
-  version: "11.1.3"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/pitr/nfs/yamls/mariadbrestore.yaml
+++ b/docs/guides/mariadb/pitr/nfs/yamls/mariadbrestore.yaml
@@ -13,7 +13,7 @@ spec:
         name: mariadb-full
         namespace: demo
       recoveryTimestamp: "2025-09-17T05:28:26Z"
-  version: "11.1.3"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/pitr/overview/index.md
+++ b/docs/guides/mariadb/pitr/overview/index.md
@@ -216,7 +216,7 @@ metadata:
   labels:
     archiver: "true"
 spec:
-  version: "11.1.3"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:
@@ -373,7 +373,7 @@ spec:
         name: mariadb-full
         namespace: demo
       recoveryTimestamp: "2024-09-17T05:28:26Z"
-  version: "11.1.3"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/pitr/overview/yamls/mariadb.yaml
+++ b/docs/guides/mariadb/pitr/overview/yamls/mariadb.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     archiver: "true"
 spec:
-  version: "11.1.3"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/pitr/overview/yamls/mariadbrestore.yaml
+++ b/docs/guides/mariadb/pitr/overview/yamls/mariadbrestore.yaml
@@ -13,7 +13,7 @@ spec:
         name: mariadb-full
         namespace: demo
       recoveryTimestamp: "2025-09-17T05:28:26Z"
-  version: "11.1.3"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/private-registry/quickstart/examples/demo.yaml
+++ b/docs/guides/mariadb/private-registry/quickstart/examples/demo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: md-pvt-reg
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mariadb/private-registry/quickstart/index.md
+++ b/docs/guides/mariadb/private-registry/quickstart/index.md
@@ -73,7 +73,7 @@ Docker hub repositories:
           runAsUser: 995
       podSecurityPolicies:
         databasePolicyName: maria-db
-      version: 11.8.5
+      version: 12.1.2
     ```
 
 - To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial. Run the following command to prepare your cluster for this tutorial:
@@ -118,7 +118,7 @@ metadata:
   name: md-pvt-reg
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mariadb/quickstart/overview/examples/sample-mariadb-v1.yaml
+++ b/docs/guides/mariadb/quickstart/overview/examples/sample-mariadb-v1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mariadb/quickstart/overview/index.md
+++ b/docs/guides/mariadb/quickstart/overview/index.md
@@ -78,7 +78,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -102,7 +102,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -121,7 +121,7 @@ mariadb.kubedb.com/sample-mariadb created
 
 Here,
 
-- `spec.version` is the name of the MariaDBVersion CRD where the docker images are specified. In this tutorial, a MariaDB `11.8.5` database is going to create.
+- `spec.version` is the name of the MariaDBVersion CRD where the docker images are specified. In this tutorial, a MariaDB `12.1.2` database is going to create.
 - `spec.storageType` specifies the type of storage that will be used for MariaDB database. It can be `Durable` or `Ephemeral`. Default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create MariaDB database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the PetSet created by KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests.
 - `spec.terminationPolicy` or `spec.deletionPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `MariaDB` crd or which resources KubeDB should keep or delete when you delete `MariaDB` crd. If admission webhook is enabled, It prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`.
@@ -258,7 +258,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   deletionPolicy: Delete
-  version: 11.8.5
+  version: 12.1.2
 status:
   observedGeneration: 2
   phase: Ready

--- a/docs/guides/mariadb/reconfigure-tls/cluster/examples/sample-mariadb.yaml
+++ b/docs/guides/mariadb/reconfigure-tls/cluster/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/reconfigure-tls/cluster/index.md
+++ b/docs/guides/mariadb/reconfigure-tls/cluster/index.md
@@ -47,7 +47,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/reconfigure/cluster/examples/sample-mariadb-config.yaml
+++ b/docs/guides/mariadb/reconfigure/cluster/examples/sample-mariadb-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   configuration:
     secretName: md-configuration

--- a/docs/guides/mariadb/reconfigure/cluster/index.md
+++ b/docs/guides/mariadb/reconfigure/cluster/index.md
@@ -39,7 +39,7 @@ Now, we are going to deploy a  `MariaDB` Cluster using a supported version by `K
 
 ### Prepare MariaDB Cluster
 
-Now, we are going to deploy a `MariaDB` Cluster database with version `11.8.5`.
+Now, we are going to deploy a `MariaDB` Cluster database with version `12.1.2`.
 
 ### Deploy MariaDB
 
@@ -70,7 +70,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   configuration:
     secretName: md-configuration

--- a/docs/guides/mariadb/reconfigure/standalone/examples/sample-mariadb-config.yaml
+++ b/docs/guides/mariadb/reconfigure/standalone/examples/sample-mariadb-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   configuration:
     secretName: md-configuration
   storageType: Durable

--- a/docs/guides/mariadb/reconfigure/standalone/index.md
+++ b/docs/guides/mariadb/reconfigure/standalone/index.md
@@ -38,7 +38,7 @@ Now, we are going to deploy a  `MariaDB` Standalone using a supported version by
 
 ### Prepare MariaDB Standalone
 
-Now, we are going to deploy a `MariaDB` Standalone database with version `11.8.5`.
+Now, we are going to deploy a `MariaDB` Standalone database with version `12.1.2`.
 
 ### Deploy MariaDB
 
@@ -69,7 +69,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   configuration:
     secretName: md-configuration
   storageType: Durable

--- a/docs/guides/mariadb/restart/restart.md
+++ b/docs/guides/mariadb/restart/restart.md
@@ -42,7 +42,7 @@ metadata:
   name: mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/rotate-auth/rotateauth.md
+++ b/docs/guides/mariadb/rotate-auth/rotateauth.md
@@ -46,7 +46,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mariadb/scaling/horizontal-scaling/cluster/example/sample-mariadb.yaml
+++ b/docs/guides/mariadb/scaling/horizontal-scaling/cluster/example/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/scaling/horizontal-scaling/cluster/index.md
+++ b/docs/guides/mariadb/scaling/horizontal-scaling/cluster/index.md
@@ -41,7 +41,7 @@ Here, we are going to deploy a  `MariaDB` cluster using a supported version by `
 
 ### Prepare MariaDB Cluster Database
 
-Now, we are going to deploy a `MariaDB` cluster with version `11.8.5`.
+Now, we are going to deploy a `MariaDB` cluster with version `12.1.2`.
 
 ### Deploy MariaDB Cluster
 
@@ -54,7 +54,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/scaling/horizontal-scaling/maxscale.md
+++ b/docs/guides/mariadb/scaling/horizontal-scaling/maxscale.md
@@ -50,7 +50,7 @@ metadata:
   name: md-replication
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   topology:
     mode: MariaDBReplication

--- a/docs/guides/mariadb/scaling/vertical-scaling/cluster/example/sample-mariadb.yaml
+++ b/docs/guides/mariadb/scaling/vertical-scaling/cluster/example/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/scaling/vertical-scaling/cluster/index.md
+++ b/docs/guides/mariadb/scaling/vertical-scaling/cluster/index.md
@@ -41,7 +41,7 @@ Here, we are going to deploy a  `MariaDB` cluster using a supported version by `
 
 ### Prepare MariaDB Cluster
 
-Now, we are going to deploy a `MariaDB` cluster database with version `11.8.5`.
+Now, we are going to deploy a `MariaDB` cluster database with version `12.1.2`.
 > Vertical Scaling for `MariaDB Standalone` can be performed in the same way as `MariaDB Cluster`. Only remove the `spec.replicas` field from the below yaml to deploy a MariaDB Standalone.
 
 ### Deploy MariaDB Cluster 
@@ -55,7 +55,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/scaling/vertical-scaling/maxscale.md
+++ b/docs/guides/mariadb/scaling/vertical-scaling/maxscale.md
@@ -50,7 +50,7 @@ metadata:
   name: md-replication
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   topology:
     mode: MariaDBReplication

--- a/docs/guides/mariadb/tls/configure/examples/tls-cluster.yaml
+++ b/docs/guides/mariadb/tls/configure/examples/tls-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: md-cluster-tls
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/tls/configure/examples/tls-standalone.yaml
+++ b/docs/guides/mariadb/tls/configure/examples/tls-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: md-standalone-tls
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mariadb/tls/configure/index.md
+++ b/docs/guides/mariadb/tls/configure/index.md
@@ -92,7 +92,7 @@ metadata:
   name: md-standalone-tls
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -280,7 +280,7 @@ metadata:
   name: md-cluster-tls
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/update-version/cluster/examples/mdops-update.yaml
+++ b/docs/guides/mariadb/update-version/cluster/examples/mdops-update.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: sample-mariadb
   updateVersion:
-    targetVersion: "11.8.5"
+    targetVersion: "12.1.2"

--- a/docs/guides/mariadb/update-version/cluster/index.md
+++ b/docs/guides/mariadb/update-version/cluster/index.md
@@ -37,7 +37,7 @@ namespace/demo created
 
 ## Prepare MariaDB Cluster
 
-Now, we are going to deploy a `MariaDB` cluster database with version `10.4.32`.
+Now, we are going to deploy a `MariaDB` cluster database with version `11.8.5`.
 
 ### Deploy MariaDB cluster
 
@@ -52,7 +52,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "10.4.32"
+  version: "11.8.5"
   replicas: 3
   storageType: Durable
   storage:
@@ -78,14 +78,14 @@ Now, wait until `sample-mariadb` created has status `Ready`. i.e,
 ```bash
 $ kubectl get mariadb -n demo                                                                                                                                             
 NAME             VERSION    STATUS     AGE
-sample-mariadb   10.4.32    Ready     3m15s
+sample-mariadb   11.8.5    Ready     3m15s
 ```
 
 We are now ready to apply the `MariaDBOpsRequest` CR to update this database.
 
 ### update MariaDB Version
 
-Here, we are going to update `MariaDB` cluster from `10.4.32` to `11.8.5`.
+Here, we are going to update `MariaDB` cluster from `11.8.5` to `12.1.2`.
 
 #### Create MariaDBOpsRequest:
 
@@ -102,14 +102,14 @@ spec:
   databaseRef:
     name: sample-mariadb
   updateVersion:
-    targetVersion: "11.8.5"
+    targetVersion: "12.1.2"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `sample-mariadb` MariaDB database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `11.8.5`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `12.1.2`.
 
 Let's create the `MariaDBOpsRequest` CR we have shown above,
 
@@ -137,13 +137,13 @@ Now, we are going to verify whether the `MariaDB` and the related `PetSets` and 
 
 ```bash
 $ kubectl get mariadb -n demo sample-mariadb -o=jsonpath='{.spec.version}{"\n"}'
-11.8.5
+12.1.2
 
 $ kubectl get sts -n demo sample-mariadb -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-mariadb:11.8.5
+mariadb:12.1.2
 
 $ kubectl get pods -n demo sample-mariadb-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-mariadb:11.8.5
+mariadb:12.1.2
 ```
 
 You can see from above, our `MariaDB` cluster database has been updated with the new version. So, the update process is successfully completed.

--- a/docs/guides/mariadb/volume-expansion/maxscale.md
+++ b/docs/guides/mariadb/volume-expansion/maxscale.md
@@ -69,7 +69,7 @@ metadata:
   name: mariadb-replication
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   topology:
     mode: MariaDBReplication

--- a/docs/guides/mariadb/volume-expansion/volume-expansion/example/sample-mariadb.yaml
+++ b/docs/guides/mariadb/volume-expansion/volume-expansion/example/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/mariadb/volume-expansion/volume-expansion/index.md
+++ b/docs/guides/mariadb/volume-expansion/volume-expansion/index.md
@@ -54,7 +54,7 @@ topolvm-provisioner   topolvm.cybozu.com      Delete          WaitForFirstConsum
 
 We can see from the output the `topolvm-provisioner` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We will use this storage class. You can install topolvm from [here](https://github.com/topolvm/topolvm).
 
-Now, we are going to deploy a `MariaDB` database of 3 replicas with version `11.8.5`.
+Now, we are going to deploy a `MariaDB` database of 3 replicas with version `12.1.2`.
 
 ### Deploy MariaDB
 
@@ -67,7 +67,7 @@ metadata:
   name: sample-mariadb
   namespace: demo
 spec:
-  version: "11.8.5"
+  version: "12.1.2"
   replicas: 3
   storageType: Durable
   storage:


### PR DESCRIPTION
Bumps the **mariadb** example and guide manifests to the latest supported version (`12.1.2`) per the installer `active_versions.json`.

- General "deploy a mariadb" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.