### PR TITLE
Update mssqlserver docs examples to latest supported version (2025-cu0)

### DIFF
--- a/docs/examples/mssqlserver/ag-cluster/mssqlserver-ag-cluster.yaml
+++ b/docs/examples/mssqlserver/ag-cluster/mssqlserver-ag-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssqlserver-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/examples/mssqlserver/autoscaler/compute/mssqlserver-ag-cluster.yaml
+++ b/docs/examples/mssqlserver/autoscaler/compute/mssqlserver-ag-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssqlserver-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/examples/mssqlserver/autoscaler/storage/mssqlserver-ag-cluster.yaml
+++ b/docs/examples/mssqlserver/autoscaler/storage/mssqlserver-ag-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssqlserver-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/examples/mssqlserver/configuration/custom-config-podtemplate.yaml
+++ b/docs/examples/mssqlserver/configuration/custom-config-podtemplate.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-config-podtemplate
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   tls:
     issuerRef:

--- a/docs/examples/mssqlserver/configuration/mssql-custom-config.yaml
+++ b/docs/examples/mssqlserver/configuration/mssql-custom-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssql-custom-config
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   configuration:
     secretName: ms-custom-config
   replicas: 1

--- a/docs/examples/mssqlserver/dag-cluster/ag1.yaml
+++ b/docs/examples/mssqlserver/dag-cluster/ag1.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ag1
   namespace: demo
 spec:
-  version: "2022-cu16"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: DistributedAG

--- a/docs/examples/mssqlserver/dag-cluster/ag2.yaml
+++ b/docs/examples/mssqlserver/dag-cluster/ag2.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ag2
   namespace: demo
 spec:
-  version: "2022-cu16"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: DistributedAG

--- a/docs/examples/mssqlserver/initialization/initialize-ag-cluster.yaml
+++ b/docs/examples/mssqlserver/initialization/initialize-ag-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ms-ag-init
   namespace: demo
 spec:
-  version: "2022-cu19"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/examples/mssqlserver/initialization/initialize-standalone.yaml
+++ b/docs/examples/mssqlserver/initialization/initialize-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ms-init
   namespace: demo
 spec:
-  version: "2022-cu19"
+  version: "2025-cu0"
   storageType: Durable
   tls:
     issuerRef:

--- a/docs/examples/mssqlserver/monitoring/mssql-monitoring.yaml
+++ b/docs/examples/mssqlserver/monitoring/mssql-monitoring.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssql-monitoring
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   tls:
     issuerRef:

--- a/docs/examples/mssqlserver/quickstart/mssqlserver-quickstart.yaml
+++ b/docs/examples/mssqlserver/quickstart/mssqlserver-quickstart.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssqlserver-quickstart
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/examples/mssqlserver/reconfigure-tls/ms-standalone.yaml
+++ b/docs/examples/mssqlserver/reconfigure-tls/ms-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ms-standalone
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   tls:
     issuerRef:

--- a/docs/examples/mssqlserver/reconfigure-tls/mssql-ag-cluster.yaml
+++ b/docs/examples/mssqlserver/reconfigure-tls/mssql-ag-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssql-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/examples/mssqlserver/reconfigure/ms-standalone.yaml
+++ b/docs/examples/mssqlserver/reconfigure/ms-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ms-standalone
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   configuration:
     secretName: ms-custom-config
   replicas: 1

--- a/docs/examples/mssqlserver/reconfigure/mssqlserver-ag-cluster.yaml
+++ b/docs/examples/mssqlserver/reconfigure/mssqlserver-ag-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssqlserver-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   configuration:
     secretName: ms-custom-config
   replicas: 3

--- a/docs/examples/mssqlserver/restart/mssqlserver-ag-cluster.yaml
+++ b/docs/examples/mssqlserver/restart/mssqlserver-ag-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssqlserver-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/examples/mssqlserver/scaling/horizontal-scaling/mssql-ag-cluster.yaml
+++ b/docs/examples/mssqlserver/scaling/horizontal-scaling/mssql-ag-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssql-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 2
   topology:
     mode: AvailabilityGroup

