### PR TITLE
Update mongodb docs examples to latest supported version (8.0.17)

### DIFF
--- a/docs/examples/mongodb/Initialization/demo-1.yaml
+++ b/docs/examples/mongodb/Initialization/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgo-init-script
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/mongodb/Initialization/git-sync-public.yaml
+++ b/docs/examples/mongodb/Initialization/git-sync-public.yaml
@@ -16,7 +16,7 @@ spec:
           - --root=/git
           # terminate after successful sync
           - --one-time
-  version: "8.0.10"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mongodb/arbiter/replicaset.yaml
+++ b/docs/examples/mongodb/arbiter/replicaset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mongo-arb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "rs0"
   replicas: 2

--- a/docs/examples/mongodb/arbiter/sharding.yaml
+++ b/docs/examples/mongodb/arbiter/sharding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mongo-sh-arb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3

--- a/docs/examples/mongodb/autoscaling/compute/mg-rs.yaml
+++ b/docs/examples/mongodb/autoscaling/compute/mg-rs.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-rs
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   replicas: 3

--- a/docs/examples/mongodb/autoscaling/compute/mg-sh.yaml
+++ b/docs/examples/mongodb/autoscaling/compute/mg-sh.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-sh
   namespace: demo       
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   shardTopology:
     configServer:

--- a/docs/examples/mongodb/autoscaling/compute/mg-standalone.yaml
+++ b/docs/examples/mongodb/autoscaling/compute/mg-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-standalone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     resources:

--- a/docs/examples/mongodb/autoscaling/storage/mg-rs.yaml
+++ b/docs/examples/mongodb/autoscaling/storage/mg-rs.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-rs
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   replicas: 3

--- a/docs/examples/mongodb/autoscaling/storage/mg-sh.yaml
+++ b/docs/examples/mongodb/autoscaling/storage/mg-sh.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-sh
   namespace: demo       
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   shardTopology:
     configServer:

--- a/docs/examples/mongodb/autoscaling/storage/mg-standalone.yaml
+++ b/docs/examples/mongodb/autoscaling/storage/mg-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-standalone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: topolvm-provisioner

--- a/docs/examples/mongodb/cli/mongodb-demo.yaml
+++ b/docs/examples/mongodb/cli/mongodb-demo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mongodb-demo
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/mongodb/clustering/mongo-sharding.yaml
+++ b/docs/examples/mongodb/clustering/mongo-sharding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mongo-sh
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3

--- a/docs/examples/mongodb/clustering/replicaset.yaml
+++ b/docs/examples/mongodb/clustering/replicaset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgo-replicaset
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   replicaSet:
     name: rs0

--- a/docs/examples/mongodb/clustering/standalone.yaml
+++ b/docs/examples/mongodb/clustering/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-alone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   podTemplate:
     spec:
       containers:

--- a/docs/examples/mongodb/configuration/demo-1.yaml
+++ b/docs/examples/mongodb/configuration/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgo-custom-config
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mongodb/configuration/mgo-misc-config.yaml
+++ b/docs/examples/mongodb/configuration/mgo-misc-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgo-misc-config
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: "Durable"
   storage:
     storageClassName: "standard"

--- a/docs/examples/mongodb/custom-rbac/mg-custom-db-two.yaml
+++ b/docs/examples/mongodb/custom-rbac/mg-custom-db-two.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minute-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/examples/mongodb/custom-rbac/mg-custom-db.yaml
+++ b/docs/examples/mongodb/custom-rbac/mg-custom-db.yaml
@@ -4,7 +4,7 @@ metadata:
   name: quick-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/examples/mongodb/hidden-node/replicaset.yaml
+++ b/docs/examples/mongodb/hidden-node/replicaset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mongo-rs-hid
   namespace: demo
 spec:
-  version: "percona-7.0.18"
+  version: "percona-8.0.17"
   replicaSet:
     name: "replicaset"
   podTemplate:

--- a/docs/examples/mongodb/hidden-node/sharding.yaml
+++ b/docs/examples/mongodb/hidden-node/sharding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mongo-sh-hid
   namespace: demo
 spec:
-  version: "percona-7.0.18"
+  version: "percona-8.0.17"
   shardTopology:
     configServer:
       replicas: 3

--- a/docs/examples/mongodb/horizons/mongodb.yaml
+++ b/docs/examples/mongodb/horizons/mongodb.yaml
@@ -36,4 +36,4 @@ spec:
       apiGroup: cert-manager.io
       kind: Issuer
       name: mongo-ca-issuer
-  version: 7.0.21
+  version: "8.0.17"

--- a/docs/examples/mongodb/monitoring/builtin-prom-mgo.yaml
+++ b/docs/examples/mongodb/monitoring/builtin-prom-mgo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-mgo
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/examples/mongodb/monitoring/coreos-prom-mgo.yaml
+++ b/docs/examples/mongodb/monitoring/coreos-prom-mgo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coreos-prom-mgo
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/examples/mongodb/private-registry/demo-1.yaml
+++ b/docs/examples/mongodb/private-registry/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgo-pvt-reg
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   storage:
     storageClassName: "longhorn"
     accessModes:

--- a/docs/examples/mongodb/quickstart/replicaset-v1.yaml
+++ b/docs/examples/mongodb/quickstart/replicaset-v1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgo-quickstart
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "rs1"
   replicas: 3

--- a/docs/examples/mongodb/quickstart/replicaset-v1alpha2.yaml
+++ b/docs/examples/mongodb/quickstart/replicaset-v1alpha2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgo-quickstart
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "rs1"
   replicas: 3

--- a/docs/examples/mongodb/reconfigure-tls/mg-replicaset.yaml
+++ b/docs/examples/mongodb/reconfigure-tls/mg-replicaset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-rs
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   replicaSet:
     name: rs0

--- a/docs/examples/mongodb/reconfigure/mg-replicaset-config.yaml
+++ b/docs/examples/mongodb/reconfigure/mg-replicaset-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-replicaset
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   replicaSet:
     name: rs0

--- a/docs/examples/mongodb/reconfigure/mg-shard-config.yaml
+++ b/docs/examples/mongodb/reconfigure/mg-shard-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-sharding
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3

--- a/docs/examples/mongodb/reconfigure/mg-standalone-config.yaml
+++ b/docs/examples/mongodb/reconfigure/mg-standalone-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-standalone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mongodb/reprovision/mongo.yaml
+++ b/docs/examples/mongodb/reprovision/mongo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mongo
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   podTemplate:

--- a/docs/examples/mongodb/restart/mongo.yaml
+++ b/docs/examples/mongodb/restart/mongo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mongo
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   podTemplate:

--- a/docs/examples/mongodb/scaling/mg-replicaset.yaml
+++ b/docs/examples/mongodb/scaling/mg-replicaset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-replicaset
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   replicas: 3

--- a/docs/examples/mongodb/scaling/mg-shard.yaml
+++ b/docs/examples/mongodb/scaling/mg-shard.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-sharding
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3

--- a/docs/examples/mongodb/scaling/mg-standalone.yaml
+++ b/docs/examples/mongodb/scaling/mg-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-standalone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mongodb/tls/mg-replicaset-ssl.yaml
+++ b/docs/examples/mongodb/tls/mg-replicaset-ssl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgo-rs-tls
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   sslMode: requireSSL
   tls:
     issuerRef:

--- a/docs/examples/mongodb/tls/mg-shard-ssl.yaml
+++ b/docs/examples/mongodb/tls/mg-shard-ssl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mongo-sh-tls
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   sslMode: requireSSL
   tls:
     issuerRef:

