### PR TITLE
Update memcached docs examples to latest supported version (1.6.40)

### DIFF
--- a/docs/examples/memcached/auto-scaler/memcached.yaml
+++ b/docs/examples/memcached/auto-scaler/memcached.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:

--- a/docs/examples/memcached/cli/memcached-demo.yaml
+++ b/docs/examples/memcached/cli/memcached-demo.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:

--- a/docs/examples/memcached/custom-config/custom-memcached.yaml
+++ b/docs/examples/memcached/custom-config/custom-memcached.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   configuration:
     secretName: mc-configuration
   podTemplate:

--- a/docs/examples/memcached/custom-config/custom-podtemplate.yaml
+++ b/docs/examples/memcached/custom-config/custom-podtemplate.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-mc
   namespace: demo
 spec:
-  version: "1.6.22"
+  version: "1.6.40"
   replicas: 1
   podTemplate:
     spec:

--- a/docs/examples/memcached/custom-config/node-selector.yaml
+++ b/docs/examples/memcached/custom-config/node-selector.yaml
@@ -4,7 +4,7 @@ metadata:
   name: memcached-node-selector
   namespace: demo
 spec:
-  version: "1.6.22"
+  version: "1.6.40"
   replicas: 1
   podTemplate:
     spec:

--- a/docs/examples/memcached/custom-config/sidecar-container.yaml
+++ b/docs/examples/memcached/custom-config/sidecar-container.yaml
@@ -4,7 +4,7 @@ metadata:
   name: memcached-custom-sidecar
   namespace: demo
 spec:
-  version: "1.6.22"
+  version: "1.6.40"
   replicas: 1
   podTemplate:
     spec:

--- a/docs/examples/memcached/custom-config/with-tolerations.yaml
+++ b/docs/examples/memcached/custom-config/with-tolerations.yaml
@@ -4,7 +4,7 @@ metadata:
   name: memcached-with-tolerations
   namespace: demo
 spec:
-  version: "1.6.22"
+  version: "1.6.40"
   replicas: 1
   podTemplate:
     spec:

--- a/docs/examples/memcached/custom-config/without-toleration.yaml
+++ b/docs/examples/memcached/custom-config/without-toleration.yaml
@@ -4,6 +4,6 @@ metadata:
   name: memcached-without-tolerations
   namespace: demo
 spec:
-  version: "1.6.22"
+  version: "1.6.40"
   replicas: 1
   deletionPolicy: WipeOut

--- a/docs/examples/memcached/custom-rbac/mc-custom-db-two.yaml
+++ b/docs/examples/memcached/custom-rbac/mc-custom-db-two.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       serviceAccountName: my-custom-serviceaccount

--- a/docs/examples/memcached/custom-rbac/mc-custom-db.yaml
+++ b/docs/examples/memcached/custom-rbac/mc-custom-db.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       serviceAccountName: my-custom-serviceaccount

--- a/docs/examples/memcached/monitoring/builtin-prom-memcd.yaml
+++ b/docs/examples/memcached/monitoring/builtin-prom-memcd.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   deletionPolicy: WipeOut
   podTemplate:
     spec:

--- a/docs/examples/memcached/monitoring/memcached.yaml
+++ b/docs/examples/memcached/monitoring/memcached.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   deletionPolicy: WipeOut
   podTemplate:
     spec:

--- a/docs/examples/memcached/private-registry/demo-2.yaml
+++ b/docs/examples/memcached/private-registry/demo-2.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:

--- a/docs/examples/memcached/quickstart/demo-v1.yaml
+++ b/docs/examples/memcached/quickstart/demo-v1.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:

--- a/docs/examples/memcached/quickstart/demo-v1alpha2.yaml
+++ b/docs/examples/memcached/quickstart/demo-v1alpha2.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       resources:

--- a/docs/examples/memcached/reconfigure-tls/memcached.yaml
+++ b/docs/examples/memcached/reconfigure-tls/memcached.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   deletionPolicy: WipeOut

--- a/docs/examples/memcached/reconfigure/memcached-config.yaml
+++ b/docs/examples/memcached/reconfigure/memcached-config.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   configuration:
     secretName: mc-configuration
   deletionPolicy: WipeOut