--- a/docs/examples/mssqlserver/scaling/vertical-scaling/mssql-ag-cluster.yaml
+++ b/docs/examples/mssqlserver/scaling/vertical-scaling/mssql-ag-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssql-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/examples/mssqlserver/scaling/vertical-scaling/mssql-standalone.yaml
+++ b/docs/examples/mssqlserver/scaling/vertical-scaling/mssql-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssql-standalone
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/examples/mssqlserver/standalone/mssqlserver-standalone.yaml
+++ b/docs/examples/mssqlserver/standalone/mssqlserver-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssqlserver-standalone
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/examples/mssqlserver/tls/mssql-ag-tls.yaml
+++ b/docs/examples/mssqlserver/tls/mssql-ag-tls.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssql-ag-tls
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/examples/mssqlserver/tls/mssql-standalone-tls.yaml
+++ b/docs/examples/mssqlserver/tls/mssql-standalone-tls.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssql-standalone-tls
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/examples/mssqlserver/update-version/msops-update-ag-cluster.yaml
+++ b/docs/examples/mssqlserver/update-version/msops-update-ag-cluster.yaml
@@ -8,6 +8,6 @@ spec:
   databaseRef:
     name: mssql-ag-cluster
   updateVersion:
-    targetVersion: 2022-cu14
+    targetVersion: 2025-cu0
   timeout: 5m
   apply: IfReady

--- a/docs/examples/mssqlserver/update-version/msops-update-standalone.yaml
+++ b/docs/examples/mssqlserver/update-version/msops-update-standalone.yaml
@@ -8,6 +8,6 @@ spec:
   databaseRef:
     name: mssql-standalone
   updateVersion:
-    targetVersion: 2022-cu14
+    targetVersion: 2025-cu0
   timeout: 5m
   apply: IfReady

--- a/docs/examples/mssqlserver/update-version/mssql-ag-cluster.yaml
+++ b/docs/examples/mssqlserver/update-version/mssql-ag-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssql-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2022-cu22"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/examples/mssqlserver/update-version/mssql-standalone.yaml
+++ b/docs/examples/mssqlserver/update-version/mssql-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssql-standalone
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2022-cu22"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/examples/mssqlserver/volume-expansion/mssql-standalone.yaml
+++ b/docs/examples/mssqlserver/volume-expansion/mssql-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssql-standalone
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/examples/mssqlserver/volume-expansion/mssqlserver-ag-cluster.yaml
+++ b/docs/examples/mssqlserver/volume-expansion/mssqlserver-ag-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mssqlserver-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/autoscaler/compute/cluster.md
+++ b/docs/guides/mssqlserver/autoscaler/compute/cluster.md
@@ -79,7 +79,7 @@ $ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" 
 issuer.cert-manager.io/mssqlserver-ca-issuer created
 ```
 
-In this section, we are going to deploy a MSSQLServer Availability Group Cluster with version `2022-cu12`. Then, in the next section we will set up autoscaling for this database using `MSSQLServerAutoscaler` CRD. Below is the YAML of the `MSSQLServer` CR that we are going to create,
+In this section, we are going to deploy a MSSQLServer Availability Group Cluster with version `2025-cu0`. Then, in the next section we will set up autoscaling for this database using `MSSQLServerAutoscaler` CRD. Below is the YAML of the `MSSQLServer` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -88,7 +88,7 @@ metadata:
   name: mssqlserver-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/autoscaler/storage/cluster.md
+++ b/docs/guides/mssqlserver/autoscaler/storage/cluster.md
@@ -95,7 +95,7 @@ $ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" 
 issuer.cert-manager.io/mssqlserver-ca-issuer created
 ```
 
-Now, we are going to deploy a MSSQLServer cluster database with version `2022-cu12`. Then, in the next section we will set up autoscaling for this database using `MSSQLServerAutoscaler` CRD. Below is the YAML of the `MSSQLServer` CR that we are going to create,
+Now, we are going to deploy a MSSQLServer cluster database with version `2025-cu0`. Then, in the next section we will set up autoscaling for this database using `MSSQLServerAutoscaler` CRD. Below is the YAML of the `MSSQLServer` CR that we are going to create,
 
 > If you want to autoscale MSSQLServer `Standalone`, Just deploy a [standalone](/docs/guides/mssqlserver/clustering/standalone.md) sql server instance using KubeDB.
 
