### PR TITLE
Update neo4j docs examples to latest supported version (2025.12.1)

### DIFF
--- a/docs/examples/neo4j/quickstart/neo4j.yaml
+++ b/docs/examples/neo4j/quickstart/neo4j.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   replicas: 3
   deletionPolicy: WipeOut
-  version: "2025.11.2"
+  version: "2025.12.1"
   storage:
     storageClassName: local-path
     accessModes:

--- a/docs/guides/neo4j/backup/kubestash/customization/common/sample-neo4j.yaml
+++ b/docs/guides/neo4j/backup/kubestash/customization/common/sample-neo4j.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-neo4j
   namespace: demo
 spec:
-  version: 2025.11.2
+  version: 2025.12.1
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/neo4j/backup/kubestash/logical/examples/restored-neo4j.yaml
+++ b/docs/guides/neo4j/backup/kubestash/logical/examples/restored-neo4j.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   init:
     waitForInitialRestore: true
-  version: 2025.11.2
+  version: 2025.12.1
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/neo4j/backup/kubestash/logical/examples/sample-neo4j.yaml
+++ b/docs/guides/neo4j/backup/kubestash/logical/examples/sample-neo4j.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-neo4j
   namespace: demo
 spec:
-  version: 2025.11.2
+  version: 2025.12.1
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/neo4j/backup/kubestash/logical/index.md
+++ b/docs/guides/neo4j/backup/kubestash/logical/index.md
@@ -91,7 +91,7 @@ Let's check if the database is ready to use,
 ```bash
 $ kubectl get neo4j -n demo sample-neo4j
 NAME           VERSION     STATUS   AGE
-sample-neo4j   2025.11.2   Ready    5m1s
+sample-neo4j   2025.12.1   Ready    5m1s
 ```
 
 The database is `Ready`. Verify that KubeDB has created a `Secret` and a `Service` for this database using the following commands,
@@ -118,7 +118,7 @@ Verify that the `AppBinding` has been created successfully using the following c
 ```bash
 $ kubectl get appbindings -n demo
 NAME           TYPE               VERSION                AGE
-sample-neo4j   kubedb.com/Neo4j   2025.11.2-enterprise   86s
+sample-neo4j   kubedb.com/Neo4j   2025.12.1-enterprise   86s
 ```
 
 Let's check the YAML of the above `AppBinding`,
