### PR TITLE
Update postgres docs examples to latest supported version (18.3)

### DIFF
--- a/docs/examples/postgres/arbiter/arbiter-pg.yaml
+++ b/docs/examples/postgres/arbiter/arbiter-pg.yaml
@@ -20,4 +20,4 @@ spec:
     resources:
       requests:
         storage: 1Gi
-  version: "16.1"
+  version: "18.3"

--- a/docs/examples/postgres/autoscaler/compute/ha-postgres.yaml
+++ b/docs/examples/postgres/autoscaler/compute/ha-postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ha-postgres
   namespace: demo
 spec:
-  version: "16.1"
+  version: "18.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/examples/postgres/autoscaler/storage/ha-postgres.yaml
+++ b/docs/examples/postgres/autoscaler/storage/ha-postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ha-postgres
   namespace: demo
 spec:
-  version: "16.1"
+  version: "18.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/examples/postgres/clustering/ha-postgres.yaml
+++ b/docs/examples/postgres/clustering/ha-postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ha-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/examples/postgres/clustering/hot-postgres.yaml
+++ b/docs/examples/postgres/clustering/hot-postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hot-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Durable

--- a/docs/examples/postgres/configuration/pg-tuning.yaml
+++ b/docs/examples/postgres/configuration/pg-tuning.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pg-ha-tuning
   namespace: demo
 spec:
-  version: "17.4"
+  version: "18.3"
   replicas: 3
   configuration:
     tuning:

--- a/docs/examples/postgres/custom-config/pg-custom-config.yaml
+++ b/docs/examples/postgres/custom-config/pg-custom-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   configuration:
     secretName: pg-custom-config
   storage:

--- a/docs/examples/postgres/custom-rbac/pg-custom-db-two.yaml
+++ b/docs/examples/postgres/custom-rbac/pg-custom-db-two.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/instance: quick-postgres
 spec:
-  version: "13.13"
+  version: "18.3"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/examples/postgres/custom-rbac/pg-custom-db.yaml
+++ b/docs/examples/postgres/custom-rbac/pg-custom-db.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/instance: quick-postgres
 spec:
-  version: "13.13"
+  version: "18.3"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/examples/postgres/gitops/postgres.yaml
+++ b/docs/examples/postgres/gitops/postgres.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "16.6"
+  version: "18.3"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/examples/postgres/initialization/script-postgres.yaml
+++ b/docs/examples/postgres/initialization/script-postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: script-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/postgres/migration/sample-postgres.yaml
+++ b/docs/examples/postgres/migration/sample-postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Durable

--- a/docs/examples/postgres/monitoring/builtin-prom-postgres.yaml
+++ b/docs/examples/postgres/monitoring/builtin-prom-postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/examples/postgres/monitoring/coreos-prom-postgres.yaml
+++ b/docs/examples/postgres/monitoring/coreos-prom-postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coreos-prom-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/examples/postgres/pg-overview.yaml
+++ b/docs/examples/postgres/pg-overview.yaml
@@ -4,7 +4,7 @@ metadata:
   name: p1
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 2
   standbyMode: Hot
   streamingMode: Asynchronous

--- a/docs/examples/postgres/quickstart/instant-postgres.yaml
+++ b/docs/examples/postgres/quickstart/instant-postgres.yaml
@@ -4,5 +4,5 @@ metadata:
   name: instant-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   storageType: Ephemeral

--- a/docs/examples/postgres/quickstart/quick-postgres-v1.yaml
+++ b/docs/examples/postgres/quickstart/quick-postgres-v1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: quick-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/postgres/quickstart/quick-postgres-v1alpha2.yaml
+++ b/docs/examples/postgres/quickstart/quick-postgres-v1alpha2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: quick-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/postgres/reconfigure-tls/ha-postgres.yaml
+++ b/docs/examples/postgres/reconfigure-tls/ha-postgres.yaml
@@ -14,4 +14,4 @@ spec:
     resources:
       requests:
         storage: 1Gi
-  version: "13.13"
+  version: "18.3"

