### PR TITLE
Update percona-xtradb docs examples to latest supported version (8.4.3)

### DIFF
--- a/docs/guides/percona-xtradb/autoscaler/compute/cluster/examples/sample-pxc.yaml
+++ b/docs/guides/percona-xtradb/autoscaler/compute/cluster/examples/sample-pxc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/percona-xtradb/autoscaler/compute/cluster/index.md
+++ b/docs/guides/percona-xtradb/autoscaler/compute/cluster/index.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `PerconaXtraDB` Cluster using a supported version
 
 #### Deploy PerconaXtraDB Cluster
 
-In this section, we are going to deploy a PerconaXtraDB Cluster with version `8.0.40`. Then, in the next section we will set up autoscaling for this database using `PerconaXtraDBAutoscaler` CRD. Below is the YAML of the `PerconaXtraDB` CR that we are going to create,
+In this section, we are going to deploy a PerconaXtraDB Cluster with version `8.4.3`. Then, in the next section we will set up autoscaling for this database using `PerconaXtraDBAutoscaler` CRD. Below is the YAML of the `PerconaXtraDB` CR that we are going to create,
 > If you want to autoscale PerconaXtraDB `Standalone`, Just remove the `spec.Replicas` from the below yaml and rest of the steps are same.
 
 ```yaml
@@ -52,7 +52,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:
@@ -88,7 +88,7 @@ Now, wait until `sample-pxc` has status `Ready`. i.e,
 ```bash
 $ kubectl get perconaxtradb -n demo
 NAME             VERSION   STATUS   AGE
-sample-pxc       8.0.40    Ready    14m
+sample-pxc       8.4.3    Ready    14m
 ```
 
 Let's check the Pod containers resources,

--- a/docs/guides/percona-xtradb/autoscaler/storage/cluster/examples/sample-pxc.yaml
+++ b/docs/guides/percona-xtradb/autoscaler/storage/cluster/examples/sample-pxc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/percona-xtradb/autoscaler/storage/cluster/index.md
+++ b/docs/guides/percona-xtradb/autoscaler/storage/cluster/index.md
@@ -58,7 +58,7 @@ Now, we are going to deploy a `PerconaXtraDB` replicaset using a supported versi
 
 #### Deploy PerconaXtraDB Cluster
 
-In this section, we are going to deploy a PerconaXtraDB replicaset database with version `8.0.40`.  Then, in the next section we will set up autoscaling for this database using `PerconaXtraDBAutoscaler` CRD. Below is the YAML of the `PerconaXtraDB` CR that we are going to create,
+In this section, we are going to deploy a PerconaXtraDB replicaset database with version `8.4.3`.  Then, in the next section we will set up autoscaling for this database using `PerconaXtraDBAutoscaler` CRD. Below is the YAML of the `PerconaXtraDB` CR that we are going to create,
 
 > If you want to autoscale PerconaXtraDB `Standalone`, Just remove the `spec.Replicas` from the below yaml and rest of the steps are same.
 
@@ -69,7 +69,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:
@@ -94,7 +94,7 @@ Now, wait until `sample-pxc` has status `Ready`. i.e,
 ```bash
 $ kubectl get perconaxtradb -n demo
 NAME             VERSION   STATUS   AGE
-sample-pxc      8.0.40    Ready    3m46s
+sample-pxc      8.4.3    Ready    3m46s
 ```
 
 Let's check volume size from petset, and from the persistent volume,

--- a/docs/guides/percona-xtradb/clustering/galera-cluster/examples/demo-1.yaml
+++ b/docs/guides/percona-xtradb/clustering/galera-cluster/examples/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/percona-xtradb/clustering/galera-cluster/index.md
+++ b/docs/guides/percona-xtradb/clustering/galera-cluster/index.md
@@ -46,7 +46,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:
@@ -78,7 +78,7 @@ kind: PerconaXtraDB
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1","kind":"PerconaXtraDB","metadata":{"annotations":{},"name":"sample-pxc","namespace":"demo"},"spec":{"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","deletionPolicy":"WipeOut","version":"8.0.40"}}
+      {"apiVersion":"kubedb.com/v1","kind":"PerconaXtraDB","metadata":{"annotations":{},"name":"sample-pxc","namespace":"demo"},"spec":{"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","deletionPolicy":"WipeOut","version":"8.4.3"}}
   creationTimestamp: "2022-12-20T05:15:56Z"
   finalizers:
   - kubedb.com
@@ -128,7 +128,7 @@ spec:
     replicationUserSecret:
       name: sample-pxc-replication
   deletionPolicy: WipeOut
-  version: 8.0.40
+  version: 8.4.3
 status:
   conditions:
   - lastTransitionTime: "2022-12-20T05:15:56Z"

--- a/docs/guides/percona-xtradb/concepts/appbinding/index.md
+++ b/docs/guides/percona-xtradb/concepts/appbinding/index.md
@@ -49,7 +49,7 @@ spec:
   secret:
     name: sample-pxc-auth
   type: kubedb.com/perconaxtradb
-  version: 8.0.40
+  version: 8.4.3
 ```
 
 Here, we are going to describe the sections of an `AppBinding` crd.