@@ -106,7 +106,7 @@ metadata:
   name: mssqlserver-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/backup/application-level/examples/sample-mssql.yaml
+++ b/docs/guides/mssqlserver/backup/application-level/examples/sample-mssql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mssqlserver
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/guides/mssqlserver/backup/application-level/index.md
+++ b/docs/guides/mssqlserver/backup/application-level/index.md
@@ -106,7 +106,7 @@ metadata:
   name: sample-mssqlserver
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/guides/mssqlserver/backup/auto-backup/examples/sample-mssqlserver-2.yaml
+++ b/docs/guides/mssqlserver/backup/auto-backup/examples/sample-mssqlserver-2.yaml
@@ -12,7 +12,7 @@ metadata:
     variables.kubestash.com/targetName: sample-mssqlserver-2
     variables.kubestash.com/targetedDatabase: agdb1
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/backup/auto-backup/examples/sample-mssqlserver.yaml
+++ b/docs/guides/mssqlserver/backup/auto-backup/examples/sample-mssqlserver.yaml
@@ -7,7 +7,7 @@ metadata:
     blueprint.kubestash.com/name: mssqlserver-default-backup-blueprint
     blueprint.kubestash.com/namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/guides/mssqlserver/backup/auto-backup/index.md
+++ b/docs/guides/mssqlserver/backup/auto-backup/index.md
@@ -248,7 +248,7 @@ metadata:
     blueprint.kubestash.com/name: mssqlserver-default-backup-blueprint
     blueprint.kubestash.com/namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:
@@ -615,7 +615,7 @@ metadata:
     variables.kubestash.com/targetName: sample-mssqlserver-2
     variables.kubestash.com/targetedDatabase: agdb1
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/backup/customization/common/sample-mssqlserver.yaml
+++ b/docs/guides/mssqlserver/backup/customization/common/sample-mssqlserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mssqlserver
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/backup/logical/examples/restored-mssqlserver.yaml
+++ b/docs/guides/mssqlserver/backup/logical/examples/restored-mssqlserver.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   init:
     waitForInitialRestore: true
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/guides/mssqlserver/backup/logical/examples/sample-mssqlserver.yaml
+++ b/docs/guides/mssqlserver/backup/logical/examples/sample-mssqlserver.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mssqlserver
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/guides/mssqlserver/backup/logical/index.md
+++ b/docs/guides/mssqlserver/backup/logical/index.md
@@ -104,7 +104,7 @@ metadata:
   name: sample-mssqlserver
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:
@@ -619,7 +619,7 @@ metadata:
 spec:
   init:
     waitForInitialRestore: true
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/guides/mssqlserver/clustering/ag_cluster.md
+++ b/docs/guides/mssqlserver/clustering/ag_cluster.md
@@ -141,7 +141,7 @@ metadata:
   name: mssqlserver-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup
@@ -182,7 +182,7 @@ mssqlserver.kubedb.com/mssqlserver-ag-cluster created
 
 Here,
 
-- `spec.version` is the name of the MSSQLServerVersion CR where the docker images are specified. In this tutorial, a MSSQLServer `2022-cu12` database is going to be created.
+- `spec.version` is the name of the MSSQLServerVersion CR where the docker images are specified. In this tutorial, a MSSQLServer `2025-cu0` database is going to be created.
 - `spec.replicas` denotes the number of replicas of the created availability group
 - `spec.topology` specifies the mode `AvailabilityGroup` and the list of names of the databases that we want in our availability group. 
    KubeDB operator will create and add these databases to the created availability group automatically. User don't have to create, configure or add the database to the availability group manually. User can update this list later as well. 

--- a/docs/guides/mssqlserver/clustering/arbiter.md
+++ b/docs/guides/mssqlserver/clustering/arbiter.md
@@ -97,7 +97,7 @@ metadata:
   name: ms-even-cluster
   namespace: demo
 spec:
-  version: "2022-cu16"
+  version: "2025-cu0"
   replicas: 2
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/clustering/dag_cluster.md
+++ b/docs/guides/mssqlserver/clustering/dag_cluster.md
@@ -144,7 +144,7 @@ metadata:
   name: ag1
   namespace: demo
 spec:
-  version: "2022-cu16"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: DistributedAG
@@ -237,7 +237,7 @@ mssqlserver.kubedb.com/ag1 created
 
 Here,
 
-- `spec.version` is the name of the MSSQLServerVersion CR where the docker images are specified. In this tutorial, a MSSQLServer `2022-cu16` database is going to be created.
+- `spec.version` is the name of the MSSQLServerVersion CR where the docker images are specified. In this tutorial, a MSSQLServer `2025-cu0` database is going to be created.
 - `spec.replicas` denotes the number of replicas of the local availability group
 - `spec.topology` specifies the mode `DistributedAG` and the list of names of the databases that we want in our availability group. 
    KubeDB operator will create and add these databases to the created availability group automatically. Users don't have to create, configure or add the database to the availability group manually. Users can update this list later as well. 
@@ -532,7 +532,7 @@ metadata:
   name: ag2
   namespace: demo
 spec:
-  version: "2022-cu16"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: DistributedAG

--- a/docs/guides/mssqlserver/clustering/standalone.md
+++ b/docs/guides/mssqlserver/clustering/standalone.md
@@ -143,7 +143,7 @@ metadata:
   name: mssqlserver-standalone
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:
@@ -178,7 +178,7 @@ mssqlserver.kubedb.com/mssqlserver-standalone created
 
 Here,
 
-- `spec.version` is the name of the MSSQLServerVersion CR where the docker images are specified. In this tutorial, a MSSQLServer `2022-cu12` database is going to be created.
+- `spec.version` is the name of the MSSQLServerVersion CR where the docker images are specified. In this tutorial, a MSSQLServer `2025-cu0` database is going to be created.
 - `spec.storageType` specifies the type of storage that will be used for MSSQLServer database. It can be `Durable` or `Ephemeral`. Default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create MSSQLServer database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.tls` specifies the TLS/SSL configurations. The KubeDB operator supports TLS management by using the [cert-manager](https://cert-manager.io/). Here `tls.clientTLS: false` means tls will not be enabled for SQL Server but the Issuer will be used to configure tls enabled wal-g proxy-server which is required for SQL Server backup operation.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the PetSet created by KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests.

--- a/docs/guides/mssqlserver/concepts/mssqlserver.md
+++ b/docs/guides/mssqlserver/concepts/mssqlserver.md
@@ -179,7 +179,7 @@ spec:
         labels:
           release: prometheus
         interval: 10s
-  version: 2022-cu12
+  version: 2025-cu0
   deletionPolicy: Halt
 ```
 

--- a/docs/guides/mssqlserver/configuration/using-config-file.md
+++ b/docs/guides/mssqlserver/configuration/using-config-file.md
@@ -143,7 +143,7 @@ metadata:
   name: mssql-custom-config
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   configuration:
     secretName: ms-custom-config
   replicas: 1

--- a/docs/guides/mssqlserver/configuration/using-podtemplate.md
+++ b/docs/guides/mssqlserver/configuration/using-podtemplate.md
@@ -123,7 +123,7 @@ metadata:
   name: custom-config-podtemplate
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   tls:
     issuerRef:

--- a/docs/guides/mssqlserver/failover/guide.md
+++ b/docs/guides/mssqlserver/failover/guide.md
@@ -133,7 +133,7 @@ metadata:
   name: mssqlserver-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/gitops/gitops.md
+++ b/docs/guides/mssqlserver/gitops/gitops.md
@@ -103,7 +103,7 @@ $ tree .
     └── ms-issuer.yaml
 1 directories, 1 files
 
-Now, we are going to deploy a `MSSQLServer` availability group with version `2022-cu12`.
+Now, we are going to deploy a `MSSQLServer` availability group with version `2022-cu22`.
 
 
 ### Create a Mssqlserver GitOps CR
@@ -114,7 +114,7 @@ metadata:
   name: mssql-gitops
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2022-cu22"
   replicas: 4
   topology:
     mode: AvailabilityGroup
