### PR TITLE
Update proxysql docs examples to latest supported version (3.0.1-debian)

### DIFF
--- a/docs/examples/proxysql/builtin-prom-proxysql.yaml
+++ b/docs/examples/proxysql/builtin-prom-proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-proxysql
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 1
   backend:
     name: my-group

--- a/docs/examples/proxysql/coreos-prom-proxysql.yaml
+++ b/docs/examples/proxysql/coreos-prom-proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coreos-prom-proxysql
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 1
   backend:
     name: my-group

--- a/docs/examples/proxysql/custom-proxysql.yaml
+++ b/docs/examples/proxysql/custom-proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-proxysql
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 1
   backend:
     name: my-group

--- a/docs/examples/proxysql/demo-proxy-my-group.yaml
+++ b/docs/examples/proxysql/demo-proxy-my-group.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-my-group
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 1
   backend:
     name: mysql-server

--- a/docs/examples/proxysql/proxysql-private-registry.yaml
+++ b/docs/examples/proxysql/proxysql-private-registry.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxysql-pvt-reg
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 1
   backend:
     name: my-group

--- a/docs/guides/proxysql/autoscaler/compute/cluster/examples/sample-proxysql.yaml
+++ b/docs/guides/proxysql/autoscaler/compute/cluster/examples/sample-proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-server

--- a/docs/guides/proxysql/autoscaler/compute/cluster/index.md
+++ b/docs/guides/proxysql/autoscaler/compute/cluster/index.md
@@ -81,7 +81,7 @@ Here, we are going to deploy a `ProxySQL` Cluster using a supported version by `
 
 ### Deploy ProxySQL Cluster
 
-In this section, we are going to deploy a ProxySQL Cluster with version `2.3.2-debian`. Then, in the next section we will set up autoscaling for this database using `ProxySQLAutoscaler` CRD. Below is the YAML of the `ProxySQL` CR that we are going to create,
+In this section, we are going to deploy a ProxySQL Cluster with version `3.0.1-debian`. Then, in the next section we will set up autoscaling for this database using `ProxySQLAutoscaler` CRD. Below is the YAML of the `ProxySQL` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -90,7 +90,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-server
@@ -121,7 +121,7 @@ Now, wait until `proxy-server` has status `Ready`. i.e,
 ```bash
 $ kubectl get proxysql -n demo
 NAME             VERSION       STATUS   AGE
-proxy-server   2.3.2-debian    Ready    4m
+proxy-server   3.0.1-debian    Ready    4m
 ```
 
 Let's check the Pod containers resources,

--- a/docs/guides/proxysql/backends/mariadb-galera/examples/sample-proxysql.yaml
+++ b/docs/guides/proxysql/backends/mariadb-galera/examples/sample-proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mariadb-proxy
   namespace: demo
 spec:
-  version: "2.7.3-debian"
+  version: "3.0.1-debian"
   replicas: 3
   syncUsers: true
   backend:

--- a/docs/guides/proxysql/backends/mariadb-galera/index.md
+++ b/docs/guides/proxysql/backends/mariadb-galera/index.md
@@ -125,7 +125,7 @@ metadata:
   name: mariadb-proxy
   namespace: demo
 spec:
-  version: "2.7.3-debian"
+  version: "3.0.1-debian"
   replicas: 3
   syncUsers: true
   backend:
@@ -138,14 +138,14 @@ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >
 proxysql.kubedb.com/mariadb-proxy created
 ```
 
-Here in the `.spec.version` field we are saying that we want a ProxySQL-2.6.3 with base image of debian. In the `.spec.replicas` section we have given 3, so the operator will create 3 nodes for ProxySQL. The `spec.syncUser` field is set to  true, which means all the users in the backend MariaDB server will be fetched to the ProxySQL server.
+Here in the `.spec.version` field we are saying that we want a ProxySQL-3.0.1 with base image of debian. In the `.spec.replicas` section we have given 3, so the operator will create 3 nodes for ProxySQL. The `spec.syncUser` field is set to  true, which means all the users in the backend MariaDB server will be fetched to the ProxySQL server.
 
 Let's wait for the ProxySQL to be Ready. 
 
 ```bash
 $ kubectl get prx -n demo
 NAME            VERSION        STATUS   AGE
-mariadb-proxy   2.7.3-debian   Ready    96s
+mariadb-proxy   3.0.1-debian   Ready    96s
 ```
 
 Let's check the pods and associated kubernetes objects

