### PR TITLE
Update mysql docs examples to latest supported version (9.6.0)

### DIFF
--- a/docs/examples/mysql/Initialization/demo-1.yaml
+++ b/docs/examples/mysql/Initialization/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-init-script
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/mysql/cli/mysql-demo.yaml
+++ b/docs/examples/mysql/cli/mysql-demo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-demo
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/mysql/clustering/demo-1.yaml
+++ b/docs/examples/mysql/clustering/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/configuration/mysql-custom.yaml
+++ b/docs/examples/mysql/configuration/mysql-custom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   configuration:
     secretName: my-custom-config
   storage:

--- a/docs/examples/mysql/configuration/mysql-misc-config.yaml
+++ b/docs/examples/mysql/configuration/mysql-misc-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-misc-config
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: "Durable"
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/custom-rbac/my-custom-db-two.yaml
+++ b/docs/examples/mysql/custom-rbac/my-custom-db-two.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minute-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/examples/mysql/custom-rbac/my-custom-db.yaml
+++ b/docs/examples/mysql/custom-rbac/my-custom-db.yaml
@@ -4,7 +4,7 @@ metadata:
   name: quick-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/examples/mysql/horizontalscaling/group_replication.yaml
+++ b/docs/examples/mysql/horizontalscaling/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/migration/sample-mysql.yaml
+++ b/docs/examples/mysql/migration/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/monitoring/builtin-prom-mysql.yaml
+++ b/docs/examples/mysql/monitoring/builtin-prom-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/monitoring/coreos-prom-mysql.yaml
+++ b/docs/examples/mysql/monitoring/coreos-prom-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coreos-prom-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/private-registry/demo-2.yaml
+++ b/docs/examples/mysql/private-registry/demo-2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-pvt-reg
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/mysql/quickstart/demo-2.yaml
+++ b/docs/examples/mysql/quickstart/demo-2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/restart/mysql.yaml
+++ b/docs/examples/mysql/restart/mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql
   namespace: demo
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/tls/tls-group.yaml
+++ b/docs/examples/mysql/tls/tls-group.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group-tls
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/tls/tls-standalone.yaml
+++ b/docs/examples/mysql/tls/tls-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone-tls
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/update-version/minorversion/group_replication.yaml
+++ b/docs/examples/mysql/update-version/minorversion/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.4.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/update-version/minorversion/standalone.yaml
+++ b/docs/examples/mysql/update-version/minorversion/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.4.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/mysql/verticalscaling/group_replication.yaml
+++ b/docs/examples/mysql/verticalscaling/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/examples/mysql/verticalscaling/standalone.yaml
+++ b/docs/examples/mysql/verticalscaling/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/autoscaler/compute/cluster/examples/sample-mysql.yaml
+++ b/docs/guides/mysql/autoscaler/compute/cluster/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/autoscaler/compute/cluster/index.md
+++ b/docs/guides/mysql/autoscaler/compute/cluster/index.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `MySQL` Cluster using a supported version by `Kub
 
 #### Deploy MySQL Cluster
 
-In this section, we are going to deploy a MySQL Cluster with version `8.4.8`. Then, in the next section we will set up autoscaling for this database using `MySQLAutoscaler` CRD. Below is the YAML of the `MySQL` CR that we are going to create,
+In this section, we are going to deploy a MySQL Cluster with version `9.6.0`. Then, in the next section we will set up autoscaling for this database using `MySQLAutoscaler` CRD. Below is the YAML of the `MySQL` CR that we are going to create,
 > If you want to autoscale MySQL `Standalone`, Just remove the `spec.Replicas` from the below yaml and rest of the steps are same.
 
 ```yaml
@@ -52,7 +52,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/autoscaler/storage/cluster/examples/sample-mysql.yaml
+++ b/docs/guides/mysql/autoscaler/storage/cluster/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mysql/autoscaler/storage/cluster/index.md
@@ -69,7 +69,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/backup/kubestash/application-level/examples/sample-mysql.yaml
+++ b/docs/guides/mysql/backup/kubestash/application-level/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/backup/kubestash/application-level/index.md
+++ b/docs/guides/mysql/backup/kubestash/application-level/index.md
@@ -65,7 +65,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication  
@@ -170,7 +170,7 @@ spec:
   secret:
     name: sample-mysql-auth
   type: kubedb.com/mysql