@@ -217,7 +217,7 @@ metadata:
   name: mssql-gitops
   namespace: demo
 spec:
-  version: "2022-cu19"
+  version: "2022-cu22"
   replicas: 3
   topology:
     mode: AvailabilityGroup
@@ -301,7 +301,7 @@ metadata:
   name: mssql-gitops
   namespace: demo
 spec:
-  version: "2022-cu19"
+  version: "2022-cu22"
   replicas: 3
   topology:
     mode: AvailabilityGroup
@@ -386,7 +386,7 @@ metadata:
   name: mssql-gitops
   namespace: demo
 spec:
-  version: "2022-cu19"
+  version: "2022-cu22"
   replicas: 3
   topology:
     mode: AvailabilityGroup
@@ -490,7 +490,7 @@ metadata:
   name: mssql-gitops
   namespace: demo
 spec:
-  version: "2022-cu19"
+  version: "2022-cu22"
   replicas: 3
   topology:
     mode: AvailabilityGroup
@@ -592,7 +592,7 @@ metadata:
   name: mssql-gitops
   namespace: demo
 spec:
-  version: "2022-cu19"
+  version: "2022-cu22"
   replicas: 3
   topology:
     mode: AvailabilityGroup
@@ -663,7 +663,7 @@ mssqlserveropsrequest.ops.kubedb.com/mssql-gitops-volumeexpansion-rsa80j     Vol
 
 List Mssqlserver versions using `kubectl get msversion` and choose desired version that is compatible for upgrade from current version. Check the version constraints and ops request [here](/docs/guides/mssqlserver/update-version/overview.md).
 
-Let's choose `2022-cu22` in this example.
+Let's choose `2025-cu0` in this example.
 
 Update the `mssqlserver.yaml` with the following,
 ```yaml
@@ -673,7 +673,7 @@ metadata:
   name: mssql-gitops
   namespace: demo
 spec:
-  version: "2022-cu22"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup
@@ -719,7 +719,7 @@ spec:
   deletionPolicy: WipeOut
 ```
 
-Update the `version` field to `2022-cu22`. Commit the changes and push to your Git repository. Your repository is synced with `ArgoCD` and the `Mssqlserver` CR is updated in your cluster.
+Update the `version` field to `2025-cu0`. Commit the changes and push to your Git repository. Your repository is synced with `ArgoCD` and the `Mssqlserver` CR is updated in your cluster.
 
 Now, `gitops` operator will detect the version changes and create a `VersionUpdate` mssqlserverOpsRequest to update the `Mssqlserver` database version. List the resources created by `gitops` operator in the `demo` namespace.
 
@@ -766,7 +766,7 @@ metadata:
   name: mssql-gitops
   namespace: demo
 spec:
-  version: "2022-cu22"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup
@@ -863,7 +863,7 @@ metadata:
   name: mssql-gitops
   namespace: demo
 spec:
-  version: "2022-cu22"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/initialization/index.md
+++ b/docs/guides/mssqlserver/initialization/index.md
@@ -118,7 +118,7 @@ metadata:
   name: ms-init
   namespace: demo
 spec:
-  version: "2022-cu19"
+  version: "2025-cu0"
   storageType: Durable
   tls:
     issuerRef:
@@ -168,7 +168,7 @@ metadata:
   name: ms-ag-init
   namespace: demo
 spec:
-  version: "2022-cu19"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/monitoring/overview.md
+++ b/docs/guides/mssqlserver/monitoring/overview.md
@@ -53,7 +53,7 @@ metadata:
   name: mssql-monitoring
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   tls:
     issuerRef:

--- a/docs/guides/mssqlserver/monitoring/using-prometheus-operator.md
+++ b/docs/guides/mssqlserver/monitoring/using-prometheus-operator.md
@@ -214,7 +214,7 @@ metadata:
   name: mssql-monitoring
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   tls:
     issuerRef:

--- a/docs/guides/mssqlserver/pitr/archiver.md
+++ b/docs/guides/mssqlserver/pitr/archiver.md
@@ -254,7 +254,7 @@ spec:
     ref:
       name: sample-mssqlserverarchiver
       namespace: demo
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 2
   topology:
     mode: AvailabilityGroup