--- a/docs/examples/memcached/restart/memcached.yaml
+++ b/docs/examples/memcached/restart/memcached.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:

--- a/docs/examples/memcached/scaling/memcached-horizontal.yaml
+++ b/docs/examples/memcached/scaling/memcached-horizontal.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:

--- a/docs/examples/memcached/scaling/memcached-vertical.yaml
+++ b/docs/examples/memcached/scaling/memcached-vertical.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:

--- a/docs/examples/memcached/tls/mc-tls.yaml
+++ b/docs/examples/memcached/tls/mc-tls.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   tls:
     issuerRef:
       apiGroup: "cert-manager.io"

--- a/docs/examples/memcached/update-version/memcached.yaml
+++ b/docs/examples/memcached/update-version/memcached.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.33"
   podTemplate:
     spec:
       containers:

--- a/docs/examples/memcached/update-version/opsrequest-version-update.yaml
+++ b/docs/examples/memcached/update-version/opsrequest-version-update.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: memcd-quickstart
   updateVersion:
-    targetVersion: 1.6.29
+    targetVersion: 1.6.40

--- a/docs/guides/memcached/autoscaler/compute/compute-autoscale.md
+++ b/docs/guides/memcached/autoscaler/compute/compute-autoscale.md
@@ -45,7 +45,7 @@ Here, we are going to deploy a `Memcached` database using a supported version by
 
 #### Deploy Memcached Database
 
-In this section, we are going to deploy a Memcached database with version `1.6.22`.  Then, in the next section we will set up autoscaling for this database using `MemcachedAutoscaler` CRD. Below is the YAML of the `Memcached` CR that we are going to create:
+In this section, we are going to deploy a Memcached database with version `1.6.40`.  Then, in the next section we will set up autoscaling for this database using `MemcachedAutoscaler` CRD. Below is the YAML of the `Memcached` CR that we are going to create:
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -55,7 +55,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:
@@ -82,7 +82,7 @@ Now, wait until `mc-compute-autoscaler` has status `Ready`. i.e,
 ```bash
 $ kubectl get mc -n demo
 NAME                    VERSION     STATUS    AGE
-mc-autoscaler-compute   1.6.22      Ready     2m
+mc-autoscaler-compute   1.6.40      Ready     2m
 ```
 
 Let's check the Pod containers resources,

--- a/docs/guides/memcached/cli/cli.md
+++ b/docs/guides/memcached/cli/cli.md
@@ -47,10 +47,10 @@ cat memcached-demo.yaml | kubectl create -f -
 ```bash
 $ kubectl get memcached
 NAME             VERSION    STATUS    AGE
-memcached-demo   1.6.22     Running   40s
-memcached-dev    1.6.22     Running   40s
-memcached-prod   1.6.22     Running   40s
-memcached-qa     1.6.22     Running   40s
+memcached-demo   1.6.40     Running   40s
+memcached-dev    1.6.40     Running   40s
+memcached-prod   1.6.40     Running   40s
+memcached-qa     1.6.40     Running   40s
 ```
 
 To get YAML of an object, use `--output=yaml` flag.
@@ -87,7 +87,7 @@ spec:
           memory: 64Mi
   replicas: 1
   deletionPolicy: WipeOut
-  version: 1.6.22
+  version: 1.6.40
 status:
   observedGeneration: 1$7916315637361465932
   phase: Running
@@ -104,10 +104,10 @@ To list all KubeDB objects, use following command:
 ```bash
 $ kubectl get all -o wide
 NAME                    VERSION     STATUS    AGE
-mc/memcached-demo       1.6.22      Running   3h
-mc/memcached-dev        1.6.22      Running   3h
-mc/memcached-prod       1.6.22      Running   3h
-mc/memcached-qa         1.6.22      Running   3h
+mc/memcached-demo       1.6.40      Running   3h
+mc/memcached-dev        1.6.40      Running   3h
+mc/memcached-prod       1.6.40      Running   3h
+mc/memcached-qa         1.6.40      Running   3h
 ```
 
 Flag `--output=wide` is used to print additional information.