-  version: 8.2.0
+  version: 9.6.0
 ```
 
 KubeStash uses the `AppBinding` CR to connect with the target database. It requires the following two fields to set in AppBinding's `.spec` section.

--- a/docs/guides/mysql/backup/kubestash/auto-backup/examples/sample-mysql-2.yaml
+++ b/docs/guides/mysql/backup/kubestash/auto-backup/examples/sample-mysql-2.yaml
@@ -12,7 +12,7 @@ metadata:
     variables.kubestash.com/targetName: sample-mysql-2
     variables.kubestash.com/targetedDatabases: mysql
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/kubestash/auto-backup/examples/sample-mysql.yaml
+++ b/docs/guides/mysql/backup/kubestash/auto-backup/examples/sample-mysql.yaml
@@ -7,7 +7,7 @@ metadata:
     blueprint.kubestash.com/name: mysql-default-backup-blueprint
     blueprint.kubestash.com/namespace: demo
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/mysql/backup/kubestash/auto-backup/index.md
@@ -212,7 +212,7 @@ metadata:
     blueprint.kubestash.com/name: mysql-default-backup-blueprint
     blueprint.kubestash.com/namespace: demo
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:
@@ -515,7 +515,7 @@ metadata:
     variables.kubestash.com/targetName: sample-mysql-2
     variables.kubestash.com/targetedDatabases: mysql
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/kubestash/customization/examples/common/sample-mysql.yaml
+++ b/docs/guides/mysql/backup/kubestash/customization/examples/common/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/backup/kubestash/logical/examples/restored-mysql.yaml
+++ b/docs/guides/mysql/backup/kubestash/logical/examples/restored-mysql.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   init:
     waitForInitialRestore: true
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/backup/kubestash/logical/examples/sample-mysql.yaml
+++ b/docs/guides/mysql/backup/kubestash/logical/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/backup/kubestash/logical/index.md
+++ b/docs/guides/mysql/backup/kubestash/logical/index.md
@@ -65,7 +65,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication  
@@ -170,7 +170,7 @@ spec:
   secret:
     name: sample-mysql-auth
   type: kubedb.com/mysql
-  version: 8.2.0
+  version: 9.6.0
 ```
 
 KubeStash uses the `AppBinding` CR to connect with the target database. It requires the following two fields to set in AppBinding's `.spec` section.
@@ -574,7 +574,7 @@ metadata:
 spec:
   init:
     waitForInitialRestore: true
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/backup/stash/auto-backup/examples/sample-mysql-2.yaml
+++ b/docs/guides/mysql/backup/stash/auto-backup/examples/sample-mysql-2.yaml
@@ -7,7 +7,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mysql-backup-template
     stash.appscode.com/schedule: "*/3 * * * *"
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/stash/auto-backup/examples/sample-mysql-3.yaml
+++ b/docs/guides/mysql/backup/stash/auto-backup/examples/sample-mysql-3.yaml
@@ -7,7 +7,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mysql-backup-template
     params.stash.appscode.com/args: --databases mysql
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/stash/auto-backup/examples/sample-mysql.yaml
+++ b/docs/guides/mysql/backup/stash/auto-backup/examples/sample-mysql.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     stash.appscode.com/backup-blueprint: mysql-backup-template
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/stash/auto-backup/index.md
+++ b/docs/guides/mysql/backup/stash/auto-backup/index.md
@@ -135,7 +135,7 @@ metadata:
   annotations:
     stash.appscode.com/backup-blueprint: mysql-backup-template
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:
@@ -321,7 +321,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mysql-backup-template
     stash.appscode.com/schedule: "*/3 * * * *"
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:
@@ -510,7 +510,7 @@ metadata:
     stash.appscode.com/backup-blueprint: mysql-backup-template
     params.stash.appscode.com/args: --databases mysql
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/stash/customization/examples/sample-mysql.yaml
+++ b/docs/guides/mysql/backup/stash/customization/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/stash/standalone/examples/restored-mysql.yaml
+++ b/docs/guides/mysql/backup/stash/standalone/examples/restored-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restored-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/stash/standalone/examples/sample-mysql.yaml
+++ b/docs/guides/mysql/backup/stash/standalone/examples/sample-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/backup/stash/standalone/index.md
+++ b/docs/guides/mysql/backup/stash/standalone/index.md
@@ -57,7 +57,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:
@@ -165,7 +165,7 @@ spec:
   secret:
     name: sample-mysql-auth
   type: kubedb.com/mysql
-  version: 8.4.8
+  version: 9.6.0
 ```
 
 Stash uses the AppBinding CRD to connect with the target database. It requires the following two fields to set in AppBinding's `.spec` section.
@@ -445,7 +445,7 @@ metadata:
   name: restored-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   storageType: Durable
   storage:

--- a/docs/guides/mysql/cli/index.md
+++ b/docs/guides/mysql/cli/index.md
@@ -112,7 +112,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   deletionPolicy: Delete
-  version: 8.4.8
+  version: 9.6.0
 ```
 
 To get JSON of an object, use `--output=json` flag.

--- a/docs/guides/mysql/cli/yamls/mysql-demo.yaml
+++ b/docs/guides/mysql/cli/yamls/mysql-demo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-demo
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mysql/clients/index.md
+++ b/docs/guides/mysql/clients/index.md
@@ -48,7 +48,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/clients/yamls/group-replication.yaml
+++ b/docs/guides/mysql/clients/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/clustering/group-replication/index.md
+++ b/docs/guides/mysql/clustering/group-replication/index.md
@@ -48,7 +48,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -269,7 +269,7 @@ spec:
     group:
       name: dc002fc3-c412-4d18-b1d4-66c1fbfbbc9b
     mode: GroupReplication