--- a/docs/guides/proxysql/backends/mysqlgrp/examples/sample-proxysql.yaml
+++ b/docs/guides/proxysql/backends/mysqlgrp/examples/sample-proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mysql-proxy
   namespace: demo
 spec:
-  version: "2.7.3-debian"
+  version: "3.0.1-debian"
   replicas: 3
   syncUsers: true
   backend:

--- a/docs/guides/proxysql/backends/mysqlgrp/index.md
+++ b/docs/guides/proxysql/backends/mysqlgrp/index.md
@@ -145,7 +145,7 @@ metadata:
   name: mysql-proxy
   namespace: demo
 spec:
-  version: "2.7.3-debian"
+  version: "3.0.1-debian"
   replicas: 3
   syncUsers: true
   backend:
@@ -158,14 +158,14 @@ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >
 proxysql.kubedb.com/mysql-proxy created
 ```
 
-Here in the `.spec.version` field we are saying that we want a ProxySQL-2.6.3 with base image of debian. In the `.spec.replicas` section we have given 3, so the operator will create 3 nodes for ProxySQL. The `spec.syncUser` field is set to  true, which means all the users in the backend MySQL server will be fetched to the ProxySQL server.
+Here in the `.spec.version` field we are saying that we want a ProxySQL-3.0.1 with base image of debian. In the `.spec.replicas` section we have given 3, so the operator will create 3 nodes for ProxySQL. The `spec.syncUser` field is set to  true, which means all the users in the backend MySQL server will be fetched to the ProxySQL server.
 
 Let's wait for the ProxySQL to be Ready. 
 
 ```bash
 $ kubectl get prx -n demo
 NAME          VERSION        STATUS   AGE
-mysql-proxy   2.7.3-debian   Ready    109s
+mysql-proxy   3.0.1-debian   Ready    109s
 ```
 
 Let's check the pods and associated kubernetes objects

--- a/docs/guides/proxysql/backends/xtradb-galera/external/examples/sample-proxy-v1.yaml
+++ b/docs/guides/proxysql/backends/xtradb-galera/external/examples/sample-proxy-v1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 1
   syncUsers: true
   backend:

--- a/docs/guides/proxysql/backends/xtradb-galera/external/examples/sample-proxy-v1alpha2.yaml
+++ b/docs/guides/proxysql/backends/xtradb-galera/external/examples/sample-proxy-v1alpha2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 1
   syncUsers: true
   backend:

--- a/docs/guides/proxysql/backends/xtradb-galera/external/index.md
+++ b/docs/guides/proxysql/backends/xtradb-galera/external/index.md
@@ -278,7 +278,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 1
   syncUsers: true
   backend:
@@ -299,7 +299,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 1
   syncUsers: true
   backend:
@@ -312,14 +312,14 @@ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >
   proxysql.kubedb.com/proxysql-server created
 ```
 
-This is the simplest version of a KubeDB ProxySQL server. Here in the `.spec.version` field we are saying that we want a ProxySQL-2.4.4 with base image of debian. In the `.spec.replicas` section we have written 1, so the operator will create a single node ProxySQL. The `spec.syncUser` field is set to  true, which means all the users in the backend MySQL server will be fetched to the ProxySQL server. 
+This is the simplest version of a KubeDB ProxySQL server. Here in the `.spec.version` field we are saying that we want a ProxySQL-3.0.1 with base image of debian. In the `.spec.replicas` section we have written 1, so the operator will create a single node ProxySQL. The `spec.syncUser` field is set to  true, which means all the users in the backend MySQL server will be fetched to the ProxySQL server. 
 
 Let's wait for the ProxySQL to be Ready. 
 
 ```bash
 $ kubectl get proxysql -n demo
 NAME           VERSION        STATUS   AGE
-proxy-server   2.4.4-debian   Ready    4m
+proxy-server   3.0.1-debian   Ready    4m
 ```
 
 Let's check the pod.