--- a/docs/examples/postgres/reconfigure/ha-postgres.yaml
+++ b/docs/examples/postgres/reconfigure/ha-postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ha-postgres
   namespace: demo
 spec:
-  version: "16.1"
+  version: "18.3"
   replicas: 3
   configuration:
     secretName: pg-configuration

--- a/docs/examples/postgres/restart/postgres.yaml
+++ b/docs/examples/postgres/restart/postgres.yaml
@@ -14,4 +14,4 @@ spec:
     resources:
       requests:
         storage: 1Gi
-  version: "13.13"
+  version: "18.3"

--- a/docs/examples/postgres/synchronous/postgres.yaml
+++ b/docs/examples/postgres/synchronous/postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: demo-pg
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   streamingMode: Synchronous

--- a/docs/examples/postgres/virtual_secret/postgres.yaml
+++ b/docs/examples/postgres/virtual_secret/postgres.yaml
@@ -18,4 +18,4 @@ spec:
         storage: 1Gi
   storageType: Durable
   deletionPolicy: WipeOut
-  version: "17.5"
+  version: "18.3"

--- a/docs/examples/postgres/volume-expansion/pg-ha-cluster.yaml
+++ b/docs/examples/postgres/volume-expansion/pg-ha-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pg-ha-cluster
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Durable

--- a/docs/examples/postgres/volume-expansion/pg-standalone.yaml
+++ b/docs/examples/postgres/volume-expansion/pg-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pg-standalone
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 1
   standbyMode: Hot
   storageType: Durable

--- a/docs/guides/postgres/autoscaler/compute/cluster.md
+++ b/docs/guides/postgres/autoscaler/compute/cluster.md
@@ -41,7 +41,7 @@ Here, we are going to deploy a `Postgres` Cluster using a supported version by `
 
 #### Deploy Postgres Cluster
 
-In this section, we are going to deploy a Postgres Cluster with version `16.1`. Then, in the next section we will set up autoscaling for this database using `PostgresAutoscaler` CRD. Below is the YAML of the `Postgres` CR that we are going to create,
+In this section, we are going to deploy a Postgres Cluster with version `18.3`. Then, in the next section we will set up autoscaling for this database using `PostgresAutoscaler` CRD. Below is the YAML of the `Postgres` CR that we are going to create,
 > If you want to autoscale Postgres `Standalone`, Just remove the `spec.Replicas` from the below yaml and rest of the steps are same.
 
 ```yaml
@@ -51,7 +51,7 @@ metadata:
   name: ha-postgres
   namespace: demo
 spec:
-  version: "16.1"
+  version: "18.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/postgres/autoscaler/storage/cluster.md
+++ b/docs/guides/postgres/autoscaler/storage/cluster.md
@@ -57,7 +57,7 @@ Now, we are going to deploy a `Postgres` cluster using a supported version by `K
 
 #### Deploy Postgres Cluster
 
-In this section, we are going to deploy a Postgres cluster database with version `16.1`.  Then, in the next section we will set up autoscaling for this database using `PostgresAutoscaler` CRD. Below is the YAML of the `Postgres` CR that we are going to create,
+In this section, we are going to deploy a Postgres cluster database with version `18.3`.  Then, in the next section we will set up autoscaling for this database using `PostgresAutoscaler` CRD. Below is the YAML of the `Postgres` CR that we are going to create,
 
 > If you want to autoscale Postgres `Standalone`, Just remove the `spec.Replicas` from the below yaml and rest of the steps are same.
 
@@ -68,7 +68,7 @@ metadata:
   name: ha-postgres
   namespace: demo
 spec:
-  version: "16.1"
+  version: "18.3"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/postgres/backup/kubestash/application-level/index.md
+++ b/docs/guides/postgres/backup/kubestash/application-level/index.md
@@ -65,7 +65,7 @@ metadata:
   name: sample-postgres
   namespace: demo
 spec:
-  version: "16.1"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   streamingMode: Synchronous
@@ -179,7 +179,7 @@ spec:
   secret:
     name: sample-postgres-auth
   type: kubedb.com/postgres
-  version: "16.1"
+  version: "18.3"
 ```
 
 KubeStash uses the `AppBinding` CR to connect with the target database. It requires the following two fields to set in AppBinding's `.spec` section.

