### PR TITLE
Update pgpool docs examples to latest supported version (4.6.0)

### DIFF
--- a/docs/examples/pgpool/autoscaling/compute/pgpool-autoscale.yaml
+++ b/docs/examples/pgpool/autoscaling/compute/pgpool-autoscale.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgpool-autoscale
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/configuration/pgpool-config-file.yaml
+++ b/docs/examples/pgpool/configuration/pgpool-config-file.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pp-custom-config
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   configuration:
     secretName: pp-configuration

--- a/docs/examples/pgpool/configuration/pgpool-config-sidecar.yaml
+++ b/docs/examples/pgpool/configuration/pgpool-config-sidecar.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgpool-custom-sidecar
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/configuration/pgpool-init-config.yaml
+++ b/docs/examples/pgpool/configuration/pgpool-init-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pp-init-config
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/configuration/pgpool-node-selector.yaml
+++ b/docs/examples/pgpool/configuration/pgpool-node-selector.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgpool-node-selector
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/configuration/pgpool-with-tolerations.yaml
+++ b/docs/examples/pgpool/configuration/pgpool-with-tolerations.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgpool-with-tolerations
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/configuration/pgpool-without-tolerations.yaml
+++ b/docs/examples/pgpool/configuration/pgpool-without-tolerations.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgpool-without-tolerations
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/configuration/pp-misc-config.yaml
+++ b/docs/examples/pgpool/configuration/pp-misc-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgpool
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/custom-rbac/pgpool-new.yaml
+++ b/docs/examples/pgpool/custom-rbac/pgpool-new.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgpool-new
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/custom-rbac/pp-custom.yaml
+++ b/docs/examples/pgpool/custom-rbac/pp-custom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgpool
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/initialization/git-sync/git-sync-public.yaml
+++ b/docs/examples/pgpool/initialization/git-sync/git-sync-public.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgpool-demo
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: postgres

--- a/docs/examples/pgpool/monitroing/builtin-prom-pp.yaml
+++ b/docs/examples/pgpool/monitroing/builtin-prom-pp.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-pp
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   deletionPolicy: WipeOut
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/monitroing/coreos-prom-pp.yaml
+++ b/docs/examples/pgpool/monitroing/coreos-prom-pp.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coreos-prom-pp
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   postgresRef:
     name: ha-postgres
     namespace: demo

--- a/docs/examples/pgpool/quickstart/quick-pgpool.yaml
+++ b/docs/examples/pgpool/quickstart/quick-pgpool.yaml
@@ -4,7 +4,7 @@ metadata:
   name: quick-pgpool
   namespace: pool
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: quick-postgres

--- a/docs/examples/pgpool/reconfiguration/pp-custom-config.yaml
+++ b/docs/examples/pgpool/reconfiguration/pp-custom-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pp-custom
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   configuration:
     secretName: pp-custom-config

--- a/docs/examples/pgpool/reconfigure-tls/pgpool.yaml
+++ b/docs/examples/pgpool/reconfigure-tls/pgpool.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgpool
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/restart/pgpool.yaml
+++ b/docs/examples/pgpool/restart/pgpool.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgpool
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/scaling/pp-horizontal.yaml
+++ b/docs/examples/pgpool/scaling/pp-horizontal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pp-horizontal
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/scaling/pp-vertical.yaml
+++ b/docs/examples/pgpool/scaling/pp-vertical.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pp-vertical
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/sync-users/pgpool-sync.yaml
+++ b/docs/examples/pgpool/sync-users/pgpool-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgpool-sync
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   syncUsers: true
   postgresRef:

--- a/docs/examples/pgpool/tls/pgpool-ssl.yaml
+++ b/docs/examples/pgpool/tls/pgpool-ssl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pgpool-test
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/update-version/pp-update.yaml
+++ b/docs/examples/pgpool/update-version/pp-update.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pp-update
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.5.3"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/examples/pgpool/update-version/ppops-update.yaml
+++ b/docs/examples/pgpool/update-version/ppops-update.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: pp-update
   updateVersion:
-    targetVersion: 4.5.0
+    targetVersion: 4.6.0

--- a/docs/examples/pgpool/vs.yaml
+++ b/docs/examples/pgpool/vs.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pp-vs
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: pg-demo

--- a/docs/guides/pgpool/autoscaler/compute/compute-autoscale.md
+++ b/docs/guides/pgpool/autoscaler/compute/compute-autoscale.md
@@ -48,7 +48,7 @@ Here, we are going to deploy a `Pgpool` standalone using a supported version by 
 
 #### Deploy Pgpool
 
-In this section, we are going to deploy a Pgpool with version `4.5.0`  Then, in the next section we will set up autoscaling for this pgpool using `PgpoolAutoscaler` CRD. Below is the YAML of the `Pgpool` CR that we are going to create,
+In this section, we are going to deploy a Pgpool with version `4.6.0`  Then, in the next section we will set up autoscaling for this pgpool using `PgpoolAutoscaler` CRD. Below is the YAML of the `Pgpool` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -57,7 +57,7 @@ metadata:
   name: pgpool-autoscale
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/guides/pgpool/concepts/pgpool.md
+++ b/docs/guides/pgpool/concepts/pgpool.md
@@ -29,7 +29,7 @@ metadata:
   name: pgpool
   namespace: pool
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   healthChecker:
     failureThreshold: 3

--- a/docs/guides/pgpool/configuration/using-config-file.md
+++ b/docs/guides/pgpool/configuration/using-config-file.md
@@ -94,7 +94,7 @@ metadata:
   name: pp-custom-config
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   configuration:
     secretName: pp-configuration

