### PR TITLE
Update pgbouncer docs examples to latest supported version (1.24.0)

### DIFF
--- a/docs/examples/pgbouncer/autoscaling/compute/pgbouncer-autoscale.yaml
+++ b/docs/examples/pgbouncer/autoscaling/compute/pgbouncer-autoscale.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/examples/pgbouncer/monitoring/builtin-prom-pgbouncer.yaml
+++ b/docs/examples/pgbouncer/monitoring/builtin-prom-pgbouncer.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgbouncer-server
   namespace: demo
 spec:
-  version: "1.17.0"
+  version: "1.24.0"
   replicas: 1
   database:
     syncUsers: true

--- a/docs/examples/pgbouncer/monitoring/coreos-prom-pgbouncer.yaml
+++ b/docs/examples/pgbouncer/monitoring/coreos-prom-pgbouncer.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgbouncer-server
   namespace: demo
 spec:
-  version: "1.17.0"
+  version: "1.24.0"
   replicas: 1
   database:
     syncUsers: true

--- a/docs/examples/pgbouncer/pb-overview.yaml
+++ b/docs/examples/pgbouncer/pb-overview.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgbouncer-server
   namespace: demo
 spec:
-  version: "1.17.0"
+  version: "1.24.0"
   replicas: 1
   database:
     syncUsers: true

--- a/docs/examples/pgbouncer/quickstart/pgbouncer-server-mod.yaml
+++ b/docs/examples/pgbouncer/quickstart/pgbouncer-server-mod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgbouncer-server
   namespace: demo
 spec:
-  version: "1.17.0"
+  version: "1.24.0"
   replicas: 1
   database:
     syncUsers: true

--- a/docs/examples/pgbouncer/quickstart/pgbouncer-server-v1.yaml
+++ b/docs/examples/pgbouncer/quickstart/pgbouncer-server-v1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgbouncer-server
   namespace: demo
 spec:
-  version: "1.18.0"
+  version: "1.24.0"
   replicas: 1
   database:
     syncUsers: true

--- a/docs/examples/pgbouncer/quickstart/pgbouncer-server-v1alpha2.yaml
+++ b/docs/examples/pgbouncer/quickstart/pgbouncer-server-v1alpha2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgbouncer-server
   namespace: demo
 spec:
-  version: "1.18.0"
+  version: "1.24.0"
   replicas: 1
   database:
     syncUsers: true

--- a/docs/examples/pgbouncer/reconfigure-tls/pb.yaml
+++ b/docs/examples/pgbouncer/reconfigure-tls/pb.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/examples/pgbouncer/reconfigure/pb-custom-config.yaml
+++ b/docs/examples/pgbouncer/reconfigure/pb-custom-config.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/examples/pgbouncer/restart/pgbouncer.yaml
+++ b/docs/examples/pgbouncer/restart/pgbouncer.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/examples/pgbouncer/scaling/pb-horizontal.yaml
+++ b/docs/examples/pgbouncer/scaling/pb-horizontal.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/examples/pgbouncer/scaling/pb-vertical.yaml
+++ b/docs/examples/pgbouncer/scaling/pb-vertical.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/examples/pgbouncer/sync-users/pgbouncer-sync.yaml
+++ b/docs/examples/pgbouncer/sync-users/pgbouncer-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgbouncer-sync
   namespace: demo
 spec:
-  version: "1.23.1"
+  version: "1.24.0"
   replicas: 1
   database:
     syncUsers: true

--- a/docs/examples/pgbouncer/tls/pgbouncer-ssl.yaml
+++ b/docs/examples/pgbouncer/tls/pgbouncer-ssl.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/examples/pgbouncer/update-version/pb-update.yaml
+++ b/docs/examples/pgbouncer/update-version/pb-update.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.23.1"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/examples/pgbouncer/update-version/pbops-update.yaml
+++ b/docs/examples/pgbouncer/update-version/pbops-update.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: pb-update
   updateVersion:
-    targetVersion: 1.23.1
+    targetVersion: 1.24.0

--- a/docs/examples/pgbouncer/vs.yaml
+++ b/docs/examples/pgbouncer/vs.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgb-vs
   namespace: demo
 spec:
-  version: "1.18.0"
+  version: "1.24.0"
   replicas: 1
   database:
     syncUsers: true

--- a/docs/guides/pgbouncer/autoscaler/compute/compute-autoscale.md
+++ b/docs/guides/pgbouncer/autoscaler/compute/compute-autoscale.md
@@ -48,7 +48,7 @@ Here, we are going to deploy a `PgBouncer` standalone using a supported version 
 
 #### Deploy PgBouncer
 