--- a/docs/guides/proxysql/backends/xtradb-galera/kubedb/examples/xtradb-proxy.yaml
+++ b/docs/guides/proxysql/backends/xtradb-galera/kubedb/examples/xtradb-proxy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: xtradb-proxy
   namespace: demo
 spec:
-  version: "2.7.3-debian"
+  version: "3.0.1-debian"
   replicas: 3
   syncUsers: false
   backend:

--- a/docs/guides/proxysql/backends/xtradb-galera/kubedb/index.md
+++ b/docs/guides/proxysql/backends/xtradb-galera/kubedb/index.md
@@ -131,7 +131,7 @@ metadata:
   name: xtradb-proxy
   namespace: demo
 spec:
-  version: "2.7.3-debian"
+  version: "3.0.1-debian"
   replicas: 3
   syncUsers: true
   backend:
@@ -144,14 +144,14 @@ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >
 proxysql.kubedb.com/xtradb-proxy created
 ```
 
-Here in the `.spec.version` field we are saying that we want a ProxySQL-2.6.3 with base image of debian. In the `.spec.replicas` section we have given 3, so the operator will create 3 nodes for ProxySQL. The `spec.syncUser` field is set to  true, which means all the users in the backend PerconaXtraDB server will be fetched to the ProxySQL server.
+Here in the `.spec.version` field we are saying that we want a ProxySQL-3.0.1 with base image of debian. In the `.spec.replicas` section we have given 3, so the operator will create 3 nodes for ProxySQL. The `spec.syncUser` field is set to  true, which means all the users in the backend PerconaXtraDB server will be fetched to the ProxySQL server.
 
 Let's wait for the ProxySQL to be Ready. 
 
 ```bash
 $ kubectl get prx -n demo
 NAME            VERSION        STATUS   AGE
-xtradb-proxy    2.7.3-debian   Ready    17m
+xtradb-proxy    3.0.1-debian   Ready    17m
 ```
 
 Let's check the pods and associated kubernetes objects

--- a/docs/guides/proxysql/clustering/proxysql-cluster/examples/sample-proxysql.yaml
+++ b/docs/guides/proxysql/clustering/proxysql-cluster/examples/sample-proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-server

--- a/docs/guides/proxysql/clustering/proxysql-cluster/index.md
+++ b/docs/guides/proxysql/clustering/proxysql-cluster/index.md
@@ -127,7 +127,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"  
+  version: "3.0.1-debian"  
   replicas: 3
   backend:
     name: mysql-server
@@ -148,7 +148,7 @@ Let's wait for the ProxySQL to be Ready.
 ```bash
 $ kubectl get proxysql -n demo
 NAME           VERSION        STATUS   AGE
-proxy-server   2.3.2-debian   Ready    4m
+proxy-server   3.0.1-debian   Ready    4m
 ```
 
 Let's see the pods 

--- a/docs/guides/proxysql/concepts/declarative-configuration/index.md
+++ b/docs/guides/proxysql/concepts/declarative-configuration/index.md
@@ -157,7 +157,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"  
+  version: "3.0.1-debian"  
   replicas: 3
   backend:
     name: mysql-server

--- a/docs/guides/proxysql/concepts/opsrequest/index.md
+++ b/docs/guides/proxysql/concepts/opsrequest/index.md
@@ -37,7 +37,7 @@ spec:
   proxyRef:
     name: proxy-server
   updateVersion:
-    targetVersion: "2.4.4-debian"
+    targetVersion: "3.0.1-debian"
 ```
 
 **Sample ProxySQLOpsRequest Objects for Horizontal Scaling of proxysql cluster:**