--- a/docs/guides/postgres/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/postgres/backup/kubestash/auto-backup/index.md
@@ -221,7 +221,7 @@ metadata:
     blueprint.kubestash.com/name: postgres-default-backup-blueprint
     blueprint.kubestash.com/namespace: demo
 spec:
-  version: "16.1"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   streamingMode: Synchronous
@@ -580,7 +580,7 @@ metadata:
     variables.kubestash.com/targetName: sample-postgres-2
     variables.kubestash.com/targetedDatabase: postgres
 spec:
-  version: "16.1"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   streamingMode: Synchronous

--- a/docs/guides/postgres/backup/kubestash/logical/index.md
+++ b/docs/guides/postgres/backup/kubestash/logical/index.md
@@ -68,7 +68,7 @@ metadata:
   name: sample-postgres
   namespace: demo
 spec:
-  version: "16.1"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   streamingMode: Synchronous
@@ -182,7 +182,7 @@ spec:
   secret:
     name: sample-postgres-auth
   type: kubedb.com/postgres
-  version: "16.1"
+  version: "18.3"
 ```
 
 KubeStash uses the `AppBinding` CR to connect with the target database. It requires the following two fields to set in AppBinding's `.spec` section.
@@ -609,7 +609,7 @@ metadata:
 spec:
   init:
     waitForInitialRestore: true
-  version: "16.1"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   streamingMode: Synchronous

--- a/docs/guides/postgres/backup/stash/auto-backup/index.md
+++ b/docs/guides/postgres/backup/stash/auto-backup/index.md
@@ -137,7 +137,7 @@ metadata:
   annotations:
     stash.appscode.com/backup-blueprint: postgres-backup-template
 spec:
-  version: "11.22"
+  version: "18.3"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -306,7 +306,7 @@ metadata:
     stash.appscode.com/backup-blueprint: postgres-backup-template
     stash.appscode.com/schedule: "*/3 * * * *"
 spec:
-  version: "11.22"
+  version: "18.3"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -476,7 +476,7 @@ metadata:
     stash.appscode.com/backup-blueprint: postgres-backup-template
     params.stash.appscode.com/args: --no-owner --clean
 spec:
-  version: "11.22"
+  version: "18.3"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/postgres/backup/stash/standalone/index.md
+++ b/docs/guides/postgres/backup/stash/standalone/index.md
@@ -58,7 +58,7 @@ metadata:
   name: sample-postgres
   namespace: demo
 spec:
-  version: "11.22"
+  version: "18.3"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -151,7 +151,7 @@ spec:
         restoreTask:
           name: postgres-restore-11.9
   type: kubedb.com/postgres
-  version: "11.22"
+  version: "18.3"
 ```
 
 Stash uses the `AppBinding` crd to connect with the target database. It requires the following two fields to set in AppBinding's `Spec` section.
@@ -423,7 +423,7 @@ metadata:
   name: restored-postgres
   namespace: demo
 spec:
-  version: "11.22"
+  version: "18.3"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/postgres/cli/cli.md
+++ b/docs/guides/postgres/cli/cli.md
@@ -65,7 +65,7 @@ metadata:
 spec:
   authSecret:
     name: postgres-demo-auth
-  version: "13.13"
+  version: "18.3"
 status:
   creationTime: 2017-12-12T05:46:16Z
   phase: Running

--- a/docs/guides/postgres/clustering/arbiter.md
+++ b/docs/guides/postgres/clustering/arbiter.md
@@ -65,7 +65,7 @@ spec:
     resources:
       requests:
         storage: 1Gi