--- a/docs/guides/percona-xtradb/concepts/opsrequest/index.md
+++ b/docs/guides/percona-xtradb/concepts/opsrequest/index.md
@@ -37,7 +37,7 @@ spec:
   databaseRef:
     name: sample-pxc
   updateVersion:
-    targetVersion: 8.0.40
+    targetVersion: 8.4.3
 status:
   conditions:
     - lastTransitionTime: "2020-08-25T18:22:38Z"

--- a/docs/guides/percona-xtradb/concepts/perconaxtradb/index.md
+++ b/docs/guides/percona-xtradb/concepts/perconaxtradb/index.md
@@ -29,7 +29,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:
@@ -68,7 +68,7 @@ spec:
 
 `spec.version` is a required field specifying the name of the [PerconaXtraDBVersion](/docs/guides/percona-xtradb/concepts/perconaxtradb-version) crd where the docker images are specified. Currently, when you install KubeDB, it creates the following `PerconaXtraDBVersion` resources,
 
-- `9.1.0`, `8.0.40`, `8.4.3`
+- `9.1.0`, `8.4.3`, `8.4.3`
 
 ### Handling `mbind: Operation not permitted`
 On certain platforms (e.g., when using specific security profiles), for some versions of `perconaxtradb`, you may see log messages like:   

--- a/docs/guides/percona-xtradb/configuration/using-config-file/examples/px-custom.yaml
+++ b/docs/guides/percona-xtradb/configuration/using-config-file/examples/px-custom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   configuration:
     secretName: px-configuration
   storageType: Durable

--- a/docs/guides/percona-xtradb/configuration/using-config-file/index.md
+++ b/docs/guides/percona-xtradb/configuration/using-config-file/index.md
@@ -102,7 +102,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   configuration:
     secretName: px-configuration
   storageType: Durable
@@ -131,7 +131,7 @@ sample-pxc-2   2/2     Running   0          95m
 $ kubectl get perconaxtradb -n demo 
 NAME             VERSION   STATUS   AGE
 NAME         VERSION   STATUS   AGE
-sample-pxc   8.0.40    Ready    96m
+sample-pxc   8.4.3    Ready    96m
 ```
 
 We can see the database is in ready phase so it can accept connection.

--- a/docs/guides/percona-xtradb/configuration/using-pod-template/examples/md-misc-config.yaml
+++ b/docs/guides/percona-xtradb/configuration/using-pod-template/examples/md-misc-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/percona-xtradb/configuration/using-pod-template/index.md
+++ b/docs/guides/percona-xtradb/configuration/using-pod-template/index.md
@@ -68,7 +68,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -116,7 +116,7 @@ Check the perconaxtradb CRD status if the database is ready
 ```bash
 $ kubectl get perconaxtradb --all-namespaces
 NAMESPACE   NAME         VERSION   STATUS   AGE
-demo        sample-pxc   8.0.40    Ready    4m8s
+demo        sample-pxc   8.4.3    Ready    4m8s
 ```
 
 Once we see `Note] mysqld: ready for connections.` in the log, the database is ready.

--- a/docs/guides/percona-xtradb/custom-rbac/using-custom-rbac/examples/px-custom-db-2.yaml
+++ b/docs/guides/percona-xtradb/custom-rbac/using-custom-rbac/examples/px-custom-db-2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: another-perconaxtradb
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/percona-xtradb/custom-rbac/using-custom-rbac/examples/px-custom-db.yaml
+++ b/docs/guides/percona-xtradb/custom-rbac/using-custom-rbac/examples/px-custom-db.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/percona-xtradb/custom-rbac/using-custom-rbac/index.md
+++ b/docs/guides/percona-xtradb/custom-rbac/using-custom-rbac/index.md
@@ -136,7 +136,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "8.0.40"
+  version: "8.4.3"
   storageType: Durable
   podTemplate:
     spec:
@@ -169,7 +169,7 @@ Check the PerconaXtraDB custom resource to see if the database cluster is ready:
 ```bash
 ~ $ kubectl get perconaxtradb --all-namespaces
 NAMESPACE   NAME         VERSION   STATUS   AGE