@@ -121,7 +121,7 @@ You can print labels with objects. The following command will list all Memcached
 ```bash
 $ kubectl get mc --show-labels
 NAME             VERSION    STATUS    AGE       LABELS
-memcached-demo   1.6.22     Running   2m        kubedb=cli-demo
+memcached-demo   1.6.40     Running   2m        kubedb=cli-demo
 ```
 
 To print only object name, run the following command:

--- a/docs/guides/memcached/concepts/appbinding.md
+++ b/docs/guides/memcached/concepts/appbinding.md
@@ -34,7 +34,7 @@ An `AppBinding` object created by `KubeDB` for Memcached database is shown below
   metadata:
     annotations:
       kubectl.kubernetes.io/last-applied-configuration: |
-        {"apiVersion":"appcatalog.appscode.com/v1alpha1","kind":"AppBinding","metadata":{"annotations":{},"name":"memcached-appbinding","namespace":"demo"},"spec":{"appRef":{"apiGroup":"kubedb.com","kind":"Memcached","name":"mc1","namespace":"demo"},"clientConfig":{"service":{"name":"memcached","namespace":"demo","port":11211,"scheme":"tcp"}},"secret":{"name":"memcached-auth"},"type":"kubedb.com/memcached","version":"1.6.22"}}
+        {"apiVersion":"appcatalog.appscode.com/v1alpha1","kind":"AppBinding","metadata":{"annotations":{},"name":"memcached-appbinding","namespace":"demo"},"spec":{"appRef":{"apiGroup":"kubedb.com","kind":"Memcached","name":"mc1","namespace":"demo"},"clientConfig":{"service":{"name":"memcached","namespace":"demo","port":11211,"scheme":"tcp"}},"secret":{"name":"memcached-auth"},"type":"kubedb.com/memcached","version":"1.6.40"}}
     creationTimestamp: "2024-08-26T09:51:57Z"
     generation: 1
     name: memcached-appbinding
@@ -56,7 +56,7 @@ An `AppBinding` object created by `KubeDB` for Memcached database is shown below
     secret:
       name: memcached-auth
     type: kubedb.com/memcached
-    version: 1.6.22
+    version: 1.6.40
 ```
 Here, we are going to describe the sections of an `AppBinding` crd.
 

--- a/docs/guides/memcached/concepts/memcached-opsrequest.md
+++ b/docs/guides/memcached/concepts/memcached-opsrequest.md
@@ -37,7 +37,7 @@ spec:
   databaseRef:
     name: memcd-quickstart
   updateVersion:
-    targetVersion: 1.6.22
+    targetVersion: 1.6.40
 ```
 
 Sample `MemcachedOpsRequest` for horizontal scaling:

--- a/docs/guides/memcached/concepts/memcached-version.md
+++ b/docs/guides/memcached/concepts/memcached-version.md
@@ -41,19 +41,19 @@ metadata:
     app.kubernetes.io/name: kubedb-catalog
     app.kubernetes.io/version: v2024.8.21
     helm.sh/chart: kubedb-catalog-v2024.8.21
-  name: 1.6.22
+  name: 1.6.40
   resourceVersion: "2566"
   uid: 90041c04-21b8-4b39-a2a6-af2e6a2ccacd
 spec:
   db:
-    image: ghcr.io/appscode-images/memcached:1.6.22-alpine
+    image: ghcr.io/appscode-images/memcached:1.6.40-alpine
   exporter:
     image: ghcr.io/appscode-images/memcached_exporter:v0.14.3-ac
   podSecurityPolicies:
     databasePolicyName: memcached-db
   securityContext:
     runAsUser: 999
-  version: 1.6.22
+  version: 1.6.40
 ```
 
 ### metadata.name

--- a/docs/guides/memcached/concepts/memcached.md
+++ b/docs/guides/memcached/concepts/memcached.md
@@ -30,7 +30,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: 1.6.22
+  version: 1.6.40
   monitor:
     agent: prometheus.io/operator
     prometheus:
@@ -92,7 +92,7 @@ KubeDB uses `PodDisruptionBudget` to ensure that majority of these replicas are 
 `spec.version` is a required field specifying the name of the [MemcachedVersion](/docs/guides/memcached/concepts/memcached-version.md) crd where the docker images are specified. Currently, when you install KubeDB, it creates the following `MemcachedVersion` crds,
 
 - `1.5.22`
-- `1.6.22`
+- `1.6.40`
 - `1.6.29`
 
 ### spec.monitor

--- a/docs/guides/memcached/custom-configuration/using-config-file.md
+++ b/docs/guides/memcached/custom-configuration/using-config-file.md
@@ -103,7 +103,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   configuration:
     secretName: mc-configuration
   podTemplate:
@@ -127,7 +127,7 @@ Check if the database is ready
 ```bash
 $ kubectl get mc -n demo
 NAME               VERSION   STATUS   AGE