--- a/docs/examples/mongodb/tls/mg-standalone-ssl.yaml
+++ b/docs/examples/mongodb/tls/mg-standalone-ssl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgo-tls
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   sslMode: requireSSL
   tls:
     issuerRef:

--- a/docs/examples/mongodb/update-version/mg-replicaset.yaml
+++ b/docs/examples/mongodb/update-version/mg-replicaset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-replicaset
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "7.0.28"
   replicaSet: 
     name: "replicaset"
   replicas: 3

--- a/docs/examples/mongodb/update-version/mg-shard.yaml
+++ b/docs/examples/mongodb/update-version/mg-shard.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-sharding
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "7.0.28"
   shardTopology:
     configServer:
       replicas: 2

--- a/docs/examples/mongodb/update-version/mg-standalone.yaml
+++ b/docs/examples/mongodb/update-version/mg-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-standalone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "7.0.28"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mongodb/update-version/mops-update-replicaset.yaml
+++ b/docs/examples/mongodb/update-version/mops-update-replicaset.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: mg-replicaset
   updateVersion:
-    targetVersion: 4.0.5-v3
+    targetVersion: 8.0.17

--- a/docs/examples/mongodb/update-version/mops-update-shard.yaml
+++ b/docs/examples/mongodb/update-version/mops-update-shard.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: mg-sharding
   updateVersion:
-    targetVersion: 4.0.5-v3
+    targetVersion: 8.0.17

--- a/docs/examples/mongodb/update-version/mops-update-standalone.yaml
+++ b/docs/examples/mongodb/update-version/mops-update-standalone.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: mg-standalone
   updateVersion:
-    targetVersion: 4.0.5-v3
+    targetVersion: 8.0.17

--- a/docs/examples/mongodb/volume-expansion/mg-replicaset.yaml
+++ b/docs/examples/mongodb/volume-expansion/mg-replicaset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-replicaset
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   replicas: 3

--- a/docs/examples/mongodb/volume-expansion/mg-shard.yaml
+++ b/docs/examples/mongodb/volume-expansion/mg-shard.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-sharding
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 2

--- a/docs/examples/mongodb/volume-expansion/mg-standalone.yaml
+++ b/docs/examples/mongodb/volume-expansion/mg-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mg-standalone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "longhorn"

--- a/docs/guides/mongodb/arbiter/replicaset.md
+++ b/docs/guides/mongodb/arbiter/replicaset.md
@@ -48,7 +48,7 @@ metadata:
   name: mongo-arb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "rs0"
   replicas: 2
@@ -295,7 +295,7 @@ spec:
   storageEngine: wiredTiger
   storageType: Durable
   deletionPolicy: WipeOut
-  version: 4.4.26
+  version: "8.0.17"
 status:
   conditions:
   - lastTransitionTime: "2022-04-21T08:39:32Z"

--- a/docs/guides/mongodb/arbiter/sharding.md
+++ b/docs/guides/mongodb/arbiter/sharding.md
@@ -48,7 +48,7 @@ metadata:
   name: mongo-sh-arb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3
@@ -270,7 +270,7 @@ spec:
   storageEngine: wiredTiger
   storageType: Durable
   deletionPolicy: WipeOut
-  version: 4.4.26
+  version: "8.0.17"
 status:
   conditions:
   - lastTransitionTime: "2022-04-21T09:29:07Z"

--- a/docs/guides/mongodb/autoscaler/compute/replicaset.md
+++ b/docs/guides/mongodb/autoscaler/compute/replicaset.md
@@ -45,7 +45,7 @@ Here, we are going to deploy a `MongoDB` Replicaset using a supported version by
 
 #### Deploy MongoDB Replicaset
 
-In this section, we are going to deploy a MongoDB Replicaset database with version `4.4.26`.  Then, in the next section we will set up autoscaling for this database using `MongoDBAutoscaler` CRD. Below is the YAML of the `MongoDB` CR that we are going to create,
+In this section, we are going to deploy a MongoDB Replicaset database with version `8.0.17`.  Then, in the next section we will set up autoscaling for this database using `MongoDBAutoscaler` CRD. Below is the YAML of the `MongoDB` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -54,7 +54,7 @@ metadata:
   name: mg-rs
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   replicas: 3

--- a/docs/guides/mongodb/autoscaler/compute/sharding.md
+++ b/docs/guides/mongodb/autoscaler/compute/sharding.md
@@ -45,7 +45,7 @@ Here, we are going to deploy a `MongoDB` sharded database using a supported vers
 
 #### Deploy MongoDB Sharded Database
 
-In this section, we are going to deploy a MongoDB sharded database with version `4.4.26`.  Then, in the next section we will set up autoscaling for this database using `MongoDBAutoscaler` CRD. Below is the YAML of the `MongoDB` CR that we are going to create,
+In this section, we are going to deploy a MongoDB sharded database with version `8.0.17`.  Then, in the next section we will set up autoscaling for this database using `MongoDBAutoscaler` CRD. Below is the YAML of the `MongoDB` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -54,7 +54,7 @@ metadata:
   name: mg-sh
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   shardTopology:
     configServer:

--- a/docs/guides/mongodb/autoscaler/compute/standalone.md
+++ b/docs/guides/mongodb/autoscaler/compute/standalone.md
@@ -45,7 +45,7 @@ Here, we are going to deploy a `MongoDB` standalone using a supported version by
 
 #### Deploy MongoDB standalone
 
-In this section, we are going to deploy a MongoDB standalone database with version `4.4.26`.  Then, in the next section we will set up autoscaling for this database using `MongoDBAutoscaler` CRD. Below is the YAML of the `MongoDB` CR that we are going to create,
+In this section, we are going to deploy a MongoDB standalone database with version `8.0.17`.  Then, in the next section we will set up autoscaling for this database using `MongoDBAutoscaler` CRD. Below is the YAML of the `MongoDB` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -54,7 +54,7 @@ metadata:
   name: mg-standalone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     resources:

--- a/docs/guides/mongodb/autoscaler/storage/replicaset.md
+++ b/docs/guides/mongodb/autoscaler/storage/replicaset.md
@@ -60,7 +60,7 @@ Now, we are going to deploy a `MongoDB` replicaset using a supported version by 
 
 #### Deploy MongoDB replicaset
 
-In this section, we are going to deploy a MongoDB replicaset database with version `4.4.26`.  Then, in the next section we will set up autoscaling for this database using `MongoDBAutoscaler` CRD. Below is the YAML of the `MongoDB` CR that we are going to create,
+In this section, we are going to deploy a MongoDB replicaset database with version `8.0.17`.  Then, in the next section we will set up autoscaling for this database using `MongoDBAutoscaler` CRD. Below is the YAML of the `MongoDB` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -69,7 +69,7 @@ metadata:
   name: mg-rs
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   replicas: 3

--- a/docs/guides/mongodb/autoscaler/storage/sharding.md
+++ b/docs/guides/mongodb/autoscaler/storage/sharding.md
@@ -60,7 +60,7 @@ Now, we are going to deploy a `MongoDB` sharded database using a supported versi
 
 #### Deploy MongoDB Sharded Database
 