-  version: "16.1"
+  version: "18.3"
 ```
 A petset with the name `{{ dbName }}-arbiter` should be created once you apply this yaml. 
 

--- a/docs/guides/postgres/clustering/ha_cluster.md
+++ b/docs/guides/postgres/clustering/ha_cluster.md
@@ -34,7 +34,7 @@ metadata:
   name: warm-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Warm
   storageType: Ephemeral
@@ -58,7 +58,7 @@ metadata:
   name: hot-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Ephemeral

--- a/docs/guides/postgres/clustering/streaming_replication.md
+++ b/docs/guides/postgres/clustering/streaming_replication.md
@@ -43,7 +43,7 @@ metadata:
   name: ha-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   storageType: Durable
   storage:
@@ -286,7 +286,7 @@ metadata:
   name: hot-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Durable

--- a/docs/guides/postgres/concepts/postgres-gitops.md
+++ b/docs/guides/postgres/concepts/postgres-gitops.md
@@ -33,7 +33,7 @@ metadata:
   name: p1
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 2
   standbyMode: Hot
   streamingMode: Asynchronous
@@ -279,7 +279,7 @@ metadata:
   name: postgres-db
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   init:
     script:
       configMap:

--- a/docs/guides/postgres/concepts/postgres.md
+++ b/docs/guides/postgres/concepts/postgres.md
@@ -31,7 +31,7 @@ metadata:
   name: p1
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 2
   standbyMode: Hot
   streamingMode: Asynchronous
@@ -241,7 +241,7 @@ metadata:
   name: postgres-db
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   init:
     script:
       configMap:

--- a/docs/guides/postgres/configuration/pgtune.md
+++ b/docs/guides/postgres/configuration/pgtune.md
@@ -86,7 +86,7 @@ metadata:
   name: pg-ha-tuning
   namespace: demo
 spec:
-  version: "17.4"
+  version: "18.3"
   replicas: 3
   configuration:
     tuning:

--- a/docs/guides/postgres/configuration/using-config-file.md
+++ b/docs/guides/postgres/configuration/using-config-file.md
@@ -93,7 +93,7 @@ metadata:
   name: custom-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   configuration:
     secretName: pg-configuration
   storage:

--- a/docs/guides/postgres/custom-rbac/using-custom-rbac.md
+++ b/docs/guides/postgres/custom-rbac/using-custom-rbac.md
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/instance: quick-postgres
 spec:
-  version: "13.13"
+  version: "18.3"
   storageType: Durable
   podTemplate:
     spec:
@@ -301,7 +301,7 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/instance: quick-postgres
 spec:
-  version: "13.13"
+  version: "18.3"
   storageType: Durable
   podTemplate:
     spec:

--- a/docs/guides/postgres/distributed/overview/index.md
+++ b/docs/guides/postgres/distributed/overview/index.md
@@ -751,7 +751,7 @@ spec:
       requests:
         storage: 2Gi
   storageType: Durable
-  version: "17.2"
+  version: "18.3"
   podTemplate:
     spec:
       podPlacementPolicy:

--- a/docs/guides/postgres/distributed/overview/yamls/postgres.yaml
+++ b/docs/guides/postgres/distributed/overview/yamls/postgres.yaml
@@ -14,7 +14,7 @@ spec:
       requests:
         storage: 500Mi
   storageType: Durable
-  version: "17.2"
+  version: "18.3"
   podTemplate:
     spec:
       podPlacementPolicy:

--- a/docs/guides/postgres/failure-and-disaster-recovery/failure_and_disaster_recovery.md
+++ b/docs/guides/postgres/failure-and-disaster-recovery/failure_and_disaster_recovery.md
@@ -71,7 +71,7 @@ spec:
     resources:
       requests:
         storage: 7Gi
-  version: "17.2"
+  version: "18.3"
 ```
 
 Now, create the namespace and apply the manifest:

--- a/docs/guides/postgres/gitops/gitops.md
+++ b/docs/guides/postgres/gitops/gitops.md
@@ -76,7 +76,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "16.6"
+  version: "17.9"
   storageType: Durable
   podTemplate:
     spec:
@@ -157,7 +157,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "16.6"
+  version: "17.9"
   storageType: Durable
   podTemplate:
     spec:
@@ -219,7 +219,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 5
-  version: "16.6"
+  version: "17.9"
   storageType: Durable
   podTemplate:
     spec:
@@ -281,7 +281,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 5
-  version: "16.6"
+  version: "17.9"
   storageType: Durable
   podTemplate:
     spec:
@@ -370,7 +370,7 @@ spec:
   configuration:
     secretName: pg-configuration
   replicas: 5
-  version: "16.6"
+  version: "17.9"
   storageType: Durable
   podTemplate:
     spec:
@@ -478,7 +478,7 @@ spec:
   configuration:
     secretName: pg-configuration
   replicas: 5
-  version: "16.6"
+  version: "17.9"
   storageType: Durable
   podTemplate:
     spec:
@@ -595,7 +595,7 @@ spec:
   configuration:
     secretName: pg-configuration
   replicas: 5
-  version: "16.6"
+  version: "17.9"
   storageType: Durable
   sslMode: verify-full
   tls:
@@ -668,7 +668,7 @@ Type "help" for help.
 
 List postgres versions using `kubectl get postgresversion` and choose desired version that is compatible for upgrade from current version. Check the version constraints and ops request [here](/docs/guides/postgres/update-version/versionupgrading/index.md).
 
-Let's choose `17.4` in this example.
+Let's choose `18.3` in this example.
 
 Update the `postgres.yaml` with the following, 
 ```yaml
@@ -684,7 +684,7 @@ spec:
   configuration:
     secretName: pg-configuration
   replicas: 5
-  version: "17.4"
+  version: "18.3"
   storageType: Durable
   sslMode: verify-full
   tls:
@@ -721,7 +721,7 @@ spec:
   deletionPolicy: WipeOut
 ```
 
-Update the `version` field to `17.4`. Commit the changes and push to your Git repository. Your repository is synced with `ArgoCD` and the `Postgres` CR is updated in your cluster.
+Update the `version` field to `18.3`. Commit the changes and push to your Git repository. Your repository is synced with `ArgoCD` and the `Postgres` CR is updated in your cluster.
 
 Now, `gitops` operator will detect the version changes and create a `VersionUpdate` PostgresOpsRequest to update the `Postgres` database version. List the resources created by `gitops` operator in the `demo` namespace.
 
@@ -774,7 +774,7 @@ spec:
   configuration:
     secretName: pg-configuration
   replicas: 5
-  version: "17.4"
+  version: "18.3"
   storageType: Durable
   sslMode: verify-full
   tls:

--- a/docs/guides/postgres/initialization/script_source.md
+++ b/docs/guides/postgres/initialization/script_source.md
@@ -62,7 +62,7 @@ metadata:
   name: script-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/postgres/migration/storageMigration.md
+++ b/docs/guides/postgres/migration/storageMigration.md
@@ -58,7 +58,7 @@ metadata:
   name: sample-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Durable

--- a/docs/guides/postgres/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/postgres/monitoring/using-builtin-prometheus.md
@@ -49,7 +49,7 @@ metadata:
   name: builtin-prom-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/postgres/monitoring/using-prometheus-operator.md
+++ b/docs/guides/postgres/monitoring/using-prometheus-operator.md
@@ -95,7 +95,7 @@ metadata:
   name: coreos-prom-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/postgres/pitr/archiver.md
+++ b/docs/guides/postgres/pitr/archiver.md
@@ -217,7 +217,7 @@ metadata:
   labels:
     archiver: "true"
 spec:
-  version: "17.8"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Durable
@@ -366,7 +366,7 @@ spec:
         name: demo-pg-manifest
         namespace: demo
       recoveryTimestamp: "2023-12-12T13:43:41.300216Z"
-  version: "17.8"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Durable

--- a/docs/guides/postgres/quickstart/quickstart.md
+++ b/docs/guides/postgres/quickstart/quickstart.md
@@ -131,7 +131,7 @@ timescaledb-2.5.0-pg14.1   14.1      TimescaleDB    timescale/timescaledb:2.5.0-
 
 Notice the `DEPRECATED` column. Here, `true` means that this PostgresVersion is deprecated for current KubeDB version. KubeDB will not work for deprecated PostgresVersion.
 