--- a/docs/guides/pgpool/configuration/using-init-config.md
+++ b/docs/guides/pgpool/configuration/using-init-config.md
@@ -55,7 +55,7 @@ metadata:
   name: pp-init-config
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/guides/pgpool/configuration/using-podtemplate.md
+++ b/docs/guides/pgpool/configuration/using-podtemplate.md
@@ -75,7 +75,7 @@ metadata:
   name: pp-misc-config
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres
@@ -208,7 +208,7 @@ metadata:
   name: pgpool-custom-sidecar
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres
@@ -356,7 +356,7 @@ metadata:
   name: pgpool-node-selector
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres
@@ -448,7 +448,7 @@ metadata:
   name: pgpool-without-tolerations
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres
@@ -546,7 +546,7 @@ metadata:
   name: pgpool-with-tolerations
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/guides/pgpool/custom-rbac/using-custom-rbac.md
+++ b/docs/guides/pgpool/custom-rbac/using-custom-rbac.md
@@ -136,7 +136,7 @@ metadata:
   name: pgpool
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres
@@ -310,7 +310,7 @@ metadata:
   name: pgpool-new
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/guides/pgpool/initializing/git-sync.md
+++ b/docs/guides/pgpool/initializing/git-sync.md
@@ -43,7 +43,7 @@ Prepare a KubeDB Postgres cluster using this [tutorial](/docs/guides/postgres/cl
 
 ### Prepare Pgpool
 
-Now, we are going to deploy a `Pgpool` with version `4.4.5`.
+Now, we are going to deploy a `Pgpool` with version `4.6.0`.
 
 ## From Public Git Repository
 
@@ -58,7 +58,7 @@ metadata:
   name: pgpool
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: postgres
@@ -159,7 +159,7 @@ metadata:
   name: pgpool
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: postgres
@@ -250,7 +250,7 @@ metadata:
   name: pgpool
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: postgres

--- a/docs/guides/pgpool/monitoring/overview.md
+++ b/docs/guides/pgpool/monitoring/overview.md
@@ -53,7 +53,7 @@ metadata:
   name: sample-pgpool
   namespace: databases
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   deletionPolicy: WipeOut
   postgresRef:
     name: ha-postgres

--- a/docs/guides/pgpool/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/pgpool/monitoring/using-builtin-prometheus.md
@@ -52,7 +52,7 @@ metadata:
   name: builtin-prom-pp
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   deletionPolicy: WipeOut
   postgresRef:
     name: ha-postgres

--- a/docs/guides/pgpool/monitoring/using-prometheus-operator.md
+++ b/docs/guides/pgpool/monitoring/using-prometheus-operator.md
@@ -186,7 +186,7 @@ metadata:
   name: coreos-prom-pp
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   postgresRef:
     name: ha-postgres
     namespace: demo

--- a/docs/guides/pgpool/quickstart/quickstart.md
+++ b/docs/guides/pgpool/quickstart/quickstart.md
@@ -56,7 +56,7 @@ $ kubectl get pgpoolversions
 
 Notice the `DEPRECATED` column. Here, `true` means that this PgpoolVersion is deprecated for current KubeDB version. KubeDB will not work for deprecated PgpoolVersion.
 
-In this tutorial, we will use `4.5.0` PgpoolVersion CRD to create Pgpool. To know more about what `PgpoolVersion` CRD is, please visit [here](/docs/guides/pgpool/concepts/catalog.md). You can also see supported PgpoolVersion [here](/docs/guides/pgpool/README.md#supported-pgpoolversion-CRD).
+In this tutorial, we will use `4.6.0` PgpoolVersion CRD to create Pgpool. To know more about what `PgpoolVersion` CRD is, please visit [here](/docs/guides/pgpool/concepts/catalog.md). You can also see supported PgpoolVersion [here](/docs/guides/pgpool/README.md#supported-pgpoolversion-CRD).
 
 ## Get PostgreSQL Server ready
 
@@ -164,7 +164,7 @@ metadata:
   name: quick-pgpool
   namespace: pool
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: quick-postgres
@@ -177,7 +177,7 @@ spec:
 
 Here,
 
-- `spec.version` is name of the PgpoolVersion CRD where the docker images are specified. In this tutorial, a Pgpool with base image version `4.5.0` is created.
+- `spec.version` is name of the PgpoolVersion CRD where the docker images are specified. In this tutorial, a Pgpool with base image version `4.6.0` is created.
 - `spec.replicas` specifies the number of replica pgpool server pods to be created for the Pgpool object.
 - `spec.postgresRef` specifies the name and the namespace of the appbinding that points to the PostgreSQL server.
 - `spec.sslMode` specifies ssl mode for clients.

--- a/docs/guides/pgpool/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/pgpool/reconfigure-tls/reconfigure-tls.md
@@ -51,7 +51,7 @@ metadata:
   name: pgpool
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/guides/pgpool/reconfigure/reconfigure-pgpool.md
+++ b/docs/guides/pgpool/reconfigure/reconfigure-pgpool.md
@@ -44,7 +44,7 @@ Now, we are going to deploy a  `Pgpool` using a supported version by `KubeDB` op
 
 ### Prepare Pgpool
 
-Now, we are going to deploy a `Pgpool` with version `4.5.0`.
+Now, we are going to deploy a `Pgpool` with version `4.6.0`.
 
 ### Deploy Pgpool 
 
@@ -72,7 +72,7 @@ metadata:
   name: pp-custom
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   configuration:
     secretName: pp-custom-config

--- a/docs/guides/pgpool/restart/restart.md
+++ b/docs/guides/pgpool/restart/restart.md
@@ -45,7 +45,7 @@ metadata:
   name: pgpool
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/guides/pgpool/scaling/horizontal-scaling/horizontal-ops.md
+++ b/docs/guides/pgpool/scaling/horizontal-scaling/horizontal-ops.md
@@ -45,7 +45,7 @@ Prepare a KubeDB Postgres cluster using this [tutorial](/docs/guides/postgres/cl
 
 ### Prepare Pgpool
 
-Now, we are going to deploy a `Pgpool` with version `4.5.0`.
+Now, we are going to deploy a `Pgpool` with version `4.6.0`.
 
 ### Deploy Pgpool 
 
@@ -58,7 +58,7 @@ metadata:
   name: pp-horizontal
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/guides/pgpool/scaling/vertical-scaling/vertical-ops.md
+++ b/docs/guides/pgpool/scaling/vertical-scaling/vertical-ops.md
@@ -45,7 +45,7 @@ Prepare a KubeDB Postgres cluster using this [tutorial](/docs/guides/postgres/cl
 
 ### Prepare Pgpool
 
-Now, we are going to deploy a `Pgpool` with version `4.5.0`.
+Now, we are going to deploy a `Pgpool` with version `4.6.0`.
 
 ### Deploy Pgpool 
 
@@ -58,7 +58,7 @@ metadata:
   name: pp-vertical
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/guides/pgpool/sync-users/sync-users-pgpool.md
+++ b/docs/guides/pgpool/sync-users/sync-users-pgpool.md
@@ -65,7 +65,7 @@ For a Pgpool surely we will need a Postgres server so, prepare a KubeDB Postgres
 
 ### Prepare Pgpool
 
-Now, we are going to deploy a `Pgpool` with version `4.5.0`.
+Now, we are going to deploy a `Pgpool` with version `4.6.0`.
 
 ### Deploy Pgpool
 
@@ -78,7 +78,7 @@ metadata:
   name: pgpool-sync
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   syncUsers: true
   postgresRef:

--- a/docs/guides/pgpool/tls/configure_ssl.md
+++ b/docs/guides/pgpool/tls/configure_ssl.md
@@ -122,7 +122,7 @@ metadata:
   name: pp-tls
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: ha-postgres

--- a/docs/guides/pgpool/update-version/update_version.md
+++ b/docs/guides/pgpool/update-version/update_version.md
@@ -41,7 +41,7 @@ Prepare a KubeDB Postgres cluster using this [tutorial](/docs/guides/postgres/cl
 
 ### Prepare Pgpool
 
-Now, we are going to deploy a `Pgpool` =with version `4.4.5`.
+Now, we are going to deploy a `Pgpool` =with version `4.5.3`.
 
 ### Deploy Pgpool:
 
@@ -54,7 +54,7 @@ metadata:
   name: pp-update
   namespace: demo
 spec:
-  version: "4.4.5"
+  version: "4.5.3"
   replicas: 1
   postgresRef:
     name: ha-postgres
@@ -81,7 +81,7 @@ We are now ready to apply the `PgpoolOpsRequest` CR to update this Pgpool.
 
 ### update Pgpool Version
 
-Here, we are going to update `Pgpool` from `4.4.5` to `4.5.0`.
+Here, we are going to update `Pgpool` from `4.5.3` to `4.6.0`.
 
 #### Create PgpoolOpsRequest:
 
@@ -98,14 +98,14 @@ spec:
   databaseRef:
     name: pp-update
   updateVersion:
-    targetVersion: 4.5.0
+    targetVersion: 4.6.0
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `pp-update` Pgpool.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our Pgpool.
-- `spec.updateVersion.targetVersion` specifies the expected version of the Pgpool `4.5.0`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the Pgpool `4.6.0`.
 
 
 Let's create the `PgpoolOpsRequest` CR we have shown above,

--- a/docs/guides/pgpool/virtual_secret/guide.md
+++ b/docs/guides/pgpool/virtual_secret/guide.md
@@ -286,7 +286,7 @@ metadata:
   name: pp-vs
   namespace: demo
 spec:
-  version: "4.5.0"
+  version: "4.6.0"
   replicas: 1
   postgresRef:
     name: quick-postgres


### PR DESCRIPTION
Bumps the **pgpool** example and guide manifests to the latest supported version (`4.6.0`) per the installer `active_versions.json`.

- General "deploy a pgpool" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.