-In this section, we are going to deploy a MongoDB sharded database with version `4.4.26`.  Then, in the next section we will set up autoscaling for this database using `MongoDBAutoscaler` CRD. Below is the YAML of the `MongoDB` CR that we are going to create,
+In this section, we are going to deploy a MongoDB sharded database with version `8.0.17`.  Then, in the next section we will set up autoscaling for this database using `MongoDBAutoscaler` CRD. Below is the YAML of the `MongoDB` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -69,7 +69,7 @@ metadata:
   name: mg-sh
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   shardTopology:
     configServer:

--- a/docs/guides/mongodb/autoscaler/storage/standalone.md
+++ b/docs/guides/mongodb/autoscaler/storage/standalone.md
@@ -60,7 +60,7 @@ Now, we are going to deploy a `MongoDB` standalone using a supported version by 
 
 #### Deploy MongoDB standalone
 
-In this section, we are going to deploy a MongoDB standalone database with version `4.4.26`.  Then, in the next section we will set up autoscaling for this database using `MongoDBAutoscaler` CRD. Below is the YAML of the `MongoDB` CR that we are going to create,
+In this section, we are going to deploy a MongoDB standalone database with version `8.0.17`.  Then, in the next section we will set up autoscaling for this database using `MongoDBAutoscaler` CRD. Below is the YAML of the `MongoDB` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -69,7 +69,7 @@ metadata:
   name: mg-standalone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: topolvm-provisioner

--- a/docs/guides/mongodb/backup/kubestash/application-level/examples/sample-mongodb.yaml
+++ b/docs/guides/mongodb/backup/kubestash/application-level/examples/sample-mongodb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   replicas: 3

--- a/docs/guides/mongodb/backup/kubestash/application-level/index.md
+++ b/docs/guides/mongodb/backup/kubestash/application-level/index.md
@@ -65,7 +65,7 @@ metadata:
   name: sample-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   replicas: 3
@@ -177,7 +177,7 @@ spec:
   secret:
     name: sample-mongodb-auth
   type: kubedb.com/mongodb
-  version: 4.4.26
+  version: "8.0.17"
 
 ```
 

--- a/docs/guides/mongodb/backup/kubestash/auto-backup/examples/sample-mongodb.yaml
+++ b/docs/guides/mongodb/backup/kubestash/auto-backup/examples/sample-mongodb.yaml
@@ -12,7 +12,7 @@ metadata:
     variables.kubestash.com/backupPath: /demo/mgo
     variables.kubestash.com/repoName: s3-repo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/mongodb/backup/kubestash/auto-backup/index.md
@@ -202,7 +202,7 @@ metadata:
     variables.kubestash.com/backupPath: /demo/mgo
     variables.kubestash.com/repoName: s3-repo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/kubestash/logical/replicaset/examples/mongodb-replicaset-restore.yaml
+++ b/docs/guides/mongodb/backup/kubestash/logical/replicaset/examples/mongodb-replicaset-restore.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mg-rs-restore
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   replicaSet:
     name: rs0

--- a/docs/guides/mongodb/backup/kubestash/logical/replicaset/examples/mongodb-replicaset.yaml
+++ b/docs/guides/mongodb/backup/kubestash/logical/replicaset/examples/mongodb-replicaset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mg-rs
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   replicaSet:
     name: rs0

--- a/docs/guides/mongodb/backup/kubestash/logical/replicaset/index.md
+++ b/docs/guides/mongodb/backup/kubestash/logical/replicaset/index.md
@@ -57,7 +57,7 @@ metadata:
   name: sample-mg-rs
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   replicaSet:
     name: rs0
@@ -414,7 +414,7 @@ metadata:
   name: sample-mg-rs-restore
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   replicaSet:
     name: rs0

--- a/docs/guides/mongodb/backup/kubestash/logical/sharding/examples/mongodb-sharding-restore.yaml
+++ b/docs/guides/mongodb/backup/kubestash/logical/sharding/examples/mongodb-sharding-restore.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mg-sh-restore
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3

--- a/docs/guides/mongodb/backup/kubestash/logical/sharding/examples/mongodb-sharding.yaml
+++ b/docs/guides/mongodb/backup/kubestash/logical/sharding/examples/mongodb-sharding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mg-sh
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3

--- a/docs/guides/mongodb/backup/kubestash/logical/sharding/index.md
+++ b/docs/guides/mongodb/backup/kubestash/logical/sharding/index.md
@@ -57,7 +57,7 @@ metadata:
   name: sample-mg-sh
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3
@@ -422,7 +422,7 @@ metadata:
   name: sample-mg-sh-restore
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3

--- a/docs/guides/mongodb/backup/kubestash/logical/standalone/examples/mongodb-restore.yaml
+++ b/docs/guides/mongodb/backup/kubestash/logical/standalone/examples/mongodb-restore.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restore-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/kubestash/logical/standalone/examples/mongodb.yaml
+++ b/docs/guides/mongodb/backup/kubestash/logical/standalone/examples/mongodb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/kubestash/logical/standalone/index.md
+++ b/docs/guides/mongodb/backup/kubestash/logical/standalone/index.md
@@ -57,7 +57,7 @@ metadata:
   name: sample-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -409,7 +409,7 @@ metadata:
   name: restore-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/stash/auto-backup/examples/sample-mongodb-2.yaml
+++ b/docs/guides/mongodb/backup/stash/auto-backup/examples/sample-mongodb-2.yaml
@@ -7,7 +7,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mongodb-backup-template
     stash.appscode.com/schedule: "*/3 * * * *"
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/stash/auto-backup/examples/sample-mongodb-3.yaml
+++ b/docs/guides/mongodb/backup/stash/auto-backup/examples/sample-mongodb-3.yaml
@@ -7,7 +7,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mongodb-backup-template
     params.stash.appscode.com/args: "--db=testdb"
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/stash/auto-backup/examples/sample-mongodb.yaml
+++ b/docs/guides/mongodb/backup/stash/auto-backup/examples/sample-mongodb.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     stash.appscode.com/backup-blueprint: mongodb-backup-template
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/stash/auto-backup/index.md
+++ b/docs/guides/mongodb/backup/stash/auto-backup/index.md
@@ -154,7 +154,7 @@ metadata:
   annotations:
     stash.appscode.com/backup-blueprint: mongodb-backup-template
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -329,7 +329,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mongodb-backup-template
     stash.appscode.com/schedule: "*/3 * * * *"
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -515,7 +515,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mongodb-backup-template
     params.stash.appscode.com/args: "--db=testdb"
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/stash/customization/examples/sample-mariadb.yaml
+++ b/docs/guides/mongodb/backup/stash/customization/examples/sample-mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/stash/logical/replicaset/examples/mongodb-replicaset.yaml
+++ b/docs/guides/mongodb/backup/stash/logical/replicaset/examples/mongodb-replicaset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mgo-rs
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   replicaSet:
     name: rs0

--- a/docs/guides/mongodb/backup/stash/logical/replicaset/examples/restored-mongodb-replicaset.yaml
+++ b/docs/guides/mongodb/backup/stash/logical/replicaset/examples/restored-mongodb-replicaset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restored-mgo-rs
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   replicaSet:
     name: rs0

--- a/docs/guides/mongodb/backup/stash/logical/replicaset/examples/restored-standalone.yaml
+++ b/docs/guides/mongodb/backup/stash/logical/replicaset/examples/restored-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restored-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/stash/logical/replicaset/index.md
+++ b/docs/guides/mongodb/backup/stash/logical/replicaset/index.md
@@ -57,7 +57,7 @@ metadata:
   name: sample-mgo-rs
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   replicaSet:
     name: rs0
@@ -170,7 +170,7 @@ spec:
   secret:
     name: sample-mgo-rs-auth
   type: kubedb.com/mongodb
-  version: 4.4.26
+  version: "8.0.17"
 ```
 
 Stash uses the `AppBinding` crd to connect with the target database. It requires the following two fields to set in AppBinding's `Spec` section.