-custom-memcached   1.6.22    Ready    17m
+custom-memcached   1.6.40    Ready    17m
 ```
 
 Now, we will check if the database has started with the custom configuration we have provided. We will use [stats](https://github.com/memcached/memcached/wiki/ConfiguringServer#inspecting-running-configuration) command to check the configuration.

--- a/docs/guides/memcached/custom-configuration/using-podtemplate.md
+++ b/docs/guides/memcached/custom-configuration/using-podtemplate.md
@@ -71,7 +71,7 @@ metadata:
   name: custom-memcached
   namespace: demo
 spec:
-  version: "1.6.22"
+  version: "1.6.40"
   replicas: 1
   podTemplate:
     spec:
@@ -146,7 +146,7 @@ metadata:
   name: memcached-custom-sidecar
   namespace: demo
 spec:
-  version: "1.6.22"
+  version: "1.6.40"
   replicas: 1
   podTemplate:
     spec:
@@ -195,7 +195,7 @@ kind: Memcached
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1","kind":"Memcached","metadata":{"annotations":{},"name":"memcached-custom-sidecar","namespace":"demo"},"spec":{"deletionPolicy":"WipeOut","podTemplate":{"spec":{"containers":[{"name":"memcached","resources":{"limits":{"cpu":"100m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}},{"image":"evanraisul/custom_filebeat:latest","name":"filebeat","resources":{"limits":{"cpu":"300m","memory":"300Mi"},"requests":{"cpu":"300m","memory":"300Mi"}}}]}},"replicas":1,"version":"1.6.22"}}
+      {"apiVersion":"kubedb.com/v1","kind":"Memcached","metadata":{"annotations":{},"name":"memcached-custom-sidecar","namespace":"demo"},"spec":{"deletionPolicy":"WipeOut","podTemplate":{"spec":{"containers":[{"name":"memcached","resources":{"limits":{"cpu":"100m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}},{"image":"evanraisul/custom_filebeat:latest","name":"filebeat","resources":{"limits":{"cpu":"300m","memory":"300Mi"},"requests":{"cpu":"300m","memory":"300Mi"}}}]}},"replicas":1,"version":"1.6.40"}}
   creationTimestamp: "2024-12-02T10:59:59Z"
   finalizers:
   - kubedb.com
@@ -250,7 +250,7 @@ spec:
         fsGroup: 999
       serviceAccountName: memcached-custom-sidecar
   replicas: 1
-  version: 1.6.22
+  version: 1.6.40
 status:
   conditions:
   - lastTransitionTime: "2024-12-02T10:59:59Z"
@@ -343,7 +343,7 @@ metadata:
   name: memcached-node-selector
   namespace: demo
 spec:
-  version: "1.6.22"
+  version: "1.6.40"
   replicas: 1
   podTemplate:
     spec:
@@ -432,7 +432,7 @@ metadata:
   name: memcached-without-tolerations
   namespace: demo
 spec:
-  version: "1.6.22"
+  version: "1.6.40"
   replicas: 1
   deletionPolicy: WipeOut
 ```
@@ -470,7 +470,7 @@ IPs:              <none>
 Controlled By:    PetSet/memcached-without-tolerations
 Containers:
   memcached:
-    Image:           ghcr.io/appscode-images/memcached:1.6.22-alpine
+    Image:           ghcr.io/appscode-images/memcached:1.6.40-alpine
     Ports:           11211/TCP
     Host Ports:      0/TCP, 0/TCP
     SeccompProfile:  RuntimeDefault
@@ -544,7 +544,7 @@ metadata:
   name: memcached-with-tolerations
   namespace: demo
 spec:
-  version: "1.6.22"
+  version: "1.6.40"
   replicas: 1
   podTemplate:
     spec:

--- a/docs/guides/memcached/custom-rbac/using-custom-rbac.md
+++ b/docs/guides/memcached/custom-rbac/using-custom-rbac.md
@@ -144,7 +144,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       serviceAccountName: my-custom-serviceaccount
@@ -192,7 +192,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       serviceAccountName: my-custom-serviceaccount

--- a/docs/guides/memcached/monitoring/overview.md
+++ b/docs/guides/memcached/monitoring/overview.md
@@ -54,7 +54,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   deletionPolicy: WipeOut
   podTemplate:
     spec:

--- a/docs/guides/memcached/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/memcached/monitoring/using-builtin-prometheus.md
@@ -50,7 +50,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   deletionPolicy: WipeOut
   podTemplate:
     spec:
@@ -95,7 +95,7 @@ Now, wait for the database to go into `Ready` state.
 ```bash
 $ kubectl get mc -n demo builtin-prom-memcd
 NAME                 VERSION    STATUS    AGE
-builtin-prom-memcd   1.6.22     Ready     30s
+builtin-prom-memcd   1.6.40     Ready     30s
 ```
 
 KubeDB will create a separate stats service with name `{Memcached crd name}-stats` for monitoring purpose.

--- a/docs/guides/memcached/monitoring/using-prometheus-operator.md
+++ b/docs/guides/memcached/monitoring/using-prometheus-operator.md
@@ -182,7 +182,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   deletionPolicy: WipeOut
   podTemplate:
     spec:
@@ -225,7 +225,7 @@ Now, wait for the database to go into `Running` state.
 ```bash
 $ kubectl get mc -n demo memcached
 NAME        VERSION   STATUS   AGE
-memcached   1.6.22    Ready    2m
+memcached   1.6.40    Ready    2m
 ```
 
 KubeDB will create a separate stats service with name `{Memcached crd name}-stats` for monitoring purpose.

--- a/docs/guides/memcached/private-registry/using-private-registry.md
+++ b/docs/guides/memcached/private-registry/using-private-registry.md
@@ -30,7 +30,7 @@ KubeDB operator supports using private Docker registry. This tutorial will show 
   $ kubectl get memcachedversions -n kube-system  -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,DB_IMAGE:.spec.db.image,EXPORTER_IMAGE:.spec.exporter.image,DEPRECATED:.spec.deprecated
   NAME     VERSION   DB_IMAGE                                          EXPORTER_IMAGE                                          DEPRECATED
   1.5.22   1.5.22    ghcr.io/appscode-images/memcached:1.5.22-alpine   prom/memcached-exporter:v0.14.2                         <none>
-  1.6.22   1.6.22    ghcr.io/appscode-images/memcached:1.6.22-alpine   ghcr.io/appscode-images/memcached_exporter:v0.14.3-ac   <none>
+  1.6.40   1.6.40    ghcr.io/appscode-images/memcached:1.6.40-alpine   ghcr.io/appscode-images/memcached_exporter:v0.14.3-ac   <none>
   1.6.29   1.6.29    ghcr.io/appscode-images/memcached:1.6.29-alpine   ghcr.io/appscode-images/memcached_exporter:v0.14.3-ac   <none>
   ```
 
@@ -46,17 +46,17 @@ KubeDB operator supports using private Docker registry. This tutorial will show 
   apiVersion: catalog.kubedb.com/v1alpha1
   kind: MemcachedVersion
   metadata:
-    name: 1.6.22
+    name: 1.6.40
   spec:
     db:
-      image: PRIVATE_REGISTRY/memcached:1.6.22-alpine
+      image: PRIVATE_REGISTRY/memcached:1.6.40-alpine
     exporter:
       image: PRIVATE_REGISTRY/memcached_exporter:v0.14.3
     podSecurityPolicies:
       databasePolicyName: memcached-db
     securityContext:
       runAsUser: 999
-    version: 1.6.22
+    version: 1.6.40
   ```
 
 - To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial. Run the following command to prepare your cluster for this tutorial:
@@ -102,7 +102,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:
@@ -139,7 +139,7 @@ memcd-pvt-reg-694d4d44df-tkqc4   1/1       Running             0          27s
 
 $ kubectl get mc -n demo
 NAME            VERSION    STATUS    AGE