-demo        sample-pxc   8.0.40    Ready    83m
+demo        sample-pxc   8.4.3    Ready    83m
 ```
 
 ## Reusing Service Account
@@ -193,7 +193,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "8.0.40"
+  version: "8.4.3"
   storageType: Durable
   podTemplate:
     spec:
@@ -223,7 +223,7 @@ Check the PerconaXtraDB custom resource to see if the database cluster is ready:
 ```bash
 ~ $ kubectl get perconaxtradb --all-namespaces
 NAMESPACE                NAME         VERSION   STATUS   AGE
-another-perconaxtradb    sample-pxc   8.0.40    Ready    83m
+another-perconaxtradb    sample-pxc   8.4.3    Ready    83m
 ```
 
 ## Cleaning up

--- a/docs/guides/percona-xtradb/failover/overview.md
+++ b/docs/guides/percona-xtradb/failover/overview.md
@@ -64,7 +64,7 @@ metadata:
   name: pxc-ha
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:
@@ -94,7 +94,7 @@ Sample ready output:
 
 ```text
 NAME                              VERSION   STATUS   AGE
-perconaxtradb.kubedb.com/pxc-ha   8.0.40    Ready    16h
+perconaxtradb.kubedb.com/pxc-ha   8.4.3    Ready    16h
 
 NAME                                  AGE
 petset.apps.k8s.appscode.com/pxc-ha   16h

--- a/docs/guides/percona-xtradb/monitoring/builtin-prometheus/examples/builtin-prom-px.yaml
+++ b/docs/guides/percona-xtradb/monitoring/builtin-prometheus/examples/builtin-prom-px.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-px
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/percona-xtradb/monitoring/builtin-prometheus/index.md
+++ b/docs/guides/percona-xtradb/monitoring/builtin-prometheus/index.md
@@ -49,7 +49,7 @@ metadata:
   name: builtin-prom-px
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"
@@ -78,7 +78,7 @@ Now, wait for the database to go into `Running` state.
 ```bash
 $ kubectl get perconaxtradb -n demo builtin-prom-px
 NAME              VERSION   STATUS   AGE
-builtin-prom-px   8.0.40    Ready    76s
+builtin-prom-px   8.4.3    Ready    76s
 ```
 
 KubeDB will create a separate stats service with name `{PerconaXtraDB crd name}-stats` for monitoring purpose.

--- a/docs/guides/percona-xtradb/monitoring/prometheus-operator/examples/prom-operator-px.yaml
+++ b/docs/guides/percona-xtradb/monitoring/prometheus-operator/examples/prom-operator-px.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coreos-prom-px
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/percona-xtradb/monitoring/prometheus-operator/index.md
+++ b/docs/guides/percona-xtradb/monitoring/prometheus-operator/index.md
@@ -111,7 +111,7 @@ metadata:
   name: coreos-prom-px
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"
@@ -149,7 +149,7 @@ Now, wait for the database to go into `Ready` state.
 ```bash
 $ kubectl get perconaxtradb -n demo coreos-prom-px
 NAME             VERSION   STATUS   AGE
-coreos-prom-px   8.0.40    Ready    59s
+coreos-prom-px   8.4.3    Ready    59s
 ```
 
 KubeDB will create a separate stats service with name `{PerconaXtraDB crd name}-stats` for monitoring purpose.

--- a/docs/guides/percona-xtradb/private-registry/quickstart/examples/demo.yaml
+++ b/docs/guides/percona-xtradb/private-registry/quickstart/examples/demo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: px-pvt-reg
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/percona-xtradb/private-registry/quickstart/index.md
+++ b/docs/guides/percona-xtradb/private-registry/quickstart/index.md
@@ -102,7 +102,7 @@ metadata:
   name: px-pvt-reg
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/percona-xtradb/quickstart/overview/examples/sample-pxc-v1.yaml
+++ b/docs/guides/percona-xtradb/quickstart/overview/examples/sample-pxc-v1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/percona-xtradb/quickstart/overview/examples/sample-pxc-v1alpha2.yaml
+++ b/docs/guides/percona-xtradb/quickstart/overview/examples/sample-pxc-v1alpha2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/percona-xtradb/quickstart/overview/index.md
+++ b/docs/guides/percona-xtradb/quickstart/overview/index.md
@@ -67,7 +67,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -91,7 +91,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -110,7 +110,7 @@ perconaxtradb.kubedb.com/sample-pxc created
 
 Here,
 