@@ -616,7 +616,7 @@ metadata:
   name: restored-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/stash/logical/sharding/examples/mongodb-sharding.yaml
+++ b/docs/guides/mongodb/backup/stash/logical/sharding/examples/mongodb-sharding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mgo-sh
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3

--- a/docs/guides/mongodb/backup/stash/logical/sharding/examples/restored-mongodb-sharding.yaml
+++ b/docs/guides/mongodb/backup/stash/logical/sharding/examples/restored-mongodb-sharding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restored-mgo-sh
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3

--- a/docs/guides/mongodb/backup/stash/logical/sharding/examples/restored-standalone.yaml
+++ b/docs/guides/mongodb/backup/stash/logical/sharding/examples/restored-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restored-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/stash/logical/sharding/index.md
+++ b/docs/guides/mongodb/backup/stash/logical/sharding/index.md
@@ -57,7 +57,7 @@ metadata:
   name: sample-mgo-sh
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3
@@ -184,7 +184,7 @@ spec:
   secret:
     name: sample-mgo-sh-auth
   type: kubedb.com/mongodb
-  version: 4.4.26
+  version: "8.0.17"
 ```
 
 Stash uses the `AppBinding` crd to connect with the target database. It requires the following two fields to set in AppBinding's `Spec` section.
@@ -625,7 +625,7 @@ metadata:
   name: restored-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/stash/logical/standalone/examples/mongodb.yaml
+++ b/docs/guides/mongodb/backup/stash/logical/standalone/examples/mongodb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/stash/logical/standalone/examples/restored-mongodb.yaml
+++ b/docs/guides/mongodb/backup/stash/logical/standalone/examples/restored-mongodb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restored-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/backup/stash/logical/standalone/index.md
+++ b/docs/guides/mongodb/backup/stash/logical/standalone/index.md
@@ -57,7 +57,7 @@ metadata:
   name: sample-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -165,7 +165,7 @@ spec:
   secret:
     name: sample-mongodb-auth
   type: kubedb.com/mongodb
-  version: 4.4.26
+  version: "8.0.17"
 ```
 
 Stash uses the `AppBinding` crd to connect with the target database. It requires the following two fields to set in AppBinding's `Spec` section.

--- a/docs/guides/mongodb/clustering/replicaset.md
+++ b/docs/guides/mongodb/clustering/replicaset.md
@@ -48,7 +48,7 @@ metadata:
   name: mgo-replicaset
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   replicaSet:
     name: rs0
@@ -315,7 +315,7 @@ spec:
   storageEngine: wiredTiger
   storageType: Durable
   deletionPolicy: Delete
-  version: 4.4.26
+  version: "8.0.17"
 status:
   conditions:
     - lastTransitionTime: "2021-02-11T04:29:29Z"

--- a/docs/guides/mongodb/clustering/sharding.md
+++ b/docs/guides/mongodb/clustering/sharding.md
@@ -48,7 +48,7 @@ metadata:
   name: mongo-sh
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3
@@ -303,7 +303,7 @@ spec:
   storageEngine: wiredTiger
   storageType: Durable
   deletionPolicy: Delete
-  version: 4.4.26
+  version: "8.0.17"
 status:
   conditions:
     - lastTransitionTime: "2021-02-10T12:57:03Z"

--- a/docs/guides/mongodb/clustering/standalone.md
+++ b/docs/guides/mongodb/clustering/standalone.md
@@ -46,7 +46,7 @@ metadata:
   name: mg-alone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   podTemplate:
     spec:
       containers:
@@ -288,7 +288,7 @@ spec:
   storageEngine: wiredTiger
   storageType: Durable
   deletionPolicy: WipeOut
-  version: 4.4.26
+  version: "8.0.17"
 status:
   conditions:
     - lastTransitionTime: "2022-11-04T04:30:07Z"

--- a/docs/guides/mongodb/concepts/appbinding.md
+++ b/docs/guides/mongodb/concepts/appbinding.md
@@ -78,7 +78,7 @@ spec:
   secret:
     name: sample-mgo-rs-auth
   type: kubedb.com/mongodb
-  version: 4.4.26
+  version: "8.0.17"
 ```
 
 Here, we are going to describe the sections of an `AppBinding` crd.

--- a/docs/guides/mongodb/concepts/catalog.md
+++ b/docs/guides/mongodb/concepts/catalog.md
@@ -54,7 +54,7 @@ spec:
   updateConstraints:
     allowlist:
       - '>= 4.4.0, < 5.0.0'
-  version: 4.4.26
+  version: "8.0.17"
 ```
 
 ### metadata.name

--- a/docs/guides/mongodb/concepts/mongodb.md
+++ b/docs/guides/mongodb/concepts/mongodb.md
@@ -31,7 +31,7 @@ metadata:
 spec:
   autoOps:
     disabled: true
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   authSecret:
     kind: Secret
@@ -442,7 +442,7 @@ metadata:
   name: mgo1
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   init:
     script:
       configMap:

--- a/docs/guides/mongodb/concepts/opsrequest.md
+++ b/docs/guides/mongodb/concepts/opsrequest.md
@@ -37,7 +37,7 @@ spec:
   databaseRef:
     name: mg-standalone
   updateVersion:
-    targetVersion: 4.4.26
+    targetVersion: 8.0.17
 status:
   conditions:
     - lastTransitionTime: "2020-08-25T18:22:38Z"

--- a/docs/guides/mongodb/configuration/using-config-file.md
+++ b/docs/guides/mongodb/configuration/using-config-file.md
@@ -94,7 +94,7 @@ metadata:
   name: mgo-custom-config
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/configuration/using-podtemplate.md
+++ b/docs/guides/mongodb/configuration/using-podtemplate.md
@@ -72,7 +72,7 @@ metadata:
   name: mgo-misc-config
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: "Durable"
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/custom-rbac/using-custom-rbac.md
+++ b/docs/guides/mongodb/custom-rbac/using-custom-rbac.md
@@ -142,7 +142,7 @@ metadata:
   name: quick-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   podTemplate:
       spec:
@@ -206,7 +206,7 @@ metadata:
   name: minute-mongodb
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   podTemplate:
       spec:
         serviceAccountName: my-custom-serviceaccount

--- a/docs/guides/mongodb/external-connection/horizon.md
+++ b/docs/guides/mongodb/external-connection/horizon.md
@@ -295,7 +295,7 @@ spec:
       apiGroup: cert-manager.io
       kind: Issuer
       name: mongo-ca-issuer