@@ -475,7 +475,7 @@ spec:
       fullDBRepository:
         name: sample-mssqlserver-ag-archiver
         namespace: demo
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 2
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/pitr/examples/restored-mssqlserver-ag.yaml
+++ b/docs/guides/mssqlserver/pitr/examples/restored-mssqlserver-ag.yaml
@@ -15,7 +15,7 @@ spec:
       fullDBRepository:
         name: sample-mssqlserver-ag-archiver
         namespace: demo
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 2
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/pitr/examples/sample-mssqlserver-ag.yaml
+++ b/docs/guides/mssqlserver/pitr/examples/sample-mssqlserver-ag.yaml
@@ -12,7 +12,7 @@ spec:
     ref:
       name: sample-mssqlserverarchiver
       namespace: demo
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 2
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/quickstart/quickstart.md
+++ b/docs/guides/mssqlserver/quickstart/quickstart.md
@@ -147,7 +147,7 @@ metadata:
   name: mssqlserver-quickstart
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:
@@ -182,7 +182,7 @@ mssqlserver.kubedb.com/mssqlserver-quickstart created
 
 Here,
 
-- `spec.version` is the name of the MSSQLServerVersion CR where the docker images are specified. In this tutorial, a MSSQLServer `2022-cu12` database is going to be created.
+- `spec.version` is the name of the MSSQLServerVersion CR where the docker images are specified. In this tutorial, a MSSQLServer `2025-cu0` database is going to be created.
 - `spec.storageType` specifies the type of storage that will be used for MSSQLServer database. It can be `Durable` or `Ephemeral`. Default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create MSSQLServer database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.tls` specifies the TLS/SSL configurations. The KubeDB operator supports TLS management by using the [cert-manager](https://cert-manager.io/). Here `tls.clientTLS: false` means tls will not be enabled for SQL Server but the Issuer will be used to configure tls enabled wal-g proxy-server which is required for SQL Server backup operation.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the PetSet created by KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests.

--- a/docs/guides/mssqlserver/reconfigure-tls/ag_cluster.md
+++ b/docs/guides/mssqlserver/reconfigure-tls/ag_cluster.md
@@ -86,7 +86,7 @@ metadata:
   name: mssql-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/reconfigure-tls/standalone.md
+++ b/docs/guides/mssqlserver/reconfigure-tls/standalone.md
@@ -85,7 +85,7 @@ metadata:
   name: ms-standalone
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   tls:
     issuerRef:

--- a/docs/guides/mssqlserver/reconfigure/ag_cluster.md
+++ b/docs/guides/mssqlserver/reconfigure/ag_cluster.md
@@ -43,7 +43,7 @@ Now, we are going to deploy a  `MSSQLServer` Availability Group using a supporte
 
 ### Prepare MSSQLServer Availability Group
 
-Now, we are going to deploy a `MSSQLServer` Availability Group with version `2022-cu12`.
+Now, we are going to deploy a `MSSQLServer` Availability Group with version `2025-cu0`.
 
 ### Deploy MSSQLServer Availability Group Cluster
 
@@ -106,7 +106,7 @@ metadata:
   name: mssqlserver-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   configuration:
     secretName: ms-custom-config
   replicas: 3

--- a/docs/guides/mssqlserver/reconfigure/standalone.md
+++ b/docs/guides/mssqlserver/reconfigure/standalone.md
@@ -42,7 +42,7 @@ Now, we are going to deploy a  `MSSQLServer` standalone using a supported versio
 
 ### Prepare MSSQLServer Standalone Database
 
-Now, we are going to deploy a `MSSQLServer` standalone database with version `2022-cu12`.
+Now, we are going to deploy a `MSSQLServer` standalone database with version `2025-cu0`.
 
 ### Deploy MSSQLServer standalone 
 
@@ -106,7 +106,7 @@ metadata:
   name: ms-standalone
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   configuration:
     secretName: ms-custom-config
   replicas: 1

--- a/docs/guides/mssqlserver/restart/restart.md
+++ b/docs/guides/mssqlserver/restart/restart.md
@@ -78,7 +78,7 @@ metadata:
   name: mssqlserver-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/rotate-auth/rotateauth.md
+++ b/docs/guides/mssqlserver/rotate-auth/rotateauth.md
@@ -90,7 +90,7 @@ metadata:
   name: mssqlserver-quickstart
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/guides/mssqlserver/scaling/horizontal-scaling/mssqlserver.md
+++ b/docs/guides/mssqlserver/scaling/horizontal-scaling/mssqlserver.md
@@ -57,7 +57,7 @@ NAME        VERSION   DB_IMAGE                                                DE
 2022-cu14   2022      mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04                176m
 ```
 