-In this section, we are going to deploy a PgBouncer with version `1.18.0`  Then, in the next section we will set up autoscaling for this pgbouncer using `PgBouncerAutoscaler` CRD. Below is the YAML of the `PgBouncer` CR that we are going to create,
+In this section, we are going to deploy a PgBouncer with version `1.24.0`  Then, in the next section we will set up autoscaling for this pgbouncer using `PgBouncerAutoscaler` CRD. Below is the YAML of the `PgBouncer` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -58,7 +58,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/guides/pgbouncer/concepts/opsrequest.md
+++ b/docs/guides/pgbouncer/concepts/opsrequest.md
@@ -37,7 +37,7 @@ spec:
   databaseRef:
     name: pgbouncer-server
   updateVersion:
-    targetVersion: 1.18.0
+    targetVersion: 1.24.0
 ```
 
 **Sample `PgBouncerOpsRequest` Objects for Horizontal Scaling:**

--- a/docs/guides/pgbouncer/concepts/pgbouncer.md
+++ b/docs/guides/pgbouncer/concepts/pgbouncer.md
@@ -31,7 +31,7 @@ metadata:
   name: pgbouncer-server
   namespace: demo
 spec:
-  version: "1.18.0"
+  version: "1.24.0"
   replicas: 1
   database:
     syncUsers: true
@@ -55,7 +55,7 @@ spec:
 
 `spec.version` is a required field that specifies the name of the [PgBouncerVersion](/docs/guides/pgbouncer/concepts/catalog.md) crd where the docker images are specified. Currently, when you install KubeDB, it creates the following `PgBouncerVersion` resources,
 
-- `1.18.0`
+- `1.24.0`
 
 ### spec.replicas
 

--- a/docs/guides/pgbouncer/monitoring/overview.md
+++ b/docs/guides/pgbouncer/monitoring/overview.md
@@ -54,7 +54,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 2
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/guides/pgbouncer/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/pgbouncer/monitoring/using-builtin-prometheus.md
@@ -53,7 +53,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/guides/pgbouncer/monitoring/using-prometheus-operator.md
+++ b/docs/guides/pgbouncer/monitoring/using-prometheus-operator.md
@@ -187,7 +187,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/guides/pgbouncer/quickstart/quickstart.md
+++ b/docs/guides/pgbouncer/quickstart/quickstart.md
@@ -54,7 +54,7 @@ $ kubectl get pgbouncerversions
 
 Notice the `DEPRECATED` column. Here, `true` means that this PgBouncerVersion is deprecated for current KubeDB version. KubeDB will not work for deprecated PgBouncerVersion.
 
-In this tutorial, we will use `1.18.0` PgBouncerVersion crd to create PgBouncer. To know more about what `PgBouncerVersion` crd is, please visit [here](/docs/guides/pgbouncer/concepts/catalog.md). You can also see supported PgBouncerVersion [here](/docs/guides/pgbouncer/README.md#supported-pgbouncerversion-crd).
+In this tutorial, we will use `1.24.0` PgBouncerVersion crd to create PgBouncer. To know more about what `PgBouncerVersion` crd is, please visit [here](/docs/guides/pgbouncer/concepts/catalog.md). You can also see supported PgBouncerVersion [here](/docs/guides/pgbouncer/README.md#supported-pgbouncerversion-crd).
 
 ## Get PostgreSQL Server ready
 
@@ -167,7 +167,7 @@ metadata:
   name: pgbouncer-server
   namespace: demo
 spec:
-  version: "1.18.0"
+  version: "1.24.0"
   replicas: 1
   database:
     syncUsers: true
@@ -194,7 +194,7 @@ metadata:
   name: pgbouncer-server
   namespace: demo
 spec:
-  version: "1.18.0"
+  version: "1.24.0"
   replicas: 1
   database:
     syncUsers: true
@@ -216,7 +216,7 @@ pgbouncer.kubedb.com/pgbouncer-server created
 
 Here,
 
-- `spec.version` is name of the PgBouncerVersion crd where the docker images are specified. In this tutorial, a PgBouncer with base image version 1.17.0 is created.
+- `spec.version` is name of the PgBouncerVersion crd where the docker images are specified. In this tutorial, a PgBouncer with base image version 1.24.0 is created.
 - `spec.replicas` specifies the number of replica pgbouncer server pods to be created for the PgBouncer object.
 - `spec.database` specifies the database that are going to be served via PgBouncer.
 - `spec.connectionPool` specifies the configurations for connection pool.

--- a/docs/guides/pgbouncer/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/pgbouncer/reconfigure-tls/reconfigure-tls.md
@@ -40,7 +40,7 @@ Now, we are going to deploy a  `PgBouncer` using a supported version by `KubeDB`
 
 ### Prepare PgBouncer
 
-Now, we are going to deploy a `PgBouncer` with version `1.18.0`.
+Now, we are going to deploy a `PgBouncer` with version `1.24.0`.
 
 ## Add TLS to a PgBouncer database
 
@@ -58,7 +58,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/guides/pgbouncer/reconfigure/reconfigure-pgbouncer.md
+++ b/docs/guides/pgbouncer/reconfigure/reconfigure-pgbouncer.md
@@ -43,7 +43,7 @@ Now, we are going to deploy a  `PgBouncer` using a supported version by `KubeDB`
 
 ### Prepare PgBouncer
 
-Now, we are going to deploy a `PgBouncer` with version `1.18.0`.
+Now, we are going to deploy a `PgBouncer` with version `1.24.0`.
 
 ### Deploy PgBouncer 
 
@@ -73,7 +73,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/guides/pgbouncer/restart/restart.md
+++ b/docs/guides/pgbouncer/restart/restart.md
@@ -46,7 +46,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/guides/pgbouncer/scaling/horizontal-scaling/horizontal-ops.md
+++ b/docs/guides/pgbouncer/scaling/horizontal-scaling/horizontal-ops.md
@@ -45,7 +45,7 @@ Prepare a KubeDB Postgres cluster using this [tutorial](/docs/guides/postgres/cl
 
 ### Prepare PgBouncer
 
-Now, we are going to deploy a `PgBouncer` with version `1.23.1`.
+Now, we are going to deploy a `PgBouncer` with version `1.24.0`.
 
 ### Deploy PgBouncer 
 
@@ -59,7 +59,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/guides/pgbouncer/scaling/vertical-scaling/vertical-ops.md
+++ b/docs/guides/pgbouncer/scaling/vertical-scaling/vertical-ops.md
@@ -45,7 +45,7 @@ Prepare a KubeDB Postgres cluster using this [tutorial](/docs/guides/postgres/cl
 
 ### Prepare PgBouncer
 
-Now, we are going to deploy a `PgBouncer` with version `1.18.0`.
+Now, we are going to deploy a `PgBouncer` with version `1.24.0`.
 
 ### Deploy PgBouncer 
 
@@ -59,7 +59,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/guides/pgbouncer/sync-users/sync-users-pgbouncer.md
+++ b/docs/guides/pgbouncer/sync-users/sync-users-pgbouncer.md
@@ -65,7 +65,7 @@ For a PgBouncer surely we will need a Postgres server so, prepare a KubeDB Postg
 
 ### Prepare PgBouncer
 
-Now, we are going to deploy a `PgBouncer` with version `1.23.1`.
+Now, we are going to deploy a `PgBouncer` with version `1.24.0`.
 
 ### Deploy PgBouncer
 
@@ -78,7 +78,7 @@ metadata:
   name: pgbouncer-sync
   namespace: demo
 spec:
-  version: "1.23.1"
+  version: "1.24.0"
   replicas: 1
   database:
     syncUsers: true

--- a/docs/guides/pgbouncer/tls/configure_ssl.md
+++ b/docs/guides/pgbouncer/tls/configure_ssl.md
@@ -125,7 +125,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"

--- a/docs/guides/pgbouncer/update-version/update_version.md
+++ b/docs/guides/pgbouncer/update-version/update_version.md
@@ -41,7 +41,7 @@ Prepare a KubeDB Postgres cluster using this [tutorial](/docs/guides/postgres/cl
 
 ### Prepare PgBouncer
 
-Now, we are going to deploy a `PgBouncer` with version `1.18.0`.
+Now, we are going to deploy a `PgBouncer` with version `1.23.1`.
 
 ### Deploy PgBouncer:
 
@@ -55,7 +55,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "1.18.0"
+  version: "1.23.1"
   database:
     syncUsers: true
     databaseName: "postgres"
@@ -92,7 +92,7 @@ We are now ready to apply the `PgBouncerOpsRequest` CR to update this PgBouncer.
 
 ### update PgBouncer Version
 
-Here, we are going to update `PgBouncer` from `1.18.0` to `1.23.1`.
+Here, we are going to update `PgBouncer` from `1.23.1` to `1.24.0`.
 
 #### Create PgBouncerOpsRequest:
 
@@ -109,14 +109,14 @@ spec:
   databaseRef:
     name: pb-update
   updateVersion:
-    targetVersion: 1.23.1
+    targetVersion: 1.24.0
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `pb-update` PgBouncer.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our PgBouncer.
-- `spec.updateVersion.targetVersion` specifies the expected version of the PgBouncer `1.23.1`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the PgBouncer `1.24.0`.
 
 
 Let's create the `PgBouncerOpsRequest` CR we have shown above,

--- a/docs/guides/pgbouncer/virtual_secret/guide.md
+++ b/docs/guides/pgbouncer/virtual_secret/guide.md
@@ -286,7 +286,7 @@ metadata:
   name: pgb-vs
   namespace: demo
 spec:
-  version: "1.18.0"
+  version: "1.24.0"
   replicas: 1
   database:
     syncUsers: true


### PR DESCRIPTION
Bumps the **pgbouncer** example and guide manifests to the latest supported version (`1.24.0`) per the installer `active_versions.json`.

- General "deploy a pgbouncer" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.