--- a/docs/guides/proxysql/concepts/proxysql/index.md
+++ b/docs/guides/proxysql/concepts/proxysql/index.md
@@ -29,7 +29,7 @@ metadata:
   name: demo-proxysql
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 1
   backend:
     name: my-group

--- a/docs/guides/proxysql/custom-rbac/index.md
+++ b/docs/guides/proxysql/custom-rbac/index.md
@@ -146,7 +146,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 1
   backend:
     name: xtradb-galera-appbinding

--- a/docs/guides/proxysql/custom-rbac/yamls/my-custom-db.yaml
+++ b/docs/guides/proxysql/custom-rbac/yamls/my-custom-db.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 1
   backend:
     name: xtradb-galera-appbinding

--- a/docs/guides/proxysql/monitoring/builtin-prometheus/examples/proxysql.yaml
+++ b/docs/guides/proxysql/monitoring/builtin-prometheus/examples/proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-grp

--- a/docs/guides/proxysql/monitoring/builtin-prometheus/index.md
+++ b/docs/guides/proxysql/monitoring/builtin-prometheus/index.md
@@ -82,7 +82,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-grp
@@ -111,7 +111,7 @@ Now, wait for the server to go into `Running` state.
 ```bash
 $ kubectl get proxysql -n demo proxy-server
 NAME              VERSION      STATUS   AGE
-proxy-server   2.4.4-debian    Ready    76s
+proxy-server   3.0.1-debian    Ready    76s
 ```
 
 KubeDB will create a separate stats service with name `{ProxySQL crd name}-stats` for monitoring purpose.

--- a/docs/guides/proxysql/monitoring/prometheus-operator/examples/proxysql.yaml
+++ b/docs/guides/proxysql/monitoring/prometheus-operator/examples/proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-grp

--- a/docs/guides/proxysql/monitoring/prometheus-operator/index.md
+++ b/docs/guides/proxysql/monitoring/prometheus-operator/index.md
@@ -144,7 +144,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-grp
@@ -182,7 +182,7 @@ Now, wait for the server to go into `Ready` state.
 ```bash
 $ kubectl get proxysql -n demo proxy-server
 NAME             VERSION       STATUS   AGE
-proxy-server   2.4.4-debian    Ready    59s
+proxy-server   3.0.1-debian    Ready    59s
 ```
 
 KubeDB will create a separate stats service with name `{ProxySQL crd name}-stats` for monitoring purpose.

--- a/docs/guides/proxysql/quickstart/mysqlgrp/examples/sample-proxysql-v1.yaml
+++ b/docs/guides/proxysql/quickstart/mysqlgrp/examples/sample-proxysql-v1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 3
   podTemplate:
     spec:

--- a/docs/guides/proxysql/quickstart/mysqlgrp/examples/sample-proxysql-v1alpha2.yaml
+++ b/docs/guides/proxysql/quickstart/mysqlgrp/examples/sample-proxysql-v1alpha2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 1
   syncUsers: true
   backend:

--- a/docs/guides/proxysql/quickstart/mysqlgrp/index.md
+++ b/docs/guides/proxysql/quickstart/mysqlgrp/index.md
@@ -160,7 +160,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 1
   syncUsers: true
   backend:
@@ -183,7 +183,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 1
   syncUsers: true
   backend:
@@ -196,14 +196,14 @@ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >
   proxysql.kubedb.com/proxysql-server created
 ```
 
-This is the simplest version of a KubeDB ProxySQL server. Here in the `.spec.version` field we are saying that we want a ProxySQL-2.3.2 with base image of debian. In the `.spec.replicas` section we have written 1, so the operator will create a single node ProxySQL. The `spec.syncUser` field is set to  true, which means all the users in the backend MySQL server will be fetched to the ProxySQL server.
+This is the simplest version of a KubeDB ProxySQL server. Here in the `.spec.version` field we are saying that we want a ProxySQL-3.0.1 with base image of debian. In the `.spec.replicas` section we have written 1, so the operator will create a single node ProxySQL. The `spec.syncUser` field is set to  true, which means all the users in the backend MySQL server will be fetched to the ProxySQL server.
 
 Let's wait for the ProxySQL to be Ready. 
 
 ```bash
 $ kubectl get proxysql -n demo
 NAME           VERSION        STATUS   AGE