-The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MSSQLServer`. You can use any non-deprecated version. Here, we are going to create a MSSQLServer Cluster using `MSSQLServer` `2022-cu12`.
+The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MSSQLServer`. You can use any non-deprecated version. Here, we are going to create a MSSQLServer Cluster using `MSSQLServer` `2025-cu0`.
 
 **Deploy MSSQLServer Cluster:**
 
@@ -105,7 +105,7 @@ metadata:
   name: mssql-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 2
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/scaling/vertical-scaling/ag_cluster.md
+++ b/docs/guides/mssqlserver/scaling/vertical-scaling/ag_cluster.md
@@ -54,7 +54,7 @@ NAME        VERSION   DB_IMAGE                                                DE
 2022-cu14   2022      mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04                3d21h
 ```
 
-The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MSSQLServer`. You can use any non-deprecated version. Here, we are going to create a mssqlserver using non-deprecated `MSSQLServer` version `2022-cu12`.
+The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MSSQLServer`. You can use any non-deprecated version. Here, we are going to create a mssqlserver using non-deprecated `MSSQLServer` version `2025-cu0`.
 
 
 At first, we need to create an Issuer/ClusterIssuer which will be used to generate the certificate used for TLS configurations.
@@ -98,7 +98,7 @@ metadata:
   name: mssql-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/scaling/vertical-scaling/standalone.md
+++ b/docs/guides/mssqlserver/scaling/vertical-scaling/standalone.md
@@ -54,7 +54,7 @@ NAME        VERSION   DB_IMAGE                                                DE
 2022-cu14   2022      mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04                3d21h
 ```
 
-The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MSSQLServer`. You can use any non-deprecated version. Here, we are going to create a mssqlserver using non-deprecated `MSSQLServer` version `2022-cu12`.
+The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MSSQLServer`. You can use any non-deprecated version. Here, we are going to create a mssqlserver using non-deprecated `MSSQLServer` version `2025-cu0`.
 
 
 At first, we need to create an Issuer/ClusterIssuer which will be used to generate the certificate used for TLS configurations.
@@ -98,7 +98,7 @@ metadata:
   name: mssql-standalone
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/guides/mssqlserver/tls/ag_cluster.md
+++ b/docs/guides/mssqlserver/tls/ag_cluster.md
@@ -110,7 +110,7 @@ metadata:
   name: mssql-ag-tls
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/tls/standalone.md
+++ b/docs/guides/mssqlserver/tls/standalone.md
@@ -111,7 +111,7 @@ metadata:
   name: mssql-standalone-tls
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:

--- a/docs/guides/mssqlserver/update-version/ag_cluster.md
+++ b/docs/guides/mssqlserver/update-version/ag_cluster.md
@@ -75,7 +75,7 @@ $ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" 
 issuer.cert-manager.io/mssqlserver-ca-issuer created
 ```
 
-Now, we are going to deploy a `MSSQLServer` availability group with version `2022-cu12`.
+Now, we are going to deploy a `MSSQLServer` availability group with version `2022-cu22`.
 
 ### Deploy MSSQLServer AG Cluster
 
@@ -90,7 +90,7 @@ metadata:
   name: mssql-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2022-cu22"
   replicas: 3
   topology:
     mode: AvailabilityGroup
@@ -149,7 +149,7 @@ We are now ready to apply the `MSSQLServerOpsRequest` CR to update this database
 
 ### Update MSSQLServer Version
 
-Here, we are going to update `MSSQLServer` ag cluster from `2022-cu12` to `2022-cu14`.
+Here, we are going to update `MSSQLServer` ag cluster from `2022-cu22` to `2025-cu0`.
 
 #### Create MSSQLServerOpsRequest:
 
@@ -167,7 +167,7 @@ spec:
   databaseRef:
     name: mssql-ag-cluster
   updateVersion:
-    targetVersion: 2022-cu14
+    targetVersion: 2025-cu0
   timeout: 5m
   apply: IfReady
 ```