-  version: 8.4.8
+  version: 9.6.0
 status:
   phase: Ready
 ```

--- a/docs/guides/mysql/clustering/group-replication/yamls/group-replication.yaml
+++ b/docs/guides/mysql/clustering/group-replication/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/clustering/overview/images/yamls/group-replication.yaml
+++ b/docs/guides/mysql/clustering/overview/images/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/clustering/remote-replica/index.md
+++ b/docs/guides/mysql/clustering/remote-replica/index.md
@@ -115,7 +115,7 @@ spec:
   authSecret:
     kind: Secret
     name: mysql-singapore-auth
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -299,7 +299,7 @@ spec:
     periodSeconds: 10
     timeoutSeconds: 10
     disableWriteCheck: true
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   topology:
     mode: RemoteReplica

--- a/docs/guides/mysql/clustering/remote-replica/yamls/mysql-london.yaml
+++ b/docs/guides/mysql/clustering/remote-replica/yamls/mysql-london.yaml
@@ -12,7 +12,7 @@ spec:
     periodSeconds: 10
     timeoutSeconds: 10
     disableWriteCheck: true
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   topology:
     mode: RemoteReplica

--- a/docs/guides/mysql/clustering/remote-replica/yamls/mysql-singapore.yaml
+++ b/docs/guides/mysql/clustering/remote-replica/yamls/mysql-singapore.yaml
@@ -7,7 +7,7 @@ spec:
   authSecret:
     kind: Secret
     name: mysql-singapore-auth
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/clustering/semi-sync/index.md
+++ b/docs/guides/mysql/clustering/semi-sync/index.md
@@ -48,7 +48,7 @@ metadata:
   name: semi-sync-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync
@@ -309,7 +309,7 @@ spec:
       sourceTimeout: 23h0m0s
       sourceWaitForReplicaCount: 1
   useAddressType: DNS
-  version: 8.4.8
+  version: 9.6.0
 status:
   conditions:
     ...

--- a/docs/guides/mysql/clustering/semi-sync/yamls/semi-sync.yaml
+++ b/docs/guides/mysql/clustering/semi-sync/yamls/semi-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: semi-sync-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync

--- a/docs/guides/mysql/concepts/appbinding/index.md
+++ b/docs/guides/mysql/concepts/appbinding/index.md
@@ -76,7 +76,7 @@ spec:
   secret:
     name: mysql-group-auth
   type: kubedb.com/mysql
-  version: 8.4.8
+  version: 9.6.0
 
 ```
 

--- a/docs/guides/mysql/concepts/database/index.md
+++ b/docs/guides/mysql/concepts/database/index.md
@@ -29,7 +29,7 @@ metadata:
   name: m1
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   topology:
     mode: GroupReplication
   authSecret:
@@ -216,7 +216,7 @@ metadata:
   name: m1
   namespace: demo
 spec:
-  version: 8.4.8
+  version: 9.6.0
   init:
     script:
       configMap:

--- a/docs/guides/mysql/configuration/config-file/index.md
+++ b/docs/guides/mysql/configuration/config-file/index.md
@@ -104,7 +104,7 @@ metadata:
   name: custom-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   configuration:
     secretName: my-configuration
   storage:

--- a/docs/guides/mysql/configuration/config-file/yamls/mysql-custom.yaml
+++ b/docs/guides/mysql/configuration/config-file/yamls/mysql-custom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   configuration:
     secretName: my-configuration
   storage:

--- a/docs/guides/mysql/configuration/podtemplating/index.md
+++ b/docs/guides/mysql/configuration/podtemplating/index.md
@@ -59,7 +59,7 @@ Read about the fields in details in [PodTemplate concept](/docs/guides/mysql/con
 
 Below is the YAML for the MySQL created in this example. Here, [`spec.podTemplate.spec.env`](/docs/guides/mysql/concepts/database/index.md#specpodtemplatespecenv) specifies environment variables and [`spec.podTemplate.spec.args`](/docs/guides/mysql/concepts/database/index.md#specpodtemplatespecargs) provides extra arguments for [MySQL Docker Image](https://hub.docker.com/_/mysql/).
 
-In this tutorial, an initial database `myDB` will be created by providing `env` `MYSQL_DATABASE` while the server character set will be set to `utf8mb4` by adding extra `args`. Note that, `character-set-server` in `MySQL 8.4.8` is `latin1`.
+In this tutorial, an initial database `myDB` will be created by providing `env` `MYSQL_DATABASE` while the server character set will be set to `utf8mb4` by adding extra `args`. Note that, `character-set-server` in `MySQL 9.6.0` is `latin1`.
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -68,7 +68,7 @@ metadata:
   name: mysql-misc-config
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: "Durable"
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/configuration/podtemplating/yamls/mysql-misc-config.yaml
+++ b/docs/guides/mysql/configuration/podtemplating/yamls/mysql-misc-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-misc-config
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: "Durable"
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/custom-rbac/index.md
+++ b/docs/guides/mysql/custom-rbac/index.md
@@ -142,7 +142,7 @@ metadata:
   name: quick-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   podTemplate:
     spec:
@@ -204,7 +204,7 @@ metadata:
   name: minute-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/mysql/custom-rbac/yamls/my-custom-db-two.yaml
+++ b/docs/guides/mysql/custom-rbac/yamls/my-custom-db-two.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minute-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/mysql/custom-rbac/yamls/my-custom-db.yaml
+++ b/docs/guides/mysql/custom-rbac/yamls/my-custom-db.yaml
@@ -4,7 +4,7 @@ metadata:
   name: quick-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/mysql/failure-and-disaster-recovery/overview.md
+++ b/docs/guides/mysql/failure-and-disaster-recovery/overview.md
@@ -70,7 +70,7 @@ metadata:
   name: ha-mysql
   namespace: demo
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/initialization/gitsync.md
+++ b/docs/guides/mysql/initialization/gitsync.md
@@ -52,7 +52,7 @@ spec:
           - --root=/git
           # terminate after one successful sync
           - --one-time
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     accessModes:
       - ReadWriteOnce
@@ -198,7 +198,7 @@ spec:
         # run as git sync user 
         securityContext:
           runAsUser: 65533
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     accessModes:
       - ReadWriteOnce
@@ -252,7 +252,7 @@ spec:
         # run as git sync user 
         securityContext:
           runAsUser: 65533
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/mysql/initialization/using_script.md
+++ b/docs/guides/mysql/initialization/using_script.md
@@ -112,7 +112,7 @@ metadata:
   name: mysql-init-script
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   topology:
     mode: GroupReplication
   replicas: 3
@@ -182,7 +182,7 @@ metadata:
   name: mysql-init-script
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync
@@ -220,7 +220,7 @@ metadata:
   name: mysql-init-script
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     storageClassName: "standard"
     accessModes:
@@ -445,7 +445,7 @@ spec:
   storageType: Durable
   deletionPolicy: Delete
   useAddressType: DNS
-  version: 8.4.8
+  version: 9.6.0
 status:
   conditions:
     ...

--- a/docs/guides/mysql/initialization/yamls/git-sync-pat.yaml
+++ b/docs/guides/mysql/initialization/yamls/git-sync-pat.yaml
@@ -21,7 +21,7 @@ spec:
         # run as git sync user
         securityContext:
           runAsUser: 65533
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/mysql/initialization/yamls/git-sync-public.yaml
+++ b/docs/guides/mysql/initialization/yamls/git-sync-public.yaml
@@ -14,7 +14,7 @@ spec:
           - --root=/git
           # terminate after one successful sync
           - --one-time
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/mysql/initialization/yamls/git-sync-ssh.yaml
+++ b/docs/guides/mysql/initialization/yamls/git-sync-ssh.yaml
@@ -20,7 +20,7 @@ spec:
         # run as git sync user
         securityContext:
           runAsUser: 65533
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/mysql/initialization/yamls/initialize-gr.yaml
+++ b/docs/guides/mysql/initialization/yamls/initialize-gr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-init-script
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   topology:
     mode: GroupReplication
   replicas: 3

--- a/docs/guides/mysql/initialization/yamls/initialize-semi-sync.yaml
+++ b/docs/guides/mysql/initialization/yamls/initialize-semi-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-init-script
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync

--- a/docs/guides/mysql/initialization/yamls/initialize-standalone.yaml
+++ b/docs/guides/mysql/initialization/yamls/initialize-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-init-script
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mysql/migration/storageMigration.md
+++ b/docs/guides/mysql/migration/storageMigration.md
@@ -61,7 +61,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/monitoring/builtin-prometheus/index.md
+++ b/docs/guides/mysql/monitoring/builtin-prometheus/index.md
@@ -49,7 +49,7 @@ metadata:
   name: builtin-prom-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/monitoring/builtin-prometheus/yamls/builtin-prom-mysql.yaml
+++ b/docs/guides/mysql/monitoring/builtin-prometheus/yamls/builtin-prom-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/monitoring/overview/index.md
+++ b/docs/guides/mysql/monitoring/overview/index.md
@@ -53,7 +53,7 @@ metadata:
   name: prom-operator-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/monitoring/prometheus-operator/index.md
+++ b/docs/guides/mysql/monitoring/prometheus-operator/index.md
@@ -111,7 +111,7 @@ metadata:
   name: coreos-prom-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/monitoring/prometheus-operator/yamls/prom-operator-mysql.yaml
+++ b/docs/guides/mysql/monitoring/prometheus-operator/yamls/prom-operator-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: prom-operator-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/pitr/restic/archiver.md
+++ b/docs/guides/mysql/pitr/restic/archiver.md
@@ -190,7 +190,7 @@ metadata:
   labels:
     archiver: "true"
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -384,7 +384,7 @@ spec:
         name: mysql-full
         namespace: demo
       recoveryTimestamp: "2024-12-02T06:38:42Z"
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/pitr/restic/yamls/mysql-restore.yaml
+++ b/docs/guides/mysql/pitr/restic/yamls/mysql-restore.yaml
@@ -14,7 +14,7 @@ spec:
         name: mysql-full
         namespace: demo
       recoveryTimestamp: "2024-12-02T06:38:42Z"
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/pitr/restic/yamls/mysql.yaml
+++ b/docs/guides/mysql/pitr/restic/yamls/mysql.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     archiver: "true"
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/pitr/volumesnapshot/archiver.md
+++ b/docs/guides/mysql/pitr/volumesnapshot/archiver.md
@@ -221,7 +221,7 @@ metadata:
   labels:
     archiver: "true"
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -422,7 +422,7 @@ spec:
         name: mysql-full
         namespace: demo
       recoveryTimestamp: "2024-12-03T06:09:34Z"
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/pitr/volumesnapshot/yamls/mysql-restore.yaml
+++ b/docs/guides/mysql/pitr/volumesnapshot/yamls/mysql-restore.yaml
@@ -14,7 +14,7 @@ spec:
         name: mysql-full
         namespace: demo
       recoveryTimestamp: "2024-12-03T06:09:34Z"
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/pitr/volumesnapshot/yamls/mysql.yaml
+++ b/docs/guides/mysql/pitr/volumesnapshot/yamls/mysql.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     archiver: "true"
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/private-registry/index.md
+++ b/docs/guides/mysql/private-registry/index.md
@@ -123,7 +123,7 @@ metadata:
   name: mysql-pvt-reg
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mysql/private-registry/yamls/quickstart.yaml
+++ b/docs/guides/mysql/private-registry/yamls/quickstart.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/private-registry/yamls/standalone.yaml
+++ b/docs/guides/mysql/private-registry/yamls/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-pvt-reg
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/mysql/quickstart/index.md
+++ b/docs/guides/mysql/quickstart/index.md
@@ -75,7 +75,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -99,7 +99,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -307,7 +307,7 @@ spec:
   storageType: Durable
   deletionPolicy: Delete
   useAddressType: DNS
-  version: 8.4.8
+  version: 9.6.0
 status:
   conditions:
   - lastTransitionTime: "2022-06-03T06:50:40Z"

--- a/docs/guides/mysql/quickstart/yamls/quickstart-v1.yaml
+++ b/docs/guides/mysql/quickstart/yamls/quickstart-v1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/quickstart/yamls/quickstart-v1alpha2.yaml
+++ b/docs/guides/mysql/quickstart/yamls/quickstart-v1alpha2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/reconfigure-tls/reconfigure/index.md
+++ b/docs/guides/mysql/reconfigure-tls/reconfigure/index.md
@@ -71,7 +71,7 @@ metadata:
   name: mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   topology:
     mode: GroupReplication
   storageType: Durable
@@ -138,7 +138,7 @@ metadata:
   name: semi-sync-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync
@@ -176,7 +176,7 @@ metadata:
   name: mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/reconfigure-tls/reconfigure/yamls/group-replication.yaml
+++ b/docs/guides/mysql/reconfigure-tls/reconfigure/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   topology:
     mode: GroupReplication
   storageType: Durable

--- a/docs/guides/mysql/reconfigure-tls/reconfigure/yamls/mysql.yaml
+++ b/docs/guides/mysql/reconfigure-tls/reconfigure/yamls/mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/reconfigure-tls/reconfigure/yamls/semi-sync.yaml
+++ b/docs/guides/mysql/reconfigure-tls/reconfigure/yamls/semi-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync

--- a/docs/guides/mysql/reconfigure-tls/reconfigure/yamls/standalone.yaml
+++ b/docs/guides/mysql/reconfigure-tls/reconfigure/yamls/standalone.yaml
@@ -5,7 +5,7 @@ metadata:
   name: mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/reconfigure/reconfigure-steps/index.md
+++ b/docs/guides/mysql/reconfigure/reconfigure-steps/index.md
@@ -38,7 +38,7 @@ Now, we are going to deploy a  `MySQL` Cluster using a supported version by `Kub
 
 ### Prepare MySQL Cluster
 
-Now, we are going to deploy a `MySQL` Cluster database with version `8.4.8`.
+Now, we are going to deploy a `MySQL` Cluster database with version `9.6.0`.
 
 ### Deploy MySQL
 
@@ -91,7 +91,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   topology:
     mode: GroupReplication
   replicas: 3
@@ -164,7 +164,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   topology:
     mode: SemiSync
     semiSync:
@@ -204,7 +204,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   configuration:
     secretName: my-configuration
   storageType: Durable

--- a/docs/guides/mysql/reconfigure/reconfigure-steps/yamls/group-replication.yaml
+++ b/docs/guides/mysql/reconfigure/reconfigure-steps/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   topology:
     mode: GroupReplication
   replicas: 3

--- a/docs/guides/mysql/reconfigure/reconfigure-steps/yamls/semi-sync.yaml
+++ b/docs/guides/mysql/reconfigure/reconfigure-steps/yamls/semi-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   topology:
     mode: SemiSync
     semiSync:

--- a/docs/guides/mysql/reconfigure/reconfigure-steps/yamls/stand-alone.yaml
+++ b/docs/guides/mysql/reconfigure/reconfigure-steps/yamls/stand-alone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   configuration:
     secretName: my-configuration
   storageType: Durable

--- a/docs/guides/mysql/replication-mode-transform/replication-mode-transform/examples/mysql-london.yaml
+++ b/docs/guides/mysql/replication-mode-transform/replication-mode-transform/examples/mysql-london.yaml
@@ -12,7 +12,7 @@ spec:
     periodSeconds: 10
     timeoutSeconds: 10
     disableWriteCheck: true
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   topology:
     mode: RemoteReplica

--- a/docs/guides/mysql/replication-mode-transform/replication-mode-transform/examples/mysql-singapore.yaml
+++ b/docs/guides/mysql/replication-mode-transform/replication-mode-transform/examples/mysql-singapore.yaml
@@ -7,7 +7,7 @@ spec:
   authSecret:
     kind: Secret
     name: mysql-singapore-auth
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/replication-mode-transform/replication-mode-transform/index.md
+++ b/docs/guides/mysql/replication-mode-transform/replication-mode-transform/index.md
@@ -117,7 +117,7 @@ spec:
   authSecret:
     kind: Secret
     name: mysql-singapore-auth
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -302,7 +302,7 @@ spec:
     periodSeconds: 10
     timeoutSeconds: 10
     disableWriteCheck: true
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 1
   topology:
     mode: RemoteReplica

--- a/docs/guides/mysql/restart/restart.md
+++ b/docs/guides/mysql/restart/restart.md
@@ -42,7 +42,7 @@ metadata:
   name: mysql
   namespace: demo
 spec:
-  version: "8.2.0"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/rotate-auth/guide.md
+++ b/docs/guides/mysql/rotate-auth/guide.md
@@ -78,7 +78,7 @@ metadata:
   name: mysql-quickstart
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/scaling/horizontal-scaling/cluster/index.md
+++ b/docs/guides/mysql/scaling/horizontal-scaling/cluster/index.md
@@ -68,7 +68,7 @@ NAME            VERSION   DISTRIBUTION   DB_IMAGE                               
 ```
 
 
-The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a MySQL Group Replication using `MySQL`  `8.4.8`.
+The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a MySQL Group Replication using `MySQL`  `9.6.0`.
 
 **Deploy MySQL Cluster:**
 
@@ -103,7 +103,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -184,7 +184,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync

--- a/docs/guides/mysql/scaling/horizontal-scaling/cluster/yamls/group-replication.yaml
+++ b/docs/guides/mysql/scaling/horizontal-scaling/cluster/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/scaling/horizontal-scaling/cluster/yamls/semi-sync.yaml
+++ b/docs/guides/mysql/scaling/horizontal-scaling/cluster/yamls/semi-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync

--- a/docs/guides/mysql/scaling/vertical-scaling/cluster/index.md
+++ b/docs/guides/mysql/scaling/vertical-scaling/cluster/index.md
@@ -67,7 +67,7 @@ NAME            VERSION   DISTRIBUTION   DB_IMAGE                               
 9.6.0           9.6.0     Official       ghcr.io/appscode-images/mysql:9.6.0-oracle                 45h
 ```
 
-The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a MySQL Group Replication using non-deprecated `MySQL` version `8.4.8`.
+The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a MySQL Group Replication using non-deprecated `MySQL` version `9.6.0`.
 
 **Deploy MySQL Cluster:**
 
@@ -99,7 +99,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -172,7 +172,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync

--- a/docs/guides/mysql/scaling/vertical-scaling/cluster/yamls/group-replication.yaml
+++ b/docs/guides/mysql/scaling/vertical-scaling/cluster/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/scaling/vertical-scaling/cluster/yamls/semi-sync.yaml
+++ b/docs/guides/mysql/scaling/vertical-scaling/cluster/yamls/semi-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync

--- a/docs/guides/mysql/scaling/vertical-scaling/standalone/index.md
+++ b/docs/guides/mysql/scaling/vertical-scaling/standalone/index.md
@@ -67,7 +67,7 @@ NAME            VERSION   DISTRIBUTION   DB_IMAGE                               
 9.6.0           9.6.0     Official       ghcr.io/appscode-images/mysql:9.6.0-oracle                 45h
 ```
 
-The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a standalone using non-deprecated `MySQL`  version `8.4.8`.
+The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `MySQL`. You can use any non-deprecated version. Here, we are going to create a standalone using non-deprecated `MySQL`  version `9.6.0`.
 
 **Deploy MySQL Standalone:**
 
@@ -80,7 +80,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/scaling/vertical-scaling/standalone/yamls/standalone.yaml
+++ b/docs/guides/mysql/scaling/vertical-scaling/standalone/yamls/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/schema-manager/deploy-mysqldatabase/index.md
+++ b/docs/guides/mysql/schema-manager/deploy-mysqldatabase/index.md
@@ -53,7 +53,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/schema-manager/deploy-mysqldatabase/yamls/mysql-server.yaml
+++ b/docs/guides/mysql/schema-manager/deploy-mysqldatabase/yamls/mysql-server.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/schema-manager/initializing-with-script/index.md
+++ b/docs/guides/mysql/schema-manager/initializing-with-script/index.md
@@ -53,7 +53,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/schema-manager/initializing-with-script/yamls/mysql-server.yaml
+++ b/docs/guides/mysql/schema-manager/initializing-with-script/yamls/mysql-server.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-server
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/tls/configure/index.md
+++ b/docs/guides/mysql/tls/configure/index.md
@@ -110,7 +110,7 @@ metadata:
   name: some-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -213,7 +213,7 @@ metadata:
   name: some-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync
@@ -268,7 +268,7 @@ metadata:
   name: some-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/tls/configure/yamls/group-replication.yaml
+++ b/docs/guides/mysql/tls/configure/yamls/group-replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: some-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/tls/configure/yamls/semi-sync.yaml
+++ b/docs/guides/mysql/tls/configure/yamls/semi-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: some-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync

--- a/docs/guides/mysql/tls/configure/yamls/standalone.yaml
+++ b/docs/guides/mysql/tls/configure/yamls/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: some-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/update-version/majorversion/group-replication/index.md
+++ b/docs/guides/mysql/update-version/majorversion/group-replication/index.md
@@ -145,7 +145,7 @@ spec:
   version: 8.4.8
 ```
 
-The above `spec.updateConstraints.denylist` of `8.4.8` is showing that updating below version of `8.4.8` is not possible for both group replication and standalone. That means, it is possible to update any version above `8.4.8`. Here, we are going to create a `MySQL` Group Replication using MySQL  `8.4.8`. Then we are going to update this version to `8.4.8`.
+The above `spec.updateConstraints.denylist` of `8.4.8` is showing that updating below version of `8.4.8` is not possible for both group replication and standalone. That means, it is possible to update any version above `8.4.8`. Here, we are going to create a `MySQL` Group Replication using MySQL  `8.4.8`. Then we are going to update this version to `9.6.0`.
 
 **Deploy MySQL Group Replication:**
 
@@ -244,7 +244,7 @@ We are ready to apply updating on this `MySQL` group replication.
 
 #### UpdateVesion
 
-Here, we are going to update the `MySQL` group replication from `8.4.8` to `8.4.8`.
+Here, we are going to update the `MySQL` group replication from `8.4.8` to `9.6.0`.
 
 **Create MySQLOpsRequest:**
 
@@ -261,14 +261,14 @@ spec:
   databaseRef:
     name: my-group
   updateVersion:
-    targetVersion: "8.0.36"
+    targetVersion: "9.6.0"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies expected version `8.4.8` after updating.
+- `spec.updateVersion.targetVersion` specifies expected version `9.6.0` after updating.
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 

--- a/docs/guides/mysql/update-version/majorversion/group-replication/yamls/upgrade_major_version_group.yaml
+++ b/docs/guides/mysql/update-version/majorversion/group-replication/yamls/upgrade_major_version_group.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: my-group
   updateVersion:
-    targetVersion: "8.0.36"
+    targetVersion: "9.6.0"

--- a/docs/guides/mysql/update-version/majorversion/standalone/index.md
+++ b/docs/guides/mysql/update-version/majorversion/standalone/index.md
@@ -145,7 +145,7 @@ spec:
   version: 8.4.8
 ```
 
-The above `spec.updateConstraints.denylist` is showing that updating below version of `8.4.8` is not possible for both standalone and group replication. That means, it is possible to update any version above `8.4.8`. Here, we are going to create a `MySQL` standalone using MySQL  `8.4.8`. Then we are going to update this version to `8.4.8`.
+The above `spec.updateConstraints.denylist` is showing that updating below version of `8.4.8` is not possible for both standalone and group replication. That means, it is possible to update any version above `8.4.8`. Here, we are going to create a `MySQL` standalone using MySQL  `8.4.8`. Then we are going to update this version to `9.6.0`.
 
 **Deploy MySQL standalone:**
 
@@ -216,7 +216,7 @@ We are ready to apply updating on this `MySQL` standalone.
 
 #### UpdateVersion
 
-Here, we are going to update `MySQL` standalone from `8.4.8` to `8.4.8`.
+Here, we are going to update `MySQL` standalone from `8.4.8` to `9.6.0`.
 
 **Create MySQLOpsRequest:**
 
@@ -233,14 +233,14 @@ spec:
     name: my-standalone
   type: UpdateVersion
   updateVersion:
-    targetVersion: "8.0.36"
+    targetVersion: "9.6.0"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies expected version `8.4.8` after updating.
+- `spec.updateVersion.targetVersion` specifies expected version `9.6.0` after updating.
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 

--- a/docs/guides/mysql/update-version/majorversion/standalone/yamls/upgrade_major_version_standalone.yaml
+++ b/docs/guides/mysql/update-version/majorversion/standalone/yamls/upgrade_major_version_standalone.yaml
@@ -8,4 +8,4 @@ spec:
     name: my-standalone
   type: UpdateVersion
   updateVersion:
-    targetVersion: "8.4.8"
+    targetVersion: "9.6.0"

--- a/docs/guides/mysql/update-version/minorversion/group-replication/index.md
+++ b/docs/guides/mysql/update-version/minorversion/group-replication/index.md
@@ -145,7 +145,7 @@ spec:
   version: 8.4.8
 ```
 
-The above `spec.updateConstraints.denylist` of `8.4.8` is showing that updating below version of `8.4.8` is not possible for both group replication and standalone. That means, it is possible to update any version above `8.4.8`. Here, we are going to create a `MySQL` Group Replication using MySQL  `8.4.8`. Then we are going to update this version to `8.4.8`.
+The above `spec.updateConstraints.denylist` of `8.4.8` is showing that updating below version of `8.4.8` is not possible for both group replication and standalone. That means, it is possible to update any version above `8.4.8`. Here, we are going to create a `MySQL` Group Replication using MySQL  `9.4.0`. Then we are going to update this version to `9.6.0`.
 
 **Deploy MySQL Group Replication:**
 
@@ -158,7 +158,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.36"
+  version: "9.4.0"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -247,7 +247,7 @@ We are ready to apply updating on this `MySQL` group replication.
 
 #### UpdateVersion
 
-Here, we are going to update the `MySQL` group replication from `8.4.8` to `8.4.8`.
+Here, we are going to update the `MySQL` group replication from `9.4.0` to `9.6.0`.
 
 **Create MySQLOpsRequest:**
 
@@ -264,14 +264,14 @@ spec:
   databaseRef:
     name: my-group
   updateVersion:
-    targetVersion: "8.4.8"
+    targetVersion: "9.6.0"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies expected version `8.4.8` after updating.
+- `spec.updateVersion.targetVersion` specifies expected version `9.6.0` after updating.
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 

--- a/docs/guides/mysql/update-version/minorversion/group-replication/yamls/group_replication.yaml
+++ b/docs/guides/mysql/update-version/minorversion/group-replication/yamls/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-group
   namespace: demo
 spec:
-  version: "8.0.36"
+  version: "9.4.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/update-version/minorversion/group-replication/yamls/upgrade_minor_version_group.yaml
+++ b/docs/guides/mysql/update-version/minorversion/group-replication/yamls/upgrade_minor_version_group.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: my-group
   updateVersion:
-    targetVersion: "8.4.8"
+    targetVersion: "9.6.0"

--- a/docs/guides/mysql/update-version/minorversion/standalone/index.md
+++ b/docs/guides/mysql/update-version/minorversion/standalone/index.md
@@ -145,7 +145,7 @@ spec:
   version: 8.4.8
 ```
 
-The above `spec.updateConstraints.denylist` is showing that updating below version of `8.4.8` is not possible for both standalone and group replication. That means, it is possible to update any version above `8.4.8`. Here, we are going to create a `MySQL` standalone using MySQL  `8.4.8`. Then we are going to update this version to `8.4.8`.
+The above `spec.updateConstraints.denylist` is showing that updating below version of `8.4.8` is not possible for both standalone and group replication. That means, it is possible to update any version above `8.4.8`. Here, we are going to create a `MySQL` standalone using MySQL  `9.4.0`. Then we are going to update this version to `9.6.0`.
 
 **Deploy MySQL standalone:**
 
@@ -158,7 +158,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.4.0"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -216,7 +216,7 @@ We are ready to apply updating on this `MySQL` standalone.
 
 #### UpdateVersion
 
-Here, we are going to update `MySQL` standalone from `8.4.8` to `9.0.1`.
+Here, we are going to update `MySQL` standalone from `9.4.0` to `9.6.0`.
 
 **Create MySQLOpsRequest:**
 
@@ -233,14 +233,14 @@ spec:
     name: my-standalone
   type: UpdateVersion
   updateVersion:
-    targetVersion: "9.0.1"
+    targetVersion: "9.6.0"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies expected version `9.0.1` after updating.
+- `spec.updateVersion.targetVersion` specifies expected version `9.6.0` after updating.
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 

--- a/docs/guides/mysql/update-version/minorversion/standalone/yamls/standalone.yaml
+++ b/docs/guides/mysql/update-version/minorversion/standalone/yamls/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-standalone
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.4.0"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/mysql/update-version/minorversion/standalone/yamls/upgrade_minor_version_standalone.yaml
+++ b/docs/guides/mysql/update-version/minorversion/standalone/yamls/upgrade_minor_version_standalone.yaml
@@ -8,4 +8,4 @@ spec:
     name: my-standalone
   type: UpdateVersion
   updateVersion:
-    targetVersion: "8.4.8"
+    targetVersion: "9.6.0"

--- a/docs/guides/mysql/volume-expansion/volume-expansion/expamples/group_replication.yaml
+++ b/docs/guides/mysql/volume-expansion/volume-expansion/expamples/group_replication.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication

--- a/docs/guides/mysql/volume-expansion/volume-expansion/expamples/semi-sync.yaml
+++ b/docs/guides/mysql/volume-expansion/volume-expansion/expamples/semi-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync

--- a/docs/guides/mysql/volume-expansion/volume-expansion/expamples/standalone.yaml
+++ b/docs/guides/mysql/volume-expansion/volume-expansion/expamples/standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "topolvm-provisioner"

--- a/docs/guides/mysql/volume-expansion/volume-expansion/index.md
+++ b/docs/guides/mysql/volume-expansion/volume-expansion/index.md
@@ -54,7 +54,7 @@ topolvm-provisioner   topolvm.cybozu.com      Delete          WaitForFirstConsum
 
 We can see from the output the `topolvm-provisioner` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We will use this storage class. You can install topolvm from [here](https://github.com/topolvm/topolvm).
 
-Now, we are going to deploy a `MySQL` database of 3 replicas with version `8.4.8`.
+Now, we are going to deploy a `MySQL` database of 3 replicas with version `9.6.0`.
 
 ### Deploy MySQL
 
@@ -89,7 +89,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: GroupReplication
@@ -157,7 +157,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   replicas: 3
   topology:
     mode: SemiSync
@@ -194,7 +194,7 @@ metadata:
   name: sample-mysql
   namespace: demo
 spec:
-  version: "8.4.8"
+  version: "9.6.0"
   storageType: Durable
   storage:
     storageClassName: "topolvm-provisioner"


### PR DESCRIPTION
Bumps the **mysql** example and guide manifests to the latest supported version (`9.6.0`) per the installer `active_versions.json`.

- General "deploy a mysql" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated many MySQL example manifests and guide snippets to use newer MySQL versions, mainly `9.6.0` and in a few upgrade examples `9.4.0`.
  * Refreshed examples across quickstart, clustering, backup/restore, TLS, monitoring, scaling, configuration, and version upgrade guides.
  * Aligned several walkthroughs so the written instructions match the updated example YAML values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->