-proxy-server   2.3.2-debian   Ready    4m
+proxy-server   3.0.1-debian   Ready    4m
 ```
 
 Let's check the pod.

--- a/docs/guides/proxysql/quickstart/xtradbext/examples/sample-proxy-v1.yaml
+++ b/docs/guides/proxysql/quickstart/xtradbext/examples/sample-proxy-v1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 1
   syncUsers: true
   backend:

--- a/docs/guides/proxysql/quickstart/xtradbext/examples/sample-proxy-v1alpha2.yaml
+++ b/docs/guides/proxysql/quickstart/xtradbext/examples/sample-proxy-v1alpha2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 1
   syncUsers: true
   backend:

--- a/docs/guides/proxysql/quickstart/xtradbext/index.md
+++ b/docs/guides/proxysql/quickstart/xtradbext/index.md
@@ -278,7 +278,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 1
   syncUsers: true
   backend:
@@ -299,7 +299,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.4.4-debian"
+  version: "3.0.1-debian"
   replicas: 1
   syncUsers: true
   backend:
@@ -312,14 +312,14 @@ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >
   proxysql.kubedb.com/proxysql-server created
 ```
 
-This is the simplest version of a KubeDB ProxySQL server. Here in the `.spec.version` field we are saying that we want a ProxySQL-2.4.4 with base image of debian. In the `.spec.replicas` section we have written 1, so the operator will create a single node ProxySQL. The `spec.syncUser` field is set to  true, which means all the users in the backend MySQL server will be fetched to the ProxySQL server. 
+This is the simplest version of a KubeDB ProxySQL server. Here in the `.spec.version` field we are saying that we want a ProxySQL-3.0.1 with base image of debian. In the `.spec.replicas` section we have written 1, so the operator will create a single node ProxySQL. The `spec.syncUser` field is set to  true, which means all the users in the backend MySQL server will be fetched to the ProxySQL server. 
 
 Let's wait for the ProxySQL to be Ready. 
 
 ```bash
 $ kubectl get proxysql -n demo
 NAME           VERSION        STATUS   AGE
-proxy-server   2.4.4-debian   Ready    4m
+proxy-server   3.0.1-debian   Ready    4m
 ```
 
 Let's check the pod.

--- a/docs/guides/proxysql/reconfigure-tls/cluster/examples/sample-proxysql.yaml
+++ b/docs/guides/proxysql/reconfigure-tls/cluster/examples/sample-proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-server

--- a/docs/guides/proxysql/reconfigure-tls/cluster/index.md
+++ b/docs/guides/proxysql/reconfigure-tls/cluster/index.md
@@ -130,7 +130,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-server

--- a/docs/guides/proxysql/reconfigure/cluster/examples/sample-proxysql.yaml
+++ b/docs/guides/proxysql/reconfigure/cluster/examples/sample-proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-server

--- a/docs/guides/proxysql/reconfigure/cluster/index.md
+++ b/docs/guides/proxysql/reconfigure/cluster/index.md
@@ -85,7 +85,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"  
+  version: "3.0.1-debian"  
   replicas: 3
   backend:
     name: mysql-server
@@ -102,7 +102,7 @@ Let's wait for the ProxySQL to be Ready.
 ```bash
 $ kubectl get proxysql -ndemo               
 NAME           VERSION        STATUS   AGE
-proxy-server   2.3.2-debian   Ready    98s
+proxy-server   3.0.1-debian   Ready    98s
 ```
 
 ## Reconfigure MYSQL USERS

--- a/docs/guides/proxysql/restart/index.md
+++ b/docs/guides/proxysql/restart/index.md
@@ -89,7 +89,7 @@ metadata:
   name: mysql-proxy
   namespace: demo
 spec:
-  version: "2.7.3-debian"
+  version: "3.0.1-debian"
   replicas: 3
   syncUsers: true
   backend:
@@ -108,7 +108,7 @@ Let's wait for the ProxySQL to be Ready.
 ```bash
 $ kubectl get proxysql -n demo
 NAME          VERSION        STATUS   AGE
-mysql-proxy   2.7.3-debian   Ready    3m45s
+mysql-proxy   3.0.1-debian   Ready    3m45s
 ``` 
 ## Apply Restart opsRequest
 ```yaml

--- a/docs/guides/proxysql/scaling/horizontal-scaling/cluster/examples/sample-proxysql.yaml
+++ b/docs/guides/proxysql/scaling/horizontal-scaling/cluster/examples/sample-proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-server

--- a/docs/guides/proxysql/scaling/horizontal-scaling/cluster/index.md
+++ b/docs/guides/proxysql/scaling/horizontal-scaling/cluster/index.md
@@ -82,7 +82,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-server
@@ -102,7 +102,7 @@ Now, wait until `proxy-server` has status `Ready`. i.e,
 ```bash
 $ kubectl get proxysql -n demo
 NAME             VERSION       STATUS    AGE
-proxy-server   2.3.2-debian    Ready    2m36s
+proxy-server   3.0.1-debian    Ready    2m36s
 ```
 
 Let's check the number of replicas this cluster has from the ProxySQL object, number of pods the petset have,

--- a/docs/guides/proxysql/scaling/vertical-scaling/cluster/example/sample-proxysql.yaml
+++ b/docs/guides/proxysql/scaling/vertical-scaling/cluster/example/sample-proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-server

--- a/docs/guides/proxysql/scaling/vertical-scaling/cluster/index.md
+++ b/docs/guides/proxysql/scaling/vertical-scaling/cluster/index.md
@@ -72,7 +72,7 @@ Here, we are going to deploy a  `ProxySQL` cluster using a supported version by 
 
 ### Prepare ProxySQL Cluster
 
-Now, we are going to deploy a `ProxySQL` cluster database with version `2.3.2-debian`.
+Now, we are going to deploy a `ProxySQL` cluster database with version `3.0.1-debian`.
 
 In this section, we are going to deploy a ProxySQL cluster. Then, in the next section we will update the resources of the servers using `ProxySQLOpsRequest` CRD. Below is the YAML of the `ProxySQL` CR that we are going to create,
 
@@ -83,7 +83,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-server
@@ -114,7 +114,7 @@ Now, wait until `proxy-server` has status `Ready`. i.e,
 ```bash
 $ kubectl get proxysql -n demo
 NAME             VERSION         STATUS     AGE
-proxy-server    2.3.2-debian     Ready     3m46s
+proxy-server    3.0.1-debian     Ready     3m46s
 ```
 
 Let's check the Pod containers resources,

--- a/docs/guides/proxysql/tls/configure/examples/sample-proxysql.yaml
+++ b/docs/guides/proxysql/tls/configure/examples/sample-proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "3.0.1-debian"
   replicas: 3
   backend:
     name: mysql-server

--- a/docs/guides/proxysql/tls/configure/index.md
+++ b/docs/guides/proxysql/tls/configure/index.md
@@ -129,7 +129,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"  
+  version: "3.0.1-debian"  
   replicas: 3
   backend:
     name: mysql-server
@@ -174,7 +174,7 @@ Now, wait for `ProxySQL` going on `Ready` state and also wait for `PetSet` and i
 ```bash
 $ kubectl get proxysql -n demo proxy-server
 NAME             VERSION       STATUS   AGE
-proxy-server   2.3.2-debian    Ready    5m48s
+proxy-server   3.0.1-debian    Ready    5m48s
 
 $ kubectl get sts -n demo proxy-server
 NAME             READY   AGE
@@ -216,7 +216,7 @@ ca.crt  tls.crt  tls.key
 root@proxy-server-0:/ mysql -uadmin -padmin -h127.0.0.1 -P6032 --prompt 'ProxySQLAdmin>'
 Welcome to the ProxySQL monitor.  Commands end with ; or \g.
 Your ProxySQL connection id is 64