-memcd-pvt-reg   1.6.22     Running   59s
+memcd-pvt-reg   1.6.40     Running   59s
 ```
 
 ## Cleaning up

--- a/docs/guides/memcached/quickstart/quickstart.md
+++ b/docs/guides/memcached/quickstart/quickstart.md
@@ -47,7 +47,7 @@ When you have installed KubeDB, it has created `MemcachedVersion` crd for all su
 $ kubectl get memcachedversions
 NAME        VERSION    DB_IMAGE                                            DEPRECATED   AGE
 1.5.22      1.5.22     ghcr.io/appscode-images/memcached:1.5.22-alpine                  2h
-1.6.22      1.6.22     ghcr.io/appscode-images/memcached:1.6.22-alpine                  2h
+1.6.40      1.6.40     ghcr.io/appscode-images/memcached:1.6.40-alpine                  2h
 1.6.29      1.6.29     ghcr.io/appscode-images/memcached:1.6.29-alpine                  2h
 ```
 
@@ -65,7 +65,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:
@@ -93,7 +93,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       resources:
@@ -122,7 +122,7 @@ KubeDB operator watches for `Memcached` objects using Kubernetes api. When a `Me
 ```bash
 $ kubectl get mc -n demo
 NAME               VERSION    STATUS    AGE
-memcd-quickstart   1.6.22     Running   2m
+memcd-quickstart   1.6.40     Running   2m
 
 $ kubectl describe mc -n demo memcd-quickstart
 Name:         memcd-quickstart
@@ -173,7 +173,7 @@ Spec:
         Fs Group:            999
       Service Account Name:  memcd-quickstart
   Replicas:                  1
-  Version:                   1.6.22
+  Version:                   1.6.40
 Status:
   Conditions:
     Last Transition Time:  2024-08-22T13:54:45Z
@@ -242,7 +242,7 @@ kind: Memcached
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1","kind":"Memcached","metadata":{"annotations":{},"name":"memcd-quickstart","namespace":"demo"},"spec":{"deletionPolicy":"DoNotTerminate","podTemplate":{"spec":{"containers":[{"name":"memcached","resources":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"250m","memory":"64Mi"}}}]}},"replicas":3,"version":"1.6.22"}}
+      {"apiVersion":"kubedb.com/v1","kind":"Memcached","metadata":{"annotations":{},"name":"memcd-quickstart","namespace":"demo"},"spec":{"deletionPolicy":"DoNotTerminate","podTemplate":{"spec":{"containers":[{"name":"memcached","resources":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"250m","memory":"64Mi"}}}]}},"replicas":3,"version":"1.6.40"}}
   creationTimestamp: "2024-08-22T13:54:45Z"
   finalizers:
   - kubedb.com
@@ -286,7 +286,7 @@ spec:
         fsGroup: 999
       serviceAccountName: memcd-quickstart
   replicas: 1
-  version: 1.6.22
+  version: 1.6.40
 status:
   conditions:
   - lastTransitionTime: "2024-08-22T13:54:45Z"

--- a/docs/guides/memcached/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/memcached/reconfigure-tls/reconfigure-tls.md
@@ -50,7 +50,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   deletionPolicy: WipeOut
 ```
 
@@ -67,7 +67,7 @@ Now, wait until `memcd-quickstart` has status `Ready`. i.e,
 $ watch kubectl get mc -n demo
 Every 2.0s: kubectl get mc -n demo
 NAME               VERSION   STATUS   AGE
-memcd-quickstart   1.6.22    Ready    26s
+memcd-quickstart   1.6.40    Ready    26s
 ```
 
 Now, we can connect to this database through `telnet` to verify that the `TLS` is disabled.

--- a/docs/guides/memcached/reconfigure/reconfigure.md
+++ b/docs/guides/memcached/reconfigure/reconfigure.md
@@ -40,7 +40,7 @@ Now, we are going to deploy a  `Memcached` database using a supported version by
 
 ### Prepare Memcached Database
 
-Now, we are going to deploy a `Memcached` database with version `1.6.22`.
+Now, we are going to deploy a `Memcached` database with version `1.6.40`.
 
 ### Deploy Memcached 
 