@@ -133,7 +133,7 @@ kind: AppBinding
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1alpha2","kind":"Neo4j","metadata":{"annotations":{},"name":"sample-neo4j","namespace":"demo"},"spec":{"deletionPolicy":"WipeOut","replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}}},"storageType":"Durable","version":"2025.11.2"}}
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"Neo4j","metadata":{"annotations":{},"name":"sample-neo4j","namespace":"demo"},"spec":{"deletionPolicy":"WipeOut","replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}}},"storageType":"Durable","version":"2025.12.1"}}
   creationTimestamp: "2026-06-22T05:50:48Z"
   generation: 1
   labels:
@@ -166,7 +166,7 @@ spec:
   secret:
     name: sample-neo4j-auth
   type: kubedb.com/Neo4j
-  version: 2025.11.2-enterprise
+  version: 2025.12.1-enterprise
 ```
 
 KubeStash uses the `AppBinding` CR to connect with the target database. It requires the following fields to be set in the AppBinding's `.spec` section.
@@ -450,7 +450,7 @@ apiVersion: storage.kubestash.com/v1alpha1
 kind: Snapshot
 metadata:
   annotations:
-    kubedb.com/db-version: 2025.11.2-enterprise
+    kubedb.com/db-version: 2025.12.1-enterprise
   creationTimestamp: "2026-06-22T06:11:20Z"
   finalizers:
     - kubestash.com/cleanup
@@ -572,7 +572,7 @@ Let's wait for the database to be ready to use,
 ```bash
 $ kubectl get neo4j -n demo restored-neo4j
 NAME            VERSION     STATUS   AGE
-restored-neo4j   2025.11.2   Ready    5m1s
+restored-neo4j   2025.12.1   Ready    5m1s
 ```
 
 The database is `Ready`. Now, we are going to restore the backed up data into this database.
@@ -654,7 +654,7 @@ At first, check if the database has gone into **`Ready`** state by the following
 ```bash
 $ kubectl get neo4j -n demo restored-neo4j
 NAME            VERSION     STATUS   AGE
-restored-neo4j   2025.11.2   Ready    6m31s
+restored-neo4j   2025.12.1   Ready    6m31s
 ```
 
 Now, find out the database `Pod` by the following command,

--- a/docs/guides/neo4j/backup/kubestash/logical/index.md
+++ b/docs/guides/neo4j/backup/kubestash/logical/index.md
@@ -65,7 +65,7 @@ metadata:
   name: sample-neo4j
   namespace: demo
 spec:
-  version: 2025.11.2
+  version: 2025.12.1
   replicas: 3
   storageType: Durable
   storage:
@@ -548,7 +548,7 @@ metadata:
   name: restored-neo4j
   namespace: demo
 spec:
-  version: 2025.11.2
+  version: 2025.12.1
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/neo4j/monitoring/using-prometheus-operator.md
+++ b/docs/guides/neo4j/monitoring/using-prometheus-operator.md
@@ -91,7 +91,7 @@ metadata:
 spec:
   replicas: 3
   deletionPolicy: WipeOut
-  version: "2025.11.2"
+  version: "2025.12.1"
   storage:
     storageClassName: local-path
     accessModes:

--- a/docs/guides/neo4j/monitoring/using-prometheus-operator.md
+++ b/docs/guides/neo4j/monitoring/using-prometheus-operator.md
@@ -126,7 +126,7 @@ Now, wait for the database to go into `Ready` state.
 ```bash
 $ kubectl get neo4j -n demo coreos-prom-neo4j
 NAME                VERSION      STATUS   AGE
-coreos-prom-neo4j   2025.11.2    Ready    3m
+coreos-prom-neo4j   2025.12.1    Ready    3m
 ```
 
 KubeDB will create a separate stats service with the name `{Neo4j CR name}-stats` for monitoring purposes.

--- a/docs/guides/neo4j/private-registry/using-private-registry.md
+++ b/docs/guides/neo4j/private-registry/using-private-registry.md
@@ -62,16 +62,16 @@ Create a Neo4jVersion CRD specifying images from your private registry. Replace 
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: Neo4jVersion
 metadata:
-  name: "2025.11.2"
+  name: "2025.12.1"
 spec:
   db:
-    image: PRIVATE_REGISTRY/neo4j:2025.11.2
-  version: "2025.11.2"
+    image: PRIVATE_REGISTRY/neo4j:2025.12.1
+  version: "2025.12.1"
 ```
 
 ```bash
 $ kubectl apply -f pvt-neo4jversion.yaml
-neo4jversion.catalog.kubedb.com/2025.11.2 created
+neo4jversion.catalog.kubedb.com/2025.12.1 created
 ```
 
 ## Deploy Neo4j from Private Registry
@@ -83,7 +83,7 @@ metadata:
   name: pvt-reg-neo4j
   namespace: demo
 spec:
-  version: "2025.11.2"
+  version: "2025.12.1"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/neo4j/private-registry/using-private-registry.md
+++ b/docs/guides/neo4j/private-registry/using-private-registry.md
@@ -34,7 +34,7 @@ namespace/demo created
   ```bash
   $ kubectl get neo4jversions -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,DB_IMAGE:.spec.db.image,DEPRECATED:.spec.deprecated
   NAME      VERSION   DB_IMAGE                       DEPRECATED
-  2025.11.2 2025.11.2 kubedb/neo4j:2025.11.2         <none>
+  2025.12.1 2025.12.1 kubedb/neo4j:2025.12.1         <none>
   ```
 
 ## Create ImagePullSecret

--- a/docs/guides/neo4j/restart/restart.md
+++ b/docs/guides/neo4j/restart/restart.md
@@ -61,7 +61,7 @@ Wait until `STATUS` shows `Ready` before proceeding.
 
 ```
 NAME         VERSION     STATUS   AGE
-neo4j-test   2025.10.1   Ready    3m
+neo4j-test   2025.12.1   Ready    3m
 ```
 
 ## Apply Restart OpsRequest

--- a/docs/guides/neo4j/restart/restart.md
+++ b/docs/guides/neo4j/restart/restart.md
@@ -37,7 +37,7 @@ metadata:
   name: neo4j-test
   namespace: demo
 spec:
-  version: "2025.10.1"
+  version: "2025.12.1"
   replicas: 3
   storage:
     resources:

--- a/docs/guides/neo4j/rotate-auth/rotateauth.md
+++ b/docs/guides/neo4j/rotate-auth/rotateauth.md
@@ -81,7 +81,7 @@ Wait until `STATUS` shows `Ready` before proceeding.
 
 ```
 NAME         VERSION     STATUS   AGE
-neo4j-test   2025.10.1   Ready    3m
+neo4j-test   2025.12.1   Ready    3m
 ```
 
 ---

--- a/docs/guides/neo4j/rotate-auth/rotateauth.md
+++ b/docs/guides/neo4j/rotate-auth/rotateauth.md
@@ -57,7 +57,7 @@ metadata:
   name: neo4j-test
   namespace: demo
 spec:
-  version: "2025.10.1"
+  version: "2025.12.1"
   replicas: 3
   storage:
     resources:


### PR DESCRIPTION
Bumps the **neo4j** example and guide manifests to the latest supported version (`2025.12.1`) per the installer `active_versions.json`.

- General "deploy a neo4j" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Neo4j example manifests and guides to reference Neo4j version **2025.12.1**.
  * Refreshed related command/output snippets to match the new version across backup/restore, monitoring (Prometheus operator), private registry, restart, and authentication rotation guides.
  * Kept all other example configuration and procedures unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->