@@ -176,7 +176,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `mssql-ag-cluster` MSSQLServer database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `2022-cu14`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `2025-cu0`.
 - Have a look [here](/docs/guides/mssqlserver/concepts/opsrequest.md#spectimeout) on the respective sections to understand the `timeout` & `apply` fields.
 
 Let's create the `MSSQLServerOpsRequest` CR we have shown above,

--- a/docs/guides/mssqlserver/update-version/standalone.md
+++ b/docs/guides/mssqlserver/update-version/standalone.md
@@ -40,7 +40,7 @@ namespace/demo created
 
 ### Prepare MSSQLServer Standalone Database
 
-Now, we are going to deploy a `MSSQLServer` standalone database with version `2022-cu12`.
+Now, we are going to deploy a `MSSQLServer` standalone database with version `2022-cu22`.
 
 ### Deploy MSSQLServer Standalone
 
@@ -93,7 +93,7 @@ metadata:
   name: mssql-standalone
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2022-cu22"
   replicas: 1
   storageType: Durable
   tls:
@@ -140,7 +140,7 @@ We are now ready to apply the `MSSQLServerOpsRequest` CR to update this database
 
 ### Update MSSQLServer Version
 
-Here, we are going to update `MSSQLServer` standalone from `2022-cu12` to `2022-cu14`.
+Here, we are going to update `MSSQLServer` standalone from `2022-cu22` to `2025-cu0`.
 
 #### Create MSSQLServerOpsRequest:
 
@@ -157,7 +157,7 @@ spec:
   databaseRef:
     name: mssql-standalone
   updateVersion:
-    targetVersion: 2022-cu14
+    targetVersion: 2025-cu0
   timeout: 5m
   apply: IfReady
 ```
@@ -166,7 +166,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `mssql-standalone` database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `2022-cu14`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `2025-cu0`.
 - Have a look [here](/docs/guides/mssqlserver/concepts/opsrequest.md#spectimeout) on the respective sections to understand the  `timeout` & `apply` fields.
 
 

--- a/docs/guides/mssqlserver/volume-expansion/ag_cluster.md
+++ b/docs/guides/mssqlserver/volume-expansion/ag_cluster.md
@@ -57,7 +57,7 @@ standard-static        driver.standard.io      Delete          Immediate        
 We can see from the output that `standard (default)` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We will use this storage class. 
 
 
-Now, we are going to deploy a `MSSQLServer` in `AvailabilityGroup` Mode with version `2022-cu12`.
+Now, we are going to deploy a `MSSQLServer` in `AvailabilityGroup` Mode with version `2025-cu0`.
 
 ### Deploy MSSQLServer
 
@@ -104,7 +104,7 @@ metadata:
   name: mssqlserver-ag-cluster
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 3
   topology:
     mode: AvailabilityGroup

--- a/docs/guides/mssqlserver/volume-expansion/standalone.md
+++ b/docs/guides/mssqlserver/volume-expansion/standalone.md
@@ -57,7 +57,7 @@ standard-static        driver.standard.io      Delete          Immediate        
 We can see from the output that `standard (default)` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We will use this storage class.
 
 
-Now, we are going to deploy a `MSSQLServer` in `AvailabilityGroup` Mode with version `2022-cu12`.
+Now, we are going to deploy a `MSSQLServer` in `AvailabilityGroup` Mode with version `2025-cu0`.
 
 ### Deploy MSSQLServer Standalone
 
@@ -104,7 +104,7 @@ metadata:
   name: mssql-standalone
   namespace: demo
 spec:
-  version: "2022-cu12"
+  version: "2025-cu0"
   replicas: 1
   storageType: Durable
   tls:


### PR DESCRIPTION
Bumps the **mssqlserver** example and guide manifests to the latest supported version (`2025-cu0`) per the installer `active_versions.json`.

- General "deploy a mssqlserver" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.