-- `spec.version` is the name of the PerconaXtraDBVersion CRD where the docker images are specified. In this tutorial, a PerconaXtraDB `8.0.40` database is going to create.
+- `spec.version` is the name of the PerconaXtraDBVersion CRD where the docker images are specified. In this tutorial, a PerconaXtraDB `8.4.3` database is going to create.
 - `spec.storageType` specifies the type of storage that will be used for PerconaXtraDB database. It can be `Durable` or `Ephemeral`. Default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create PerconaXtraDB database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the StatefulSet created by KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests.
 - `spec.terminationPolicy` or `spec.deletionPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `PerconaXtraDB` crd or which resources KubeDB should keep or delete when you delete `PerconaXtraDB` crd. If admission webhook is enabled, It prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`.
@@ -176,7 +176,7 @@ Spec:
     Replication User Secret:
       Name:            sample-pxc-replication
   Termination Policy:  Delete
-  Version:             8.0.40
+  Version:             8.4.3
 Status:
   Conditions:
     Last Transition Time:  2022-12-19T09:54:09Z
@@ -245,7 +245,7 @@ KubeDB operator sets the `status.phase` to `Running` once the database is succes
 ```bash
 $ kubectl get perconaxtradb -n demo
 NAME         VERSION   STATUS   AGE
-sample-pxc   8.0.40    Ready    9m32s
+sample-pxc   8.4.3    Ready    9m32s
 ```
 
 ## Connect with PerconaXtraDB database
@@ -411,7 +411,7 @@ Run the following command to get PerconaXtraDB resources,
 ```bash
 $ kubectl get perconaxtradb,sts,secret,svc,pvc -n demo
 NAME                                VERSION   STATUS   AGE
-perconaxtradb.kubedb.com/sample-pxc   8.0.40    Halted   22m
+perconaxtradb.kubedb.com/sample-pxc   8.4.3    Halted   22m
 
 NAME                      TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
 service/sample-pxc        ClusterIP   10.96.128.19   <none>        3306/TCP   4m5s

--- a/docs/guides/percona-xtradb/reconfigure-tls/cluster/examples/sample-pxc.yaml
+++ b/docs/guides/percona-xtradb/reconfigure-tls/cluster/examples/sample-pxc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/percona-xtradb/reconfigure-tls/cluster/index.md
+++ b/docs/guides/percona-xtradb/reconfigure-tls/cluster/index.md
@@ -47,7 +47,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:
@@ -72,7 +72,7 @@ Now, wait until `sample-pxc` has status `Ready`. i.e,
 ```bash
 $ kubectl get perconaxtradb -n demo
 NAME             VERSION   STATUS   AGE
-sample-pxc       8.0.40    Ready    9m17s
+sample-pxc       8.4.3    Ready    9m17s
 ```
 
 ```bash

--- a/docs/guides/percona-xtradb/reconfigure/cluster/examples/sample-pxc-config.yaml
+++ b/docs/guides/percona-xtradb/reconfigure/cluster/examples/sample-pxc-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   configuration:
     secretName: px-configuration

--- a/docs/guides/percona-xtradb/reconfigure/cluster/index.md
+++ b/docs/guides/percona-xtradb/reconfigure/cluster/index.md
@@ -39,7 +39,7 @@ Now, we are going to deploy a  `PerconaXtraDB` Cluster using a supported version
 
 ### Prepare PerconaXtraDB Cluster
 
-Now, we are going to deploy a `PerconaXtraDB` Cluster database with version `8.0.40`.
+Now, we are going to deploy a `PerconaXtraDB` Cluster database with version `8.4.3`.
 
 ### Deploy PerconaXtraDB
 
@@ -70,7 +70,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   configuration:
     secretName: px-configuration
@@ -97,7 +97,7 @@ Now, wait until `sample-pxc` has status `Ready`. i.e,
 ```bash
 $ kubectl get perconaxtradb -n demo 
 NAME             VERSION   STATUS   AGE
-sample-pxc       8.0.40    Ready    71s
+sample-pxc       8.4.3    Ready    71s
 ```
 
 Now, we will check if the database has started with the custom configuration we have provided.

--- a/docs/guides/percona-xtradb/restart/index.md
+++ b/docs/guides/percona-xtradb/restart/index.md
@@ -46,7 +46,7 @@ metadata:
   name: pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/percona-xtradb/restart/yamls/pxc.yaml