-Server version: 2.3.2-debian-ProxySQL-1:2.3.2-debian+maria~focal proxysql.org binary distribution
+Server version: 3.0.1-debian-ProxySQL-1:3.0.1-debian+maria~focal proxysql.org binary distribution
 
 Copyright (c) 2000, 2018, Oracle, ProxySQL Corporation Ab and others.
 

--- a/docs/guides/proxysql/update-version/cluster/examples/proxyops-upgrade.yaml
+++ b/docs/guides/proxysql/update-version/cluster/examples/proxyops-upgrade.yaml
@@ -8,4 +8,4 @@ spec:
   proxyRef:
     name: proxy-server
   updateVersion:
-    targetVersion: "2.4.4-debian"
+    targetVersion: "3.0.1-debian"

--- a/docs/guides/proxysql/update-version/cluster/examples/sample-proxysql.yaml
+++ b/docs/guides/proxysql/update-version/cluster/examples/sample-proxysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "2.7.3-debian"
   replicas: 3
   backend:
     name: mysql-server

--- a/docs/guides/proxysql/update-version/cluster/index.md
+++ b/docs/guides/proxysql/update-version/cluster/index.md
@@ -68,7 +68,7 @@ After applying the above yaml wait for the MySQL to be Ready.
 
 ## Prepare ProxySQL Cluster
 
-Now, we are going to deploy a `ProxySQL` cluster with version `2.3.2-debian`.
+Now, we are going to deploy a `ProxySQL` cluster with version `2.7.3-debian`.
 
 ### Deploy ProxySQL cluster
 
@@ -82,7 +82,7 @@ metadata:
   name: proxy-server
   namespace: demo
 spec:
-  version: "2.3.2-debian"
+  version: "2.7.3-debian"
   replicas: 3
   backend:
     name: mysql-server
@@ -103,14 +103,14 @@ Now, wait until `proxy-server` created has status `Ready`. i.e,
 ```bash
 $ kubectl get proxysql -n demo                                                                                                                                             
 NAME             VERSION       STATUS     AGE
-proxy-server   2.3.2-debian    Ready     3m15s
+proxy-server   2.7.3-debian    Ready     3m15s
 ```
 
 We are now ready to apply the `ProxySQLOpsRequest` CR to update this database.
 
 ## update ProxySQL Version
 
-Here, we are going to update `ProxySQL` cluster from `2.3.2-debian` to `2.4.4-debian`.
+Here, we are going to update `ProxySQL` cluster from `2.7.3-debian` to `3.0.1-debian`.
 
 ### Create ProxySQLOpsRequest:
 
@@ -127,14 +127,14 @@ spec:
   proxyRef:
     name: proxy-server
   updateVersion:
-    targetVersion: "2.4.4-debian"
+    targetVersion: "3.0.1-debian"
 ```
 
 Here,
 
 - `spec.proxyRef.name` specifies that we are performing operation on `proxy-server` ProxySQL database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `2.4.4-debian`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `3.0.1-debian`.
 
 Let's create the `ProxySQLOpsRequest` CR we have shown above,
 
@@ -162,13 +162,13 @@ Now, we are going to verify whether the `ProxySQL` and the related `PetSets` and
 
 ```bash
 $ kubectl get proxysql -n demo proxy-server -o=jsonpath='{.spec.version}{"\n"}'
-2.4.4-debian
+3.0.1-debian
 
 $ kubectl get sts -n demo proxy-server -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-kubedb/proxysql:2.4.4-debian@sha256....
+kubedb/proxysql:3.0.1-debian@sha256....
 
 $ kubectl get pods -n demo proxy-server-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-kubedb/proxysql:2.4.4-debian@sha256....
+kubedb/proxysql:3.0.1-debian@sha256....
 
 ```
 


### PR DESCRIPTION
Bumps the **proxysql** example and guide manifests to the latest supported version (`3.0.1-debian`) per the installer `active_versions.json`.

- General "deploy a proxysql" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.