-In this tutorial, we will use `13.2` PostgresVersion crd to create PostgreSQL database. To know more about what is `PostgresVersion` crd and why there is `13.2` and `13.2-debian` variation, please visit [here](/docs/guides/postgres/concepts/catalog.md). You can also see supported PostgresVersion [here](/docs/guides/postgres/README.md#supported-postgresversion-crd).
+In this tutorial, we will use `18.3` PostgresVersion crd to create PostgreSQL database. To know more about what is `PostgresVersion` crd and why there is `13.2` and `13.2-debian` variation, please visit [here](/docs/guides/postgres/concepts/catalog.md). You can also see supported PostgresVersion [here](/docs/guides/postgres/README.md#supported-postgresversion-crd).
 
 ## Create a PostgreSQL database
 
@@ -148,7 +148,7 @@ metadata:
   name: quick-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -172,7 +172,7 @@ metadata:
   name: quick-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -191,7 +191,7 @@ postgres.kubedb.com/quick-postgres created
 
 Here,
 
-- `spec.version` is name of the PostgresVersion crd where the docker images are specified. In this tutorial, a PostgreSQL 13.2 database is created.
+- `spec.version` is name of the PostgresVersion crd where the docker images are specified. In this tutorial, a PostgreSQL 18.3 database is created.
 - `spec.storageType` specifies the type of storage that will be used for Postgres database. It can be `Durable` or `Ephemeral`. Default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create Postgres database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.storage` specifies the size and StorageClass of PVC that will be dynamically allocated to store data for this database. This storage spec will be passed to the StatefulSet created by KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests. If you don't specify `spec.storageType: Ephemeral`, then this field is required.
 - `spec.terminationPolicy` or `spec.deletionPolicy` specifies what KubeDB should do when user try to delete Postgres crd. Termination policy `DoNotTerminate` prevents a user from deleting this object if admission webhook is enabled.

--- a/docs/guides/postgres/quickstart/rbac.md
+++ b/docs/guides/postgres/quickstart/rbac.md
@@ -52,7 +52,7 @@ metadata:
   name: quick-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/postgres/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/postgres/reconfigure-tls/reconfigure-tls.md
@@ -58,7 +58,7 @@ spec:
     resources:
       requests:
         storage: 1Gi
-  version: "13.13"
+  version: "18.3"
 ```
 
 Let's create the `Postgres` CR we have shown above,

--- a/docs/guides/postgres/reconfigure/cluster.md
+++ b/docs/guides/postgres/reconfigure/cluster.md
@@ -39,7 +39,7 @@ Now, we are going to deploy a  `Postgres` Cluster using a supported version by `
 
 ### Prepare Postgres Cluster
 
-Now, we are going to deploy a `Postgres` Cluster database with version `16.1`.
+Now, we are going to deploy a `Postgres` Cluster database with version `18.3`.
 
 ### Deploy Postgres
 
@@ -67,7 +67,7 @@ metadata:
   name: ha-postgres
   namespace: demo
 spec:
-  version: "16.1"
+  version: "18.3"
   replicas: 3
   configuration:
     secretName: pg-configuration

--- a/docs/guides/postgres/remote-replica/remotereplica.md
+++ b/docs/guides/postgres/remote-replica/remotereplica.md
@@ -144,7 +144,7 @@ spec:
     storageClassName: linode-block-storage
   storageType: Durable
   deletionPolicy: WipeOut
-  version: "15.5"
+  version: "18.3"
 ```
 
 ```bash
@@ -268,7 +268,7 @@ spec:
     storageClassName: linode-block-storage
   storageType: Durable
   deletionPolicy: WipeOut
-  version: "15.5"
+  version: "18.3"
 ```
 
 ```bash

--- a/docs/guides/postgres/remote-replica/yamls/pg-london.yaml
+++ b/docs/guides/postgres/remote-replica/yamls/pg-london.yaml
@@ -28,4 +28,4 @@ spec:
     storageClassName: linode-block-storage
   storageType: Durable
   deletionPolicy: WipeOut
-  version: "15.5"
+  version: "18.3"

--- a/docs/guides/postgres/remote-replica/yamls/pg-singapore.yaml
+++ b/docs/guides/postgres/remote-replica/yamls/pg-singapore.yaml
@@ -39,4 +39,4 @@ spec:
     storageClassName: linode-block-storage
   storageType: Durable
   deletionPolicy: WipeOut
-  version: "15.5"
+  version: "18.3"

--- a/docs/guides/postgres/restart/restart.md
+++ b/docs/guides/postgres/restart/restart.md
@@ -52,7 +52,7 @@ spec:
     resources:
       requests:
         storage: 1Gi
-  version: "13.13"
+  version: "18.3"
 ```
 
 Let's create the `Postgres` CR we have shown above,

--- a/docs/guides/postgres/rotate-authentication/rotateauth.md
+++ b/docs/guides/postgres/rotate-authentication/rotateauth.md
@@ -45,7 +45,7 @@ metadata:
   name: quick-postgres
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   storageType: Durable
   storage:
      storageClassName: "standard"

--- a/docs/guides/postgres/scaling/horizontal-scaling/scale-horizontally/index.md
+++ b/docs/guides/postgres/scaling/horizontal-scaling/scale-horizontally/index.md
@@ -83,7 +83,7 @@ timescaledb-2.1.0-pg13     13.2      TimescaleDB    timescale/timescaledb:2.1.0-
 timescaledb-2.5.0-pg14.1   14.1      TimescaleDB    timescale/timescaledb:2.5.0-pg14-oss                63s
 ```
 
-The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `Postgres`. You can use any non-deprecated version. Here, we are going to create a Postgres Cluster using `Postgres` `13.2`.
+The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `Postgres`. You can use any non-deprecated version. Here, we are going to create a Postgres Cluster using `Postgres` `18.3`.
 
 **Deploy Postgres Cluster:**
 
@@ -96,7 +96,7 @@ metadata:
   name: pg
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Durable

--- a/docs/guides/postgres/scaling/horizontal-scaling/scale-horizontally/yamls/postgres.yaml
+++ b/docs/guides/postgres/scaling/horizontal-scaling/scale-horizontally/yamls/postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pg
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Durable

--- a/docs/guides/postgres/scaling/vertical-scaling/scale-vertically/index.md
+++ b/docs/guides/postgres/scaling/vertical-scaling/scale-vertically/index.md
@@ -79,7 +79,7 @@ timescaledb-2.1.0-pg13     13.2      TimescaleDB    timescale/timescaledb:2.1.0-
 timescaledb-2.5.0-pg14.1   14.1      TimescaleDB    timescale/timescaledb:2.5.0-pg14-oss                63s
 ```
 
-The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `Postgres`. You can use any non-deprecated version. Here, we are going to create a postgres using non-deprecated `Postgres` version `13.2`.
+The version above that does not show `DEPRECATED` `true` is supported by `KubeDB` for `Postgres`. You can use any non-deprecated version. Here, we are going to create a postgres using non-deprecated `Postgres` version `18.3`.
 
 **Deploy Postgres:**
 
@@ -92,7 +92,7 @@ metadata:
   name: pg
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Durable

--- a/docs/guides/postgres/scaling/vertical-scaling/scale-vertically/yamls/postgres.yaml
+++ b/docs/guides/postgres/scaling/vertical-scaling/scale-vertically/yamls/postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pg
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Durable

--- a/docs/guides/postgres/synchronous/index.md
+++ b/docs/guides/postgres/synchronous/index.md
@@ -48,7 +48,7 @@ metadata:
   name: demo-pg
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   streamingMode: Synchronous

--- a/docs/guides/postgres/tls/configure/index.md
+++ b/docs/guides/postgres/tls/configure/index.md
@@ -85,7 +85,7 @@ metadata:
   name: pg
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   sslMode: verify-full

--- a/docs/guides/postgres/tls/configure/yamls/tls-postgres.yaml
+++ b/docs/guides/postgres/tls/configure/yamls/tls-postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pg
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   sslMode: verify-full

--- a/docs/guides/postgres/update-version/versionupgrading/index.md
+++ b/docs/guides/postgres/update-version/versionupgrading/index.md
@@ -171,7 +171,7 @@ metadata:
   name: pg
   namespace: demo
 spec:
-  version: "11.22"
+  version: "17.9"
   replicas: 3
   standbyMode: Hot
   storageType: Durable
@@ -239,7 +239,7 @@ We are ready to apply updating on this `Postgres` Instance.
 
 #### UpdateVersion
 
-Here, we are going to update `Postgres` Instance from `11.11` to `13.2`.
+Here, we are going to update `Postgres` Instance from `17.9` to `18.3`.
 
 **Create PostgresOpsRequest:**
 
@@ -254,7 +254,7 @@ metadata:
 spec:
   type: UpdateVersion
   updateVersion:
-    targetVersion: "13.13"
+    targetVersion: "18.3"
   databaseRef:
     name: pg
 ```
@@ -263,7 +263,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `pg-group` Postgres database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies expected version `13.2` after updating.
+- `spec.updateVersion.targetVersion` specifies expected version `18.3` after updating.
 
 Let's create the `PostgresOpsRequest` cr we have shown above,
 

--- a/docs/guides/postgres/update-version/versionupgrading/yamls/postgres.yaml
+++ b/docs/guides/postgres/update-version/versionupgrading/yamls/postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pg
   namespace: demo
 spec:
-  version: "11.22"
+  version: "17.9"
   replicas: 3
   standbyMode: Hot
   storageType: Durable

--- a/docs/guides/postgres/update-version/versionupgrading/yamls/upgrade_version.yaml
+++ b/docs/guides/postgres/update-version/versionupgrading/yamls/upgrade_version.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   type: UpdateVersion
   updateVersion:
-    targetVersion: "13.13"
+    targetVersion: "18.3"
   databaseRef:
     name: pg

--- a/docs/guides/postgres/virtual_secret/guide.md
+++ b/docs/guides/postgres/virtual_secret/guide.md
@@ -288,7 +288,7 @@ spec:
         storage: 1Gi
   storageType: Durable
   deletionPolicy: WipeOut
-  version: "17.5"
+  version: "18.3"
 ```
 Here,
 

--- a/docs/guides/postgres/volume-expansion/ha-cluster/HA Cluster.md
+++ b/docs/guides/postgres/volume-expansion/ha-cluster/HA Cluster.md
@@ -54,7 +54,7 @@ linode-block-storage  linodebs.csi.linode.com   Delete          Immediate       
 
 We can see the output from the `linode-block-storage` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We can use it.
 
-Now, we are going to deploy a `Postgres` HA cluster database with version `13.13`.
+Now, we are going to deploy a `Postgres` HA cluster database with version `18.3`.
 
 #### Deploy Postgres HA Cluster
 
@@ -67,7 +67,7 @@ metadata:
   name: pg-ha-cluster
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Durable

--- a/docs/guides/postgres/volume-expansion/ha-cluster/yamls/pg-ha-cluster.yaml
+++ b/docs/guides/postgres/volume-expansion/ha-cluster/yamls/pg-ha-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pg-ha-cluster
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 3
   standbyMode: Hot
   storageType: Durable

--- a/docs/guides/postgres/volume-expansion/standalone/standalone.md
+++ b/docs/guides/postgres/volume-expansion/standalone/standalone.md
@@ -54,7 +54,7 @@ linode-block-storage  linodebs.csi.linode.com   Delete          Immediate       
 
 We can see the output from the `linode-block-storage` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We can use it.
 
-Now, we are going to deploy a `Postgres` standalone database with version `13.13`.
+Now, we are going to deploy a `Postgres` standalone database with version `18.3`.
 
 #### Deploy Postgres standalone
 
@@ -67,7 +67,7 @@ metadata:
   name: pg-standalone
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 1
   standbyMode: Hot
   storageType: Durable

--- a/docs/guides/postgres/volume-expansion/standalone/yamls/pg-standalone.yaml
+++ b/docs/guides/postgres/volume-expansion/standalone/yamls/pg-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pg-standalone
   namespace: demo
 spec:
-  version: "13.13"
+  version: "18.3"
   replicas: 1
   standbyMode: Hot
   storageType: Durable


### PR DESCRIPTION
Bumps the **postgres** example and guide manifests to the latest supported version (`18.3`) per the installer `active_versions.json`.

- General "deploy a postgres" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.