+++ b/docs/guides/percona-xtradb/restart/yamls/pxc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/percona-xtradb/rotateauth/rotateauth.md
+++ b/docs/guides/percona-xtradb/rotateauth/rotateauth.md
@@ -51,7 +51,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -73,7 +73,7 @@ Now, wait until sample-pxc has status Ready. i.e,
 ```shell
 $  kubectl get perconaxtradb -n demo
 NAME         VERSION   STATUS   AGE
-sample-pxc   8.0.40    Ready    43m
+sample-pxc   8.4.3    Ready    43m
 ```
 ## Verify authentication
 The user can verify whether they are authorized by executing a query directly in the database. To do this, the user needs `username` and `password` in order to connect to the database. Below is an example showing how to retrieve the credentials from the secret.

--- a/docs/guides/percona-xtradb/scaling/horizontal-scaling/cluster/example/sample-pxc.yaml
+++ b/docs/guides/percona-xtradb/scaling/horizontal-scaling/cluster/example/sample-pxc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/percona-xtradb/scaling/horizontal-scaling/cluster/index.md
+++ b/docs/guides/percona-xtradb/scaling/horizontal-scaling/cluster/index.md
@@ -41,7 +41,7 @@ Here, we are going to deploy a  `PerconaXtraDB` cluster using a supported versio
 
 ### Prepare PerconaXtraDB Cluster Database
 
-Now, we are going to deploy a `PerconaXtraDB` cluster with version `8.0.40`.
+Now, we are going to deploy a `PerconaXtraDB` cluster with version `8.4.3`.
 
 ### Deploy PerconaXtraDB Cluster
 
@@ -54,7 +54,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:
@@ -79,7 +79,7 @@ Now, wait until `sample-pxc` has status `Ready`. i.e,
 ```bash
 $ kubectl get perconaxtradb -n demo
 NAME             VERSION   STATUS   AGE
-sample-pxc       8.0.40    Ready    2m36s
+sample-pxc       8.4.3    Ready    2m36s
 ```
 
 Let's check the number of replicas this database has from the PerconaXtraDB object, number of pods the petset have,

--- a/docs/guides/percona-xtradb/scaling/vertical-scaling/cluster/example/sample-pxc.yaml
+++ b/docs/guides/percona-xtradb/scaling/vertical-scaling/cluster/example/sample-pxc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/percona-xtradb/scaling/vertical-scaling/cluster/index.md
+++ b/docs/guides/percona-xtradb/scaling/vertical-scaling/cluster/index.md
@@ -41,7 +41,7 @@ Here, we are going to deploy a  `PerconaXtraDB` cluster using a supported versio
 
 ### Prepare PerconaXtraDB Cluster
 
-Now, we are going to deploy a `PerconaXtraDB` cluster database with version `8.0.40`.
+Now, we are going to deploy a `PerconaXtraDB` cluster database with version `8.4.3`.
 > Vertical Scaling for `PerconaXtraDB Standalone` can be performed in the same way as `PerconaXtraDB Cluster`. Only remove the `spec.replicas` field from the below yaml to deploy a PerconaXtraDB Standalone.
 
 ### Deploy PerconaXtraDB Cluster 
@@ -55,7 +55,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:
@@ -80,7 +80,7 @@ Now, wait until `sample-pxc` has status `Ready`. i.e,
 ```bash
 $ kubectl get perconaxtradb -n demo
 NAME             VERSION    STATUS     AGE
-sample-pxc    8.0.40     Ready     3m46s
+sample-pxc    8.4.3     Ready     3m46s
 ```
 
 Let's check the Pod containers resources,

--- a/docs/guides/percona-xtradb/tls/configure/examples/tls-cluster.yaml
+++ b/docs/guides/percona-xtradb/tls/configure/examples/tls-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/percona-xtradb/tls/configure/index.md
+++ b/docs/guides/percona-xtradb/tls/configure/index.md
@@ -92,7 +92,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:
@@ -134,7 +134,7 @@ Now, wait for `PerconaXtraDB` going on `Running` state and also wait for `PetSet
 ```bash
 $ kubectl get perconaxtradb -n demo sample-pxc
 NAME         VERSION   STATUS   AGE
-sample-pxc   8.0.40    Ready    3m23s
+sample-pxc   8.4.3    Ready    3m23s
 
 
 $ kubectl get pod -n demo | grep sample-pxc