-  version: 7.0.21
+  version: "8.0.17"
 ```
 
 Here,

--- a/docs/guides/mongodb/failure-and-disaster-recovery/overview.md
+++ b/docs/guides/mongodb/failure-and-disaster-recovery/overview.md
@@ -66,7 +66,7 @@ metadata:
   name: mg-ha-demo
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "rs1"
   replicas: 3

--- a/docs/guides/mongodb/hidden-node/replicaset.md
+++ b/docs/guides/mongodb/hidden-node/replicaset.md
@@ -48,7 +48,7 @@ metadata:
   name: mongo-rs-hid
   namespace: demo
 spec:
-  version: "percona-7.0.18"
+  version: "percona-8.0.17"
   replicaSet:
     name: "replicaset"
   podTemplate:
@@ -347,7 +347,7 @@ spec:
   storageEngine: inMemory
   storageType: Ephemeral
   deletionPolicy: WipeOut
-  version: percona-7.0.18
+  version: "percona-8.0.17"
 status:
   conditions:
     - lastTransitionTime: "2022-10-31T05:03:50Z"

--- a/docs/guides/mongodb/hidden-node/sharding.md
+++ b/docs/guides/mongodb/hidden-node/sharding.md
@@ -48,7 +48,7 @@ metadata:
   name: mongo-sh-hid
   namespace: demo
 spec:
-  version: "percona-7.0.18"
+  version: "percona-8.0.17"
   shardTopology:
     configServer:
       replicas: 3
@@ -252,7 +252,7 @@ spec:
   storageEngine: inMemory
   storageType: Ephemeral
   deletionPolicy: WipeOut
-  version: percona-7.0.18
+  version: "percona-8.0.17"
 status:
   conditions:
     - lastTransitionTime: "2022-10-31T05:59:43Z"

--- a/docs/guides/mongodb/initialization/gitsync.md
+++ b/docs/guides/mongodb/initialization/gitsync.md
@@ -54,7 +54,7 @@ spec:
           - --root=/git
           # terminate after successful sync
           - --one-time
-  version: "8.0.10"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -190,7 +190,7 @@ spec:
       # permission for reading ssh key
       securityContext:
         fsGroup: 65533
-  version: "8.0.10"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "local-path"
@@ -298,7 +298,7 @@ spec:
       # permission for reading ssh key
       securityContext:
         fsGroup: 65533
-  version: "8.0.10"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "local-path"

--- a/docs/guides/mongodb/initialization/using-script.md
+++ b/docs/guides/mongodb/initialization/using-script.md
@@ -60,7 +60,7 @@ metadata:
   name: mgo-init-script
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storage:
     storageClassName: "standard"
     accessModes:
@@ -311,7 +311,7 @@ spec:
   storageEngine: wiredTiger
   storageType: Durable
   deletionPolicy: Delete
-  version: 4.4.26
+  version: "8.0.17"
 status:
   conditions:
     - lastTransitionTime: "2021-02-10T04:38:53Z"

--- a/docs/guides/mongodb/monitoring/overview.md
+++ b/docs/guides/mongodb/monitoring/overview.md
@@ -53,7 +53,7 @@ metadata:
   name: sample-mongo
   namespace: databases
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   deletionPolicy: WipeOut
   configuration:
     secretName: config
@@ -95,7 +95,7 @@ spec:
 Here, we have specified that we are going to monitor this server using Prometheus operator through `spec.monitor.agent: prometheus.io/operator`. KubeDB will create a `ServiceMonitor` crd in databases namespace and this `ServiceMonitor` will have `release: prometheus` label.
 
 One thing to note that, we internally use `--collect-all` args, if the mongodb exporter version >= v0.31.0 . You can check the exporter version by getting the mgversion object, like this, 
-`kubectl get mgversion -o=jsonpath='{.spec.exporter.image}' 4.4.26`
+`kubectl get mgversion -o=jsonpath='{.spec.exporter.image}' 8.0.17`
 In that case, specifying args to collect something (as we used `--collect.database` above) will not have any effect. 
 
 ## Next Steps

--- a/docs/guides/mongodb/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/mongodb/monitoring/using-builtin-prometheus.md
@@ -49,7 +49,7 @@ metadata:
   name: builtin-prom-mgo
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/monitoring/using-prometheus-operator.md
+++ b/docs/guides/mongodb/monitoring/using-prometheus-operator.md
@@ -138,7 +138,7 @@ metadata:
   name: coreos-prom-mgo
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/pitr/pitr.md
+++ b/docs/guides/mongodb/pitr/pitr.md
@@ -244,7 +244,7 @@ metadata:
   labels:
     archiver: "true"
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "rs"
   replicas: 3
@@ -381,7 +381,7 @@ metadata:
   name: mg-rs-restored
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "rs"
   replicas: 3

--- a/docs/guides/mongodb/private-registry/using-private-registry.md
+++ b/docs/guides/mongodb/private-registry/using-private-registry.md
@@ -75,7 +75,7 @@ metadata:
   labels:
     app: kubedb
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   db:
     image: "PRIVATE_DOCKER_REGISTRY/mongo:4.4.26"
   exporter:
@@ -130,7 +130,7 @@ metadata:
   name: mgo-pvt-reg
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mongodb/quickstart/quickstart.md
+++ b/docs/guides/mongodb/quickstart/quickstart.md
@@ -85,7 +85,7 @@ metadata:
   name: mgo-quickstart
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "rs1"
   replicas: 3
@@ -112,7 +112,7 @@ metadata:
   name: mgo-quickstart
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "rs1"
   replicas: 3
@@ -134,7 +134,7 @@ mongodb.kubedb.com/mgo-quickstart created
 
 Here,
 
-- `spec.version` is name of the MongoDBVersion crd where the docker images are specified. In this tutorial, a MongoDB 4.4.26 database is created.
+- `spec.version` is name of the MongoDBVersion crd where the docker images are specified. In this tutorial, a MongoDB 8.0.17 database is created.
 - `spec.storageType` specifies the type of storage that will be used for MongoDB database. It can be `Durable` or `Ephemeral`. Default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create MongoDB database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.storage` specifies PVC spec that will be dynamically allocated to store data for this database. This storage spec will be passed to the StatefulSet created by KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests.
 - `spec.terminationPolicy` or `spec.deletionPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `MongoDB` crd or which resources KubeDB should keep or delete when you delete `MongoDB` crd. If admission webhook is enabled, It prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`. Learn details of all `TerminationPolicy` [here](/docs/guides/mongodb/concepts/mongodb.md#specterminationpolicy)
@@ -332,7 +332,7 @@ spec:
   storageEngine: wiredTiger
   storageType: Durable
   deletionPolicy: Delete
-  version: 4.4.26
+  version: "8.0.17"
 status:
   conditions:
     - lastTransitionTime: "2022-06-13T12:01:55Z"

--- a/docs/guides/mongodb/recommendation/recommendation.md
+++ b/docs/guides/mongodb/recommendation/recommendation.md
@@ -64,7 +64,7 @@ metadata:
   name: mg-recommendation
   namespace: demo
 spec:
-  version: "8.0.10"
+  version: "8.0.17"
   authSecret:
     kind: Secret
     name: mg-auth
@@ -104,7 +104,7 @@ metadata:
   name: mg-tls
   namespace: demo
 spec:
-  version: "8.0.10"
+  version: "8.0.17"
   tls:
     issuerRef:
       apiGroup: "cert-manager.io"
@@ -144,7 +144,7 @@ metadata:
   name: mg-recommendation
   namespace: demo
 spec:
-  version: "8.0.10"
+  version: "8.0.17"
   storage:
     resources:
       requests:

--- a/docs/guides/mongodb/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/mongodb/reconfigure-tls/reconfigure-tls.md
@@ -48,7 +48,7 @@ metadata:
   name: mg-rs
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   replicaSet:
     name: rs0

--- a/docs/guides/mongodb/reconfigure/replicaset.md
+++ b/docs/guides/mongodb/reconfigure/replicaset.md
@@ -41,7 +41,7 @@ Now, we are going to deploy a  `MongoDB` Replicaset using a supported version by
 
 ### Prepare MongoDB Replicaset
 
-Now, we are going to deploy a `MongoDB` Replicaset database with version `4.4.26`.
+Now, we are going to deploy a `MongoDB` Replicaset database with version `8.0.17`.
 
 ### Deploy MongoDB 
 
@@ -70,7 +70,7 @@ metadata:
   name: mg-replicaset
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicas: 3
   replicaSet:
     name: rs0

--- a/docs/guides/mongodb/reconfigure/sharding.md
+++ b/docs/guides/mongodb/reconfigure/sharding.md
@@ -41,7 +41,7 @@ Now, we are going to deploy a  `MongoDB` sharded database using a supported vers
 
 ### Prepare MongoDB Shard
 
-Now, we are going to deploy a `MongoDB` sharded database with version `4.4.26`.
+Now, we are going to deploy a `MongoDB` sharded database with version `8.0.17`.
 
 ### Deploy MongoDB database 
 
@@ -70,7 +70,7 @@ metadata:
   name: mg-sharding
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3

--- a/docs/guides/mongodb/reconfigure/standalone.md
+++ b/docs/guides/mongodb/reconfigure/standalone.md
@@ -40,7 +40,7 @@ Now, we are going to deploy a  `MongoDB` standalone using a supported version by
 
 ### Prepare MongoDB Standalone Database
 
-Now, we are going to deploy a `MongoDB` standalone database with version `4.4.26`.
+Now, we are going to deploy a `MongoDB` standalone database with version `8.0.17`.
 
 ### Deploy MongoDB standalone 
 
@@ -69,7 +69,7 @@ metadata:
   name: mg-standalone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/reprovision/reprovision.md
+++ b/docs/guides/mongodb/reprovision/reprovision.md
@@ -42,7 +42,7 @@ metadata:
   name: mongo
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   podTemplate:

--- a/docs/guides/mongodb/restart/restart.md
+++ b/docs/guides/mongodb/restart/restart.md
@@ -42,7 +42,7 @@ metadata:
   name: mongo
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   podTemplate:

--- a/docs/guides/mongodb/rotate-auth/rotateauth.md
+++ b/docs/guides/mongodb/rotate-auth/rotateauth.md
@@ -47,7 +47,7 @@ metadata:
   name: mgo-quickstart
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "rs1"
   replicas: 3

--- a/docs/guides/mongodb/scaling/horizontal-scaling/replicaset.md
+++ b/docs/guides/mongodb/scaling/horizontal-scaling/replicaset.md
@@ -43,7 +43,7 @@ Here, we are going to deploy a  `MongoDB` replicaset using a supported version b
 
 ### Prepare MongoDB Replicaset Database
 
-Now, we are going to deploy a `MongoDB` replicaset database with version `4.4.26`.
+Now, we are going to deploy a `MongoDB` replicaset database with version `8.0.17`.
 
 ### Deploy MongoDB replicaset 
 
@@ -56,7 +56,7 @@ metadata:
   name: mg-replicaset
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet: 
     name: "replicaset"
   replicas: 3

--- a/docs/guides/mongodb/scaling/horizontal-scaling/sharding.md
+++ b/docs/guides/mongodb/scaling/horizontal-scaling/sharding.md
@@ -43,7 +43,7 @@ Here, we are going to deploy a  `MongoDB` sharded database using a supported ver
 
 ### Prepare MongoDB Sharded Database
 
-Now, we are going to deploy a `MongoDB` sharded database with version `4.4.26`.
+Now, we are going to deploy a `MongoDB` sharded database with version `8.0.17`.
 
 ### Deploy MongoDB Sharded Database 
 
@@ -56,7 +56,7 @@ metadata:
   name: mg-sharding
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3

--- a/docs/guides/mongodb/scaling/vertical-scaling/replicaset.md
+++ b/docs/guides/mongodb/scaling/vertical-scaling/replicaset.md
@@ -43,7 +43,7 @@ Here, we are going to deploy a  `MongoDB` replicaset using a supported version b
 
 ### Prepare MongoDB Replicaset Database
 
-Now, we are going to deploy a `MongoDB` replicaset database with version `4.4.26`.
+Now, we are going to deploy a `MongoDB` replicaset database with version `8.0.17`.
 
 ### Deploy MongoDB replicaset 
 
@@ -56,7 +56,7 @@ metadata:
   name: mg-replicaset
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet: 
     name: "replicaset"
   replicas: 3

--- a/docs/guides/mongodb/scaling/vertical-scaling/sharding.md
+++ b/docs/guides/mongodb/scaling/vertical-scaling/sharding.md
@@ -43,7 +43,7 @@ Here, we are going to deploy a  `MongoDB` sharded database using a supported ver
 
 ### Prepare MongoDB Sharded Database
 
-Now, we are going to deploy a `MongoDB` sharded database with version `4.4.26`.
+Now, we are going to deploy a `MongoDB` sharded database with version `8.0.17`.
 
 ### Deploy MongoDB Sharded Database 
 
@@ -56,7 +56,7 @@ metadata:
   name: mg-sharding
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 3

--- a/docs/guides/mongodb/scaling/vertical-scaling/standalone.md
+++ b/docs/guides/mongodb/scaling/vertical-scaling/standalone.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a  `MongoDB` standalone using a supported version b
 
 ### Prepare MongoDB Standalone Database
 
-Now, we are going to deploy a `MongoDB` standalone database with version `4.4.26`.
+Now, we are going to deploy a `MongoDB` standalone database with version `8.0.17`.
 
 ### Deploy MongoDB standalone 
 
@@ -55,7 +55,7 @@ metadata:
   name: mg-standalone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mongodb/schema-manager/deploy-mongodbdatabase/index.md
+++ b/docs/guides/mongodb/schema-manager/deploy-mongodbdatabase/index.md
@@ -63,7 +63,7 @@ spec:
     selector:
       matchLabels:
         "schema.kubedb.com": "mongo"
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   podTemplate:
@@ -88,7 +88,7 @@ spec:
 
 Here,
 
-- `spec.version` is the name of the MongoDBVersion CR. Here, we are using MongoDB version `4.4.26`.
+- `spec.version` is the name of the MongoDBVersion CR. Here, we are using MongoDB version `8.0.17`.
 - `spec.storageType` specifies the type of storage that will be used for MongoDB. It can be `Durable` or `Ephemeral`. The default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create the MongoDB using `EmptyDir` volume.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the PetSet created by KubeDB operator to run database pods. So, each members will have a pod of this storage configuration. You can specify any StorageClass available in your cluster with appropriate resource requests.
 - `spec.allowedSchemas` specifies the namespace and selectors of allowed `Schema Manager`.

--- a/docs/guides/mongodb/schema-manager/deploy-mongodbdatabase/yamls/mongodb.yaml
+++ b/docs/guides/mongodb/schema-manager/deploy-mongodbdatabase/yamls/mongodb.yaml
@@ -13,7 +13,7 @@ spec:
     selector:
       matchLabels:
         "schema.kubedb.com": "mongo"
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   podTemplate:

--- a/docs/guides/mongodb/schema-manager/initializing-with-script/index.md
+++ b/docs/guides/mongodb/schema-manager/initializing-with-script/index.md
@@ -63,7 +63,7 @@ spec:
     selector:
       matchLabels:
         "schema.kubedb.com": "mongo"
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   podTemplate:
@@ -88,7 +88,7 @@ spec:
 
 Here,
 
-- `spec.version` is the name of the MongoDBVersion CR. Here, we are using MongoDB version `4.4.26`.
+- `spec.version` is the name of the MongoDBVersion CR. Here, we are using MongoDB version `8.0.17`.
 - `spec.storageType` specifies the type of storage that will be used for MongoDB. It can be `Durable` or `Ephemeral`. The default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create the MongoDB using `EmptyDir` volume.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the PetSet created by KubeDB operator to run database pods. So, each members will have a pod of this storage configuration. You can specify any StorageClass available in your cluster with appropriate resource requests.
 - `spec.allowedSchemas` specifies the namespace and selectors of allowed `Schema Manager`.

--- a/docs/guides/mongodb/schema-manager/initializing-with-script/yamls/mongodb.yaml
+++ b/docs/guides/mongodb/schema-manager/initializing-with-script/yamls/mongodb.yaml
@@ -13,7 +13,7 @@ spec:
     selector:
       matchLabels:
         "schema.kubedb.com": "mongo"
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   podTemplate:

--- a/docs/guides/mongodb/schema-manager/initializing-with-snapshot/index.md
+++ b/docs/guides/mongodb/schema-manager/initializing-with-snapshot/index.md
@@ -78,7 +78,7 @@ spec:
   allowedSchemas:
     namespaces:
       from: All
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   podTemplate:
@@ -103,7 +103,7 @@ spec:
 
 Here,
 
-- `spec.version` is the name of the MongoDBVersion CR. Here, we are using MongoDB version `4.4.26`.
+- `spec.version` is the name of the MongoDBVersion CR. Here, we are using MongoDB version `8.0.17`.
 - `spec.storageType` specifies the type of storage that will be used for MongoDB. It can be `Durable` or `Ephemeral`. The default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create the MongoDB using `EmptyDir` volume.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the PetSet created by KubeDB operator to run database pods. So, each members will have a pod of this storage configuration. You can specify any StorageClass available in your cluster with appropriate resource requests.
 - `spec.allowedSchemas` specifies the namespace and selectors of allowed `Schema Manager`.

--- a/docs/guides/mongodb/schema-manager/initializing-with-snapshot/yamls/mongodb.yaml
+++ b/docs/guides/mongodb/schema-manager/initializing-with-snapshot/yamls/mongodb.yaml
@@ -7,7 +7,7 @@ spec:
   allowedSchemas:
     namespaces:
       from: All
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet:
     name: "replicaset"
   podTemplate:

--- a/docs/guides/mongodb/tls/replicaset.md
+++ b/docs/guides/mongodb/tls/replicaset.md
@@ -102,7 +102,7 @@ metadata:
   name: mgo-rs-tls
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   sslMode: requireSSL
   tls:
     issuerRef:

--- a/docs/guides/mongodb/tls/sharding.md
+++ b/docs/guides/mongodb/tls/sharding.md
@@ -102,7 +102,7 @@ metadata:
   name: mongo-sh-tls
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   sslMode: requireSSL
   tls:
     issuerRef:

--- a/docs/guides/mongodb/tls/standalone.md
+++ b/docs/guides/mongodb/tls/standalone.md
@@ -102,7 +102,7 @@ metadata:
   name: mgo-tls
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   sslMode: requireSSL
   tls:
     issuerRef:

--- a/docs/guides/mongodb/update-version/replicaset.md
+++ b/docs/guides/mongodb/update-version/replicaset.md
@@ -39,7 +39,7 @@ namespace/demo created
 
 ## Prepare MongoDB ReplicaSet Database
 
-Now, we are going to deploy a `MongoDB` replicaset database with version `3.6.8`.
+Now, we are going to deploy a `MongoDB` replicaset database with version `7.0.28`.
 
 ### Deploy MongoDB replicaset
 
@@ -52,7 +52,7 @@ metadata:
   name: mg-replicaset
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "7.0.28"
   replicaSet: 
     name: "replicaset"
   replicas: 3
@@ -78,14 +78,14 @@ Now, wait until `mg-replicaset` created has status `Ready`. i.e,
 ```bash
 $ k get mongodb -n demo                                                                                                                                             
 NAME            VERSION    STATUS    AGE
-mg-replicaset   4.4.26   Ready     109s
+mg-replicaset   7.0.28   Ready     109s
 ```
 
 We are now ready to apply the `MongoDBOpsRequest` CR to update this database.
 
 ### update MongoDB Version
 
-Here, we are going to update `MongoDB` replicaset from `3.6.8` to `4.0.5`.
+Here, we are going to update `MongoDB` replicaset from `7.0.28` to `8.0.17`.
 
 #### Create MongoDBOpsRequest:
 
@@ -102,7 +102,7 @@ spec:
   databaseRef:
     name: mg-replicaset
   updateVersion:
-    targetVersion: 4.4.26
+    targetVersion: 8.0.17
   readinessCriteria:
     oplogMaxLagSeconds: 20
     objectsCountDiffPercentage: 10
@@ -114,7 +114,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `mg-replicaset` MongoDB database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `4.0.5`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `8.0.17`.
 - Have a look [here](/docs/guides/mongodb/concepts/opsrequest.md#specreadinesscriteria) on the respective sections to understand the `readinessCriteria`, `timeout` & `apply` fields.
 
 Let's create the `MongoDBOpsRequest` CR we have shown above,
@@ -244,13 +244,13 @@ Now, we are going to verify whether the `MongoDB` and the related `PetSets` and 
 
 ```bash
 $ kubectl get mg -n demo mg-replicaset -o=jsonpath='{.spec.version}{"\n"}'
-4.4.26
+8.0.17
 
 $ kubectl get sts -n demo mg-replicaset -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-mongo:4.0.5
+mongo:8.0.17
 
 $ kubectl get pods -n demo mg-replicaset-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-mongo:4.0.5
+mongo:8.0.17
 ```
 
 You can see from above, our `MongoDB` replicaset database has been updated with the new version. So, the updateVersion process is successfully completed.

--- a/docs/guides/mongodb/update-version/sharding.md
+++ b/docs/guides/mongodb/update-version/sharding.md
@@ -39,7 +39,7 @@ namespace/demo created
 
 ## Prepare MongoDB Sharded Database Database
 
-Now, we are going to deploy a `MongoDB` sharded database with version `3.6.8`.
+Now, we are going to deploy a `MongoDB` sharded database with version `7.0.28`.
 
 ### Deploy MongoDB Sharded Database 
 
@@ -52,7 +52,7 @@ metadata:
   name: mg-sharding
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "7.0.28"
   shardTopology:
     configServer:
       replicas: 2
@@ -85,14 +85,14 @@ Now, wait until `mg-sharding` created has status `Ready`. i.e,
 ```bash
 $ k get mongodb -n demo                                                                                                                                             
 NAME          VERSION    STATUS    AGE
-mg-sharding   4.4.26   Ready     2m9s
+mg-sharding   7.0.28   Ready     2m9s
 ```
 
 We are now ready to apply the `MongoDBOpsRequest` CR to update this database.
 
 ### Update MongoDB Version
 
-Here, we are going to update `MongoDB` sharded database from `3.6.8` to `4.0.5`.
+Here, we are going to update `MongoDB` sharded database from `7.0.28` to `8.0.17`.
 
 #### Create MongoDBOpsRequest
 
@@ -109,7 +109,7 @@ spec:
   databaseRef:
     name: mg-sharding
   updateVersion:
-    targetVersion: 4.4.26
+    targetVersion: 8.0.17
   readinessCriteria:
     oplogMaxLagSeconds: 20
     objectsCountDiffPercentage: 10
@@ -121,7 +121,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `mg-sharding` MongoDB database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `4.0.5`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `8.0.17`.
 - Have a look [here](/docs/guides/mongodb/concepts/opsrequest.md#specreadinesscriteria) on the respective sections to understand the `readinessCriteria`, `timeout` & `apply` fields.
 
 Let's create the `MongoDBOpsRequest` CR we have shown above,
@@ -284,25 +284,25 @@ Now, we are going to verify whether the `MongoDB` and the related `PetSets` of `
 
 ```bash
 $ kubectl get mg -n demo mg-sharding -o=jsonpath='{.spec.version}{"\n"}'
-4.4.26
+8.0.17
 
 $ kubectl get sts -n demo mg-sharding-configsvr -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-mongo:4.0.5
+mongo:8.0.17
 
 $ kubectl get sts -n demo mg-sharding-shard0 -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-mongo:4.0.5
+mongo:8.0.17
 
 $ kubectl get sts -n demo mg-sharding-mongos -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-mongo:4.0.5
+mongo:8.0.17
 
 $ kubectl get pods -n demo mg-sharding-configsvr-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-mongo:4.0.5
+mongo:8.0.17
 
 $ kubectl get pods -n demo mg-sharding-shard0-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-mongo:4.0.5
+mongo:8.0.17
 
 $ kubectl get pods -n demo mg-sharding-mongos-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-mongo:4.0.5
+mongo:8.0.17
 ```
 
 You can see from above, our `MongoDB` sharded database has been updated with the new version. So, the update process is successfully completed.

--- a/docs/guides/mongodb/update-version/standalone.md
+++ b/docs/guides/mongodb/update-version/standalone.md
@@ -38,7 +38,7 @@ namespace/demo created
 
 ### Prepare MongoDB Standalone Database
 
-Now, we are going to deploy a `MongoDB` standalone database with version `3.6.8`.
+Now, we are going to deploy a `MongoDB` standalone database with version `7.0.28`.
 
 ### Deploy MongoDB standalone :
 
@@ -51,7 +51,7 @@ metadata:
   name: mg-standalone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "7.0.28"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -74,14 +74,14 @@ Now, wait until `mg-standalone` created has status `Ready`. i.e,
 ```bash
 $ kubectl get mg -n demo
   NAME            VERSION    STATUS    AGE
-  mg-standalone   4.4.26   Ready     8m58s
+  mg-standalone   7.0.28   Ready     8m58s
 ```
 
 We are now ready to apply the `MongoDBOpsRequest` CR to update this database.
 
 ### update MongoDB Version
 
-Here, we are going to update `MongoDB` standalone from `3.6.8` to `4.0.5`.
+Here, we are going to update `MongoDB` standalone from `7.0.28` to `8.0.17`.
 
 #### Create MongoDBOpsRequest:
 
@@ -98,7 +98,7 @@ spec:
   databaseRef:
     name: mg-standalone
   updateVersion:
-    targetVersion: 4.4.26
+    targetVersion: 8.0.17
   readinessCriteria:
     oplogMaxLagSeconds: 20
     objectsCountDiffPercentage: 10
@@ -110,7 +110,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `mg-standalone` MongoDB database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `4.0.5`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `8.0.17`.
 - Have a look [here](/docs/guides/mongodb/concepts/opsrequest.md#specreadinesscriteria) on the respective sections to understand the `readinessCriteria`, `timeout` & `apply` fields.
 
 
@@ -242,13 +242,13 @@ Now, we are going to verify whether the `MongoDB` and the related `PetSets` thei
 
 ```bash
 $ kubectl get mg -n demo mg-standalone -o=jsonpath='{.spec.version}{"\n"}'                                                                                          
-4.4.26
+8.0.17
 
 $ kubectl get sts -n demo mg-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'                                                               
-mongo:4.0.5
+mongo:8.0.17
 
 $ kubectl get pods -n demo mg-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'                                                                           
-mongo:4.0.5
+mongo:8.0.17
 ```
 
 You can see from above, our `MongoDB` standalone database has been updated with the new version. So, the update process is successfully completed.

--- a/docs/guides/mongodb/vault-integration/kmip-encryption/examples/mg.yaml
+++ b/docs/guides/mongodb/vault-integration/kmip-encryption/examples/mg.yaml
@@ -23,6 +23,6 @@ spec:
         storage: 1Gi
   storageType: Durable
   deletionPolicy: WipeOut
-  version: "percona-5.0.29"
+  version: "percona-8.0.17"
   configuration:
     secretName: mg-configuration

--- a/docs/guides/mongodb/vault-integration/kmip-encryption/index.md
+++ b/docs/guides/mongodb/vault-integration/kmip-encryption/index.md
@@ -172,7 +172,7 @@ spec:
         storage: 1Gi
   storageType: Durable
   deletionPolicy: WipeOut
-  version: "percona-5.0.29"
+  version: "percona-8.0.17"
   configuration:
     secretName: mg-configuration
 ```

--- a/docs/guides/mongodb/volume-expansion/replicaset.md
+++ b/docs/guides/mongodb/volume-expansion/replicaset.md
@@ -55,7 +55,7 @@ longhorn (default)   kubernetes.io/gce-pd   Delete          Immediate           
 
 We can see from the output the `longhorn` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We can use it.
 
-Now, we are going to deploy a `MongoDB` replicaSet database with version `4.4.26`.
+Now, we are going to deploy a `MongoDB` replicaSet database with version `8.0.17`.
 
 ### Deploy MongoDB
 
@@ -68,7 +68,7 @@ metadata:
   name: mg-replicaset
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   replicaSet: 
     name: "replicaset"
   replicas: 3

--- a/docs/guides/mongodb/volume-expansion/sharding.md
+++ b/docs/guides/mongodb/volume-expansion/sharding.md
@@ -55,7 +55,7 @@ longhorn (default)   kubernetes.io/gce-pd   Delete          Immediate           
 
 We can see from the output the `longhorn` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We can use it.
 
-Now, we are going to deploy a `MongoDB` standalone database with version `4.4.26`.
+Now, we are going to deploy a `MongoDB` standalone database with version `8.0.17`.
 
 ### Deploy MongoDB
 
@@ -68,7 +68,7 @@ metadata:
   name: mg-sharding
   namespace: demo
 spec:
-  version: 4.4.26
+  version: "8.0.17"
   shardTopology:
     configServer:
       replicas: 2

--- a/docs/guides/mongodb/volume-expansion/standalone.md
+++ b/docs/guides/mongodb/volume-expansion/standalone.md
@@ -54,7 +54,7 @@ longhorn (default)   kubernetes.io/gce-pd   Delete          Immediate           
 
 We can see from the output the `longhorn` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We can use it.
 
-Now, we are going to deploy a `MongoDB` standalone database with version `4.4.26`.
+Now, we are going to deploy a `MongoDB` standalone database with version `8.0.17`.
 
 #### Deploy MongoDB standalone
 
@@ -67,7 +67,7 @@ metadata:
   name: mg-standalone
   namespace: demo
 spec:
-  version: "4.4.26"
+  version: "8.0.17"
   storageType: Durable
   storage:
     storageClassName: "longhorn"


### PR DESCRIPTION
Bumps the **mongodb** example and guide manifests to the latest supported version (`8.0.17`) per the installer `active_versions.json`.

- General "deploy a mongodb" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.