@@ -75,7 +75,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   configuration:
     secretName: mc-configuration
   deletionPolicy: WipeOut
@@ -93,7 +93,7 @@ Now, wait until `memcd-quickstart` has status `Ready`. i.e,
 ```bash
 $ kubectl get mc -n demo
 NAME               VERSION     STATUS    AGE
-memcd-quickstart   1.6.22      Ready     23s
+memcd-quickstart   1.6.40      Ready     23s
 ```
 
 Now, we will check if the database has started with the custom configuration we have provided.
@@ -276,7 +276,7 @@ Now, wait until `memcd-quickstart` has status `Ready`. i.e,
 ```bash
 $ kubectl get mc -n demo
 NAME               VERSION     STATUS    AGE
-memcd-quickstart   1.6.22      Ready     20s
+memcd-quickstart   1.6.40      Ready     20s
 ```
 
 Now, we will check if the database has started with the custom configuration we have provided.

--- a/docs/guides/memcached/restart/restart.md
+++ b/docs/guides/memcached/restart/restart.md
@@ -43,7 +43,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:

--- a/docs/guides/memcached/rotate-auth/rotateauth.md
+++ b/docs/guides/memcached/rotate-auth/rotateauth.md
@@ -50,7 +50,7 @@ NAME       VERSION   DB_IMAGE                                          DEPRECATE
 1.5.22     1.5.22    ghcr.io/appscode-images/memcached:1.5.22-alpine                5d19h
 1.5.4      1.5.4     ghcr.io/kubedb/memcached:1.5.4                    true         5d19h
 1.5.4-v1   1.5.4     ghcr.io/kubedb/memcached:1.5.4-v1                 true         5d19h
-1.6.22     1.6.22    ghcr.io/appscode-images/memcached:1.6.22-alpine                5d19h
+1.6.40     1.6.40    ghcr.io/appscode-images/memcached:1.6.40-alpine                5d19h
 1.6.29     1.6.29    ghcr.io/appscode-images/memcached:1.6.29-alpine                5d19h
 1.6.33     1.6.33    ghcr.io/appscode-images/memcached:1.6.33-alpine                5d19h
 ```
@@ -71,7 +71,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:
@@ -96,7 +96,7 @@ Now, wait until memcd-quickstart has status Ready. i.e,
 ```shell
 $  kubectl get mc -n demo -w
 NAME               VERSION   STATUS   AGE
-memcd-quickstart   1.6.22    Ready    17h
+memcd-quickstart   1.6.40    Ready    17h
 ```
 ## Verify Authentication
 The user can verify whether they are authorized by executing a query directly in the database. To do this, the user needs `username` and `password` in order to connect to the database. Below is an example showing how to retrieve the credentials from the Secret.
@@ -143,7 +143,7 @@ STORED
 
 #now you can use DB
 version
-VERSION 1.6.22
+VERSION 1.6.40
 
 # Exit
 quit
@@ -304,7 +304,7 @@ STORED
 #command
 version
 #output
-VERSION 1.6.22
+VERSION 1.6.40
 #output
 quit
 Connection closed by foreign host.
@@ -502,7 +502,7 @@ STORED
 #command
 version
 #output
-VERSION 1.6.22
+VERSION 1.6.40
 #output
 quit
 Connection closed by foreign host.

--- a/docs/guides/memcached/scaling/horizontal-scaling/horizontal-scaling.md
+++ b/docs/guides/memcached/scaling/horizontal-scaling/horizontal-scaling.md
@@ -43,7 +43,7 @@ Here, we are going to deploy a `Memcached` database using a supported version by
 
 ### Prepare Memcached Database
 
-Now, we are going to deploy a `Memcached` database with version `1.6.22`.
+Now, we are going to deploy a `Memcached` database with version `1.6.40`.
 
 ### Deploy Memcached Database
 
@@ -57,7 +57,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:
@@ -84,7 +84,7 @@ Now, wait until `memcd-quickstart` has status `Ready`. i.e. ,
 ```bash
 $ kubectl get memcached -n demo
 NAME               VERSION   STATUS   AGE