--- a/docs/guides/percona-xtradb/update-version/cluster/examples/pxops-update.yaml
+++ b/docs/guides/percona-xtradb/update-version/cluster/examples/pxops-update.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: sample-pxc
   updateVersion:
-    targetVersion: "8.0.28"
+    targetVersion: "8.4.3"

--- a/docs/guides/percona-xtradb/update-version/cluster/index.md
+++ b/docs/guides/percona-xtradb/update-version/cluster/index.md
@@ -37,7 +37,7 @@ namespace/demo created
 
 ## Prepare PerconaXtraDB Cluster
 
-Now, we are going to deploy a `PerconaXtraDB` cluster database with version `10.4.32`.
+Now, we are going to deploy a `PerconaXtraDB` cluster database with version `8.0.40`.
 
 ### Deploy PerconaXtraDB cluster
 
@@ -85,7 +85,7 @@ We are now ready to apply the `PerconaXtraDBOpsRequest` CR to update this databa
 
 ### Update PerconaXtraDB Version
 
-Here, we are going to update `PerconaXtraDB` cluster from `8.0.40` to `8.0.28`.
+Here, we are going to update `PerconaXtraDB` cluster from `8.0.40` to `8.4.3`.
 
 #### Create PerconaXtraDBOpsRequest:
 
@@ -102,14 +102,14 @@ spec:
   databaseRef:
     name: sample-pxc
   updateVersion:
-    targetVersion: "8.0.28"
+    targetVersion: "8.4.3"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `sample-pxc` PerconaXtraDB database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `8.0.28`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `8.4.3`.
 
 Let's create the `PerconaXtraDBOpsRequest` CR we have shown above,
 
@@ -137,13 +137,13 @@ Now, we are going to verify whether the `PerconaXtraDB` and the related `PetSets
 
 ```bash
 $ kubectl get perconaxtradb -n demo sample-pxc -o=jsonpath='{.spec.version}{"\n"}'
-8.0.28
+8.4.3
 
 $ kubectl get sts -n demo sample-pxc -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-percona/percona-xtradb-cluster:8.0.28
+percona/percona-xtradb-cluster:8.4.3
 
 $ kubectl get pods -n demo sample-pxc-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-percona/percona-xtradb-cluster:8.0.28
+percona/percona-xtradb-cluster:8.4.3
 ```
 
 You can see from above, our `PerconaXtraDB` cluster database has been updated with the new version. So, the update process is successfully completed.

--- a/docs/guides/percona-xtradb/volume-expansion/volume-expansion/example/sample-pxc.yaml
+++ b/docs/guides/percona-xtradb/volume-expansion/volume-expansion/example/sample-pxc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/percona-xtradb/volume-expansion/volume-expansion/index.md
+++ b/docs/guides/percona-xtradb/volume-expansion/volume-expansion/index.md
@@ -54,7 +54,7 @@ topolvm-provisioner   topolvm.cybozu.com      Delete          WaitForFirstConsum
 
 We can see from the output the `topolvm-provisioner` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We will use this storage class. You can install topolvm from [here](https://github.com/topolvm/topolvm).
 
-Now, we are going to deploy a `PerconaXtraDB` database of 3 replicas with version `8.0.40`.
+Now, we are going to deploy a `PerconaXtraDB` database of 3 replicas with version `8.4.3`.
 
 ### Deploy PerconaXtraDB
 
@@ -67,7 +67,7 @@ metadata:
   name: sample-pxc
   namespace: demo
 spec:
-  version: "8.0.40"
+  version: "8.4.3"
   replicas: 3
   storageType: Durable
   storage:
@@ -93,7 +93,7 @@ Now, wait until `sample-pxc` has status `Ready`. i.e,
 ```bash
 $ kubectl get perconaxtradb -n demo
 NAME             VERSION   STATUS   AGE
-sample-pxc   8.0.40    Ready    5m4s
+sample-pxc   8.4.3    Ready    5m4s
 ```
 
 Let's check volume size from petset, and from the persistent volume,


### PR DESCRIPTION
Bumps the **percona-xtradb** example and guide manifests to the latest supported version (`8.4.3`) per the installer `active_versions.json`.

- General "deploy a percona-xtradb" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Percona XtraDB guides and examples to use version **8.4.3** instead of **8.0.40** throughout setup, scaling, monitoring, TLS, failover, reconfiguration, and quickstart content.
  * Refreshed sample manifests and command outputs so the documented version matches the latest supported release.
  * Adjusted the version update workflow examples to show the new target version and expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->