-memcd-quickstart   1.6.22    Ready    5m
+memcd-quickstart   1.6.40    Ready    5m
 ```
 
 Let's check the number of replicas this database has from the Memcached object

--- a/docs/guides/memcached/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/memcached/scaling/vertical-scaling/vertical-scaling.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a  `Memcahced` database using a supported version b
 
 ### Prepare Memcahced Database
 
-Now, we are going to deploy a `Memcached` database with version `1.6.22`.
+Now, we are going to deploy a `Memcached` database with version `1.6.40`.
 
 ### Deploy Memcahced
 
@@ -56,7 +56,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   podTemplate:
     spec:
       containers:
@@ -83,7 +83,7 @@ Now, wait until `memcd-quickstart` has status `Ready`. i.e. ,
 ```bash
 $ kubectl get memcached -n demo
 NAME               VERSION   STATUS   AGE
-memcd-quickstart   1.6.22    Ready    5m
+memcd-quickstart   1.6.40    Ready    5m
 ```
 
 Let's check the Pod containers resources,

--- a/docs/guides/memcached/tls/tls.md
+++ b/docs/guides/memcached/tls/tls.md
@@ -105,7 +105,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.40"
   tls:
     issuerRef:
       apiGroup: "cert-manager.io"
@@ -132,7 +132,7 @@ Now, wait until `memcd-quickstart` has status `Ready`. i.e,
 $ watch kubectl get rd -n demo
 Every 2.0s: kubectl get memcached -n demo
 NAME               VERSION   STATUS   AGE
-memcd-quickstart   1.6.22    Ready    19m
+memcd-quickstart   1.6.40    Ready    19m
 ```
 
 ### Verify TLS/SSL in Memcached

--- a/docs/guides/memcached/update-version/update-version.md
+++ b/docs/guides/memcached/update-version/update-version.md
@@ -38,7 +38,7 @@ namespace/demo created
 
 ### Prepare Memcached Database
 
-Now, we are going to deploy a `Memcached` database with version `1.6.22`.
+Now, we are going to deploy a `Memcached` database with version `1.6.33`.
 
 ### Deploy Memcached:
 
@@ -52,7 +52,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.6.22"
+  version: "1.6.33"
   podTemplate:
     spec:
       containers:
@@ -80,14 +80,14 @@ Now, wait until `memcd-quickstart` created has status `Ready`. i.e,
 ```bash
 $ kubectl get mc -n demo
 NAME               VERSION   STATUS   AGE
-memcd-quickstart   1.6.22    Ready    3m
+memcd-quickstart   1.6.33    Ready    3m
 ```
 
 We are now ready to apply the `MemcachedOpsRequest` CR to update this database.
 
 ### Update Memcached Version
 
-Here, we are going to update `Memcached` sdatabase from `1.6.22` to `1.6.29`.
+Here, we are going to update `Memcached` sdatabase from `1.6.33` to `1.6.40`.
 
 #### Create MemcachedOpsRequest:
 
@@ -104,14 +104,14 @@ spec:
   databaseRef:
     name: memcd-quickstart
   updateVersion:
-    targetVersion: 1.6.29
+    targetVersion: 1.6.40
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `memcd-quickstart` Memcached database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `1.6.29`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `1.6.40`.
 
 Let's create the `MemcachedOpsRequest` CR we have shown above,
 
@@ -139,13 +139,13 @@ Now, we are going to verify whether the `Memcached` and the related `PetSets` th
 
 ```bash
 $ kubectl get memcached -n demo memcd-quickstart -o=jsonpath='{.spec.version}{"\n"}'
-1.6.29
+1.6.40
 
 $ kubectl get petset -n demo memcd-quickstart -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-ghcr.io/appscode-images/memcached:1.6.29-alpine
+ghcr.io/appscode-images/memcached:1.6.40-alpine
 
 $ kubectl get pods -n demo memcd-quickstart-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-ghcr.io/appscode-images/memcached:1.6.29-alpine
+ghcr.io/appscode-images/memcached:1.6.40-alpine
 ```
 
 You can see from above, our `Memcached` database has been updated with the new version. So, the UpdateVersion process is successfully completed.


### PR DESCRIPTION
Bumps the **memcached** example and guide manifests to the latest supported version (`1.6.40`) per the installer `active_versions.json`.

- General "deploy a memcached" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.