### PR TITLE
Update rabbitmq docs examples to latest supported version (4.2.4)

### DIFF
--- a/docs/examples/rabbitmq/cluster/rabbit-custom-config.yaml
+++ b/docs/examples/rabbitmq/cluster/rabbit-custom-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rm-cluster
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/rabbitmq/cluster/rabbitmq-cluster.yaml
+++ b/docs/examples/rabbitmq/cluster/rabbitmq-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rabbitmq
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 3
   storage:
     accessModes:

--- a/docs/examples/rabbitmq/quickstart/quickstart.yaml
+++ b/docs/examples/rabbitmq/quickstart/quickstart.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rm-quickstart
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 3
   storage:
     accessModes:

--- a/docs/guides/rabbitmq/README.md
+++ b/docs/guides/rabbitmq/README.md
@@ -47,6 +47,7 @@ KubeDB supports the following RabbitMQ Versions.
 - `3.12.12`
 - `3.13.2`
 - `4.0.4`
+- `4.2.4`
 
 ## Life Cycle of a RabbitMQ Object
 

--- a/docs/guides/rabbitmq/autoscaler/compute/compute-autoscale.md
+++ b/docs/guides/rabbitmq/autoscaler/compute/compute-autoscale.md
@@ -41,7 +41,7 @@ namespace/demo created
 
 ## Autoscaling of RabbitMQ
 
-In this section, we are going to deploy a RabbitMQ with version `3.13.2`  Then, in the next section we will set up autoscaling for this RabbitMQ using `RabbitMQAutoscaler` CRD. Below is the YAML of the `RabbitMQ` CR that we are going to create,
+In this section, we are going to deploy a RabbitMQ with version `4.2.4`  Then, in the next section we will set up autoscaling for this RabbitMQ using `RabbitMQAutoscaler` CRD. Below is the YAML of the `RabbitMQ` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -50,7 +50,7 @@ metadata:
   name: rabbitmq-autoscale
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 1
   storage:
     accessModes:
@@ -90,7 +90,7 @@ Now, wait until `rabbitmq-autoscale` has status `Ready`. i.e,
 ```bash
 $ kubectl get rm -n demo
 NAME                 TYPE                  VERSION   STATUS   AGE
-rabbitmq-autoscale   kubedb.com/v1alpha2   3.13.2     Ready    22s
+rabbitmq-autoscale   kubedb.com/v1alpha2   4.2.4     Ready    22s
 ```
 
 Let's check the Pod containers resources,

--- a/docs/guides/rabbitmq/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/rabbitmq/autoscaler/storage/storage-autoscale.md
@@ -58,7 +58,7 @@ Now, we are going to deploy a `RabbitMQ` cluster using a supported version by `K
 
 #### Deploy RabbitMQ Cluster
 
-In this section, we are going to deploy a RabbitMQ cluster with version `3.13.2`.  Then, in the next section we will set up autoscaling for this database using `RabbitMQAutoscaler` CRD. Below is the YAML of the `RabbitMQ` CR that we are going to create,
+In this section, we are going to deploy a RabbitMQ cluster with version `4.2.4`.  Then, in the next section we will set up autoscaling for this database using `RabbitMQAutoscaler` CRD. Below is the YAML of the `RabbitMQ` CR that we are going to create,
 
 > If you want to autoscale RabbitMQ `Standalone`, Just remove the `spec.Replicas` from the below yaml and rest of the steps are same.
 
@@ -69,7 +69,7 @@ metadata:
   name: rabbitmq-autoscale
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 3
   storage:
     accessModes:
@@ -109,7 +109,7 @@ Now, wait until `rabbitmq-autoscale` has status `Ready`. i.e,
 ```bash
 $ kubectl get rabbitmq -n demo
 NAME                 VERSION   STATUS   AGE
-rabbitmq-autoscale   3.13.2    Ready    3m46s
+rabbitmq-autoscale   4.2.4    Ready    3m46s
 ```
 
 Let's check volume size from petset, and from the persistent volume,

--- a/docs/guides/rabbitmq/concepts/appbinding.md
+++ b/docs/guides/rabbitmq/concepts/appbinding.md
@@ -30,7 +30,7 @@ kind: AppBinding
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1alpha2","kind":"RabbitMQ","metadata":{"annotations":{},"name":"rabbitmq","namespace":"rabbit"},"spec":{"deletionPolicy":"WipeOut","podTemplate":{"spec":{"containers":[{"name":"rabbitmq","resources":{"limits":{"cpu":"600m","memory":"1.5Gi"},"requests":{"cpu":"500m"}}}]}},"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","version":"3.13.2"}}
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"RabbitMQ","metadata":{"annotations":{},"name":"rabbitmq","namespace":"rabbit"},"spec":{"deletionPolicy":"WipeOut","podTemplate":{"spec":{"containers":[{"name":"rabbitmq","resources":{"limits":{"cpu":"600m","memory":"1.5Gi"},"requests":{"cpu":"500m"}}}]}},"replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"standard"},"storageType":"Durable","version":"4.2.4"}}
   creationTimestamp: "2024-09-05T19:30:24Z"
   generation: 1
   labels:
@@ -64,7 +64,7 @@ spec:
   secret:
     name: rabbitmq-admin-cred
   type: kubedb.com/rabbitmq
-  version: 3.13.2
+  version: 4.2.4
 ```
 
 Here, we are going to describe the sections of an `AppBinding` crd.

--- a/docs/guides/rabbitmq/concepts/catalog.md
+++ b/docs/guides/rabbitmq/concepts/catalog.md
@@ -27,7 +27,7 @@ Using a separate crd for specifying respective docker images, and pod security p
 As with all other Kubernetes objects, a RabbitMQVersion needs `apiVersion`, `kind`, and `metadata` fields. It also needs a `.spec` section. Get `RabbitMQVersion` CR with a simple kubectl command.
 
 ```bash
-$ kubectl get rmversion 3.13.2 -oyaml
+$ kubectl get rmversion 4.2.4 -oyaml
 ```
 
 ```yaml
@@ -45,17 +45,17 @@ metadata:
     app.kubernetes.io/name: kubedb-catalog
     app.kubernetes.io/version: v2024.8.21
     helm.sh/chart: kubedb-catalog-v2024.8.21
-  name: 3.13.2
+  name: 4.2.4
   resourceVersion: "46385"
   uid: d853aaf9-e9b8-40b8-9663-a201a5a645c1
 spec:
   db:
-    image: ghcr.io/appscode-images/rabbitmq:3.13.2-management-alpine
+    image: ghcr.io/appscode-images/rabbitmq:4.2.4-management-alpine
   initContainer:
-    image: ghcr.io/kubedb/rabbitmq-init:3.13.2
+    image: ghcr.io/kubedb/rabbitmq-init:v2026.1.19
   securityContext:
     runAsUser: 999
-  version: 3.13.2
+  version: 4.2.4
 ```
 
 ### metadata.name

--- a/docs/guides/rabbitmq/concepts/opsrequest.md
+++ b/docs/guides/rabbitmq/concepts/opsrequest.md
@@ -26,7 +26,7 @@ Here, some sample `RabbitMQOpsRequest` CRs for different administrative operatio
 
 **Sample `RabbitMQOpsRequest` for updating database:**
 
-Let's assume that you have a KubeDB managed RabbitMQ cluster named `rm-quickstart` running on your kubernetes with version `3.12.12`. Now, You can update it's version to `3.13.2` using the following manifest.
+Let's assume that you have a KubeDB managed RabbitMQ cluster named `rm-quickstart` running on your kubernetes with version `4.0.4`. Now, You can update it's version to `4.2.4` using the following manifest.
 
 ```yaml
 apiVersion: ops.kubedb.com/v1alpha1
@@ -39,7 +39,7 @@ spec:
   databaseRef:
     name: rm-quickstart
   updateVersion:
-    targetVersion: 3.13.2
+    targetVersion: 4.2.4
 ```
 
 **Sample `RabbitMQOpsRequest` Objects for Horizontal Scaling of the database Cluster:**

--- a/docs/guides/rabbitmq/concepts/rabbitmq.md
+++ b/docs/guides/rabbitmq/concepts/rabbitmq.md
@@ -102,7 +102,7 @@ AutoOps is an optional field to control the generation of versionUpdate & TLS-re
 
 `spec.version` is a required field specifying the name of the [RabbitMQVersion](/docs/guides/rabbitmq/concepts/catalog.md) crd where the docker images are specified. Currently, when you install KubeDB, it creates the following `RabbitMQVersion` resources,
 
-- `3.12.12`, `3.13.2`
+- `3.12.12`, `3.13.2`, `4.0.4`, `4.2.4`
 
 ### spec.replicas
 

--- a/docs/guides/rabbitmq/concepts/rabbitmq.md
+++ b/docs/guides/rabbitmq/concepts/rabbitmq.md
@@ -29,7 +29,7 @@ metadata:
   name: rabbitmq
   namespace: rabbit
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   authSecret:
     kind: Secret
     name: rabbit-auth

--- a/docs/guides/rabbitmq/configuration/using-config-file.md
+++ b/docs/guides/rabbitmq/configuration/using-config-file.md
@@ -88,7 +88,7 @@ metadata:
   name: rm-custom-config
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 1
   configuration:
     secretName: rm-configuration

--- a/docs/guides/rabbitmq/configuration/using-podtemplate.md
+++ b/docs/guides/rabbitmq/configuration/using-podtemplate.md
@@ -113,7 +113,7 @@ Now, check if the rabbitmq has started with the custom configuration we have pro
 
 ```bash
 $ kubectl exec -it -n demo  -- bash
-  ##  ##      RabbitMQ 3.13.2
+  ##  ##      RabbitMQ 4.2.4
   ##  ##
   ##########  Copyright (c) 2007-2024 Broadcom Inc and/or its subsidiaries
   ######  ##
@@ -418,7 +418,7 @@ IPs:              <none>
 Controlled By:    PetSet/rabbitmq-without-tolerations
 Containers:
   rabbitmq:
-    Image:           ghcr.io/appscode-images/rabbitmq:3.13.2@sha256:7f2537e3dc69dae2cebea3500502e6a2b764b42911881e623195eeed32569217
+    Image:           ghcr.io/appscode-images/rabbitmq:4.2.4@sha256:7f2537e3dc69dae2cebea3500502e6a2b764b42911881e623195eeed32569217
     Ports:           9999/TCP, 9595/TCP
     Host Ports:      0/TCP, 0/TCP
     SeccompProfile:  RuntimeDefault

--- a/docs/guides/rabbitmq/configuration/using-podtemplate.md
+++ b/docs/guides/rabbitmq/configuration/using-podtemplate.md
@@ -72,7 +72,7 @@ metadata:
   name: rm-misc-config
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 1
   podTemplate:
     spec:
@@ -168,7 +168,7 @@ metadata:
   name: rabbitmq-custom-sidecar
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 1
   podTemplate:
     spec:
@@ -275,7 +275,7 @@ metadata:
   name: rabbitmq-node-selector
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 1
   podTemplate:
     spec:
@@ -372,7 +372,7 @@ metadata:
   name: rabbitmq-without-tolerations
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 1
   storage:
     accessModes:
@@ -467,7 +467,7 @@ metadata:
   name: rabbitmq-with-tolerations
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 1
   storage:
     accessModes:

--- a/docs/guides/rabbitmq/monitoring/overview.md
+++ b/docs/guides/rabbitmq/monitoring/overview.md
@@ -53,7 +53,7 @@ metadata:
   name: sample-rabbitmq
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   deletionPolicy: WipeOut
   configuration:
     secretName: config

--- a/docs/guides/rabbitmq/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/rabbitmq/monitoring/using-builtin-prometheus.md
@@ -49,7 +49,7 @@ metadata:
   name: builtin-rabbitmq
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"
@@ -78,7 +78,7 @@ Now, wait for the database to go into `Running` state.
 ```bash
 $ kubectl get rm -n demo builtin-rabbitmq
 NAME               VERSION   STATUS    AGE
-builtin-rabbitmq   3.13.2     Ready     2m34s
+builtin-rabbitmq   4.2.4     Ready     2m34s
 ```
 
 KubeDB will create a separate stats service with name `{RabbitMQ crd name}-stats` for monitoring purpose.

--- a/docs/guides/rabbitmq/monitoring/using-prometheus-operator.md
+++ b/docs/guides/rabbitmq/monitoring/using-prometheus-operator.md
@@ -138,7 +138,7 @@ metadata:
   name: prom-rm
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"
@@ -174,7 +174,7 @@ Now, wait for the database to go into `Running` state.
 ```bash
 $ kubectl get rm -n demo prom-rm
 NAME              VERSION    STATUS    AGE
-prom-rm           3.13.2     Ready     34s
+prom-rm           4.2.4     Ready     34s
 ```
 
 KubeDB will create a separate stats service with name `{RabbitMQ crd name}-stats` for monitoring purpose.

--- a/docs/guides/rabbitmq/quickstart/quickstart.md
+++ b/docs/guides/rabbitmq/quickstart/quickstart.md
@@ -64,7 +64,7 @@ metadata:
   name: rm-quickstart
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 3
   storage:
     accessModes:
@@ -99,7 +99,7 @@ rabbitmq.kubedb.com/rm-quickstart created
 Here,
 
 - `.spec.replica` is used to provide the number of required replicas or, peers for intended rabbitmq cluster. 
-- `spec.version` is the name of the RabbitMQVersion CRD where the docker images are specified. In this tutorial, a RabbitMQ `3.13.2` database is going to be created.
+- `spec.version` is the name of the RabbitMQVersion CRD where the docker images are specified. In this tutorial, a RabbitMQ `4.2.4` database is going to be created.
 - `spec.storageType` specifies the type of storage that will be used for RabbitMQ database. It can be `Durable` or `Ephemeral`. Default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create RabbitMQ database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
   - `spec.deletionPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `RabbitMQ` CRD or which resources KubeDB should keep or delete when you delete `RabbitMQ` CRD. If admission webhook is enabled, It prevents users from deleting the database as long as the `spec.deletionPolicy` is set to `DoNotTerminate`. Learn details of all `DeletionPolicy` [here](/docs/guides/rabbitmq/concepts/rabbitmq.md#specdeletionpolicy)
 - `.spec.podTemplate` is used to provide specific pod specifications or container specification. You can override default resources, securityContext etc.  set for rabbitmq container. Find details [here](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)

--- a/docs/guides/rabbitmq/quickstart/quickstart.md
+++ b/docs/guides/rabbitmq/quickstart/quickstart.md
@@ -134,7 +134,7 @@ rm-quickstart-pods        ClusterIP      None            <none>           4369/T
 
 $ kubectl get appbinding -n demo
 NAME            TYPE                  VERSION   AGE
-rm-quickstart   kubedb.com/rabbitmq   3.13.2    23h
+rm-quickstart   kubedb.com/rabbitmq   4.2.4    23h
 ```
 
 KubeDB operator sets the `status.phase` to `Running` once the database is successfully created. Run the following command to see the modified `RabbitMQ` object:
@@ -148,7 +148,7 @@ kind: RabbitMQ
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1alpha2","kind":"RabbitMQ","metadata":{"annotations":{},"name":"rm-quickstart","namespace":"demo"},"spec":{"deletionPolicy":"WipeOut","podTemplate":{"spec":{"containers":[{"name":"rabbitmq","resources":{"limits":{"cpu":2,"memory":"2Gi"},"requests":{"cpu":0.5,"memory":"1Gi"}}}]}},"replicas":3,"serviceTemplates":[{"alias":"primary","spec":{"type":"LoadBalancer"}}],"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"linode-block-storage"},"storageType":"Durable","version":"3.13.2"}}
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"RabbitMQ","metadata":{"annotations":{},"name":"rm-quickstart","namespace":"demo"},"spec":{"deletionPolicy":"WipeOut","podTemplate":{"spec":{"containers":[{"name":"rabbitmq","resources":{"limits":{"cpu":2,"memory":"2Gi"},"requests":{"cpu":0.5,"memory":"1Gi"}}}]}},"replicas":3,"serviceTemplates":[{"alias":"primary","spec":{"type":"LoadBalancer"}}],"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"linode-block-storage"},"storageType":"Durable","version":"4.2.4"}}
   creationTimestamp: "2024-09-10T09:23:57Z"
   finalizers:
   - kubedb.com/rabbitmq
@@ -218,7 +218,7 @@ spec:
         storage: 1Gi
     storageClassName: standard
   storageType: Durable
-  version: 3.13.2
+  version: 4.2.4
 status:
   conditions:
   - lastTransitionTime: "2024-09-10T09:23:57Z"

--- a/docs/guides/rabbitmq/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/rabbitmq/reconfigure-tls/reconfigure-tls.md
@@ -48,7 +48,7 @@ metadata:
   name: rm
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 3
   storage:
     storageClassName: "standard"
@@ -71,7 +71,7 @@ Now, wait until `rm` has status `Ready`. i.e,
 ```bash
 $ kubectl get rm -n demo
 NAME    VERSION    STATUS    AGE
-rm      3.13.2     Ready     10m
+rm      4.2.4     Ready     10m
 
 
 ```bash

--- a/docs/guides/rabbitmq/reconfigure/reconfigure.md
+++ b/docs/guides/rabbitmq/reconfigure/reconfigure.md
@@ -40,7 +40,7 @@ Now, we are going to deploy a  `RabbitMQ` cluster using a supported version by `
 
 ### Prepare RabbitMQ Standalone Database
 
-Now, we are going to deploy a `RabbitMQ` cluster with version `3.13.2`.
+Now, we are going to deploy a `RabbitMQ` cluster with version `4.2.4`.
 
 ### Deploy RabbitMQ standalone 
 
@@ -68,7 +68,7 @@ metadata:
   name: rm-cluster
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -93,7 +93,7 @@ Now, wait until `rm-cluster` has status `Ready`. i.e,
 ```bash
 $ kubectl get rm -n demo
 NAME            TYPE                  VERSION   STATUS   AGE
-rm-cluster      kubedb.com/v1alpha2   3.13.2    Ready    79m
+rm-cluster      kubedb.com/v1alpha2   4.2.4    Ready    79m
 ```
 
 Now, we will check if the database has started with the custom configuration we have provided.

--- a/docs/guides/rabbitmq/restart/restart.md
+++ b/docs/guides/rabbitmq/restart/restart.md
@@ -42,7 +42,7 @@ metadata:
   name: rm
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/rabbitmq/rotate-auth/guide.md
+++ b/docs/guides/rabbitmq/rotate-auth/guide.md
@@ -82,7 +82,7 @@ spec:
         storage: 1Gi
     storageClassName: standard
   storageType: Durable
-  version: 3.12.12
+  version: 4.2.4
 ```
 
 ```bash

--- a/docs/guides/rabbitmq/rotate-auth/guide.md
+++ b/docs/guides/rabbitmq/rotate-auth/guide.md
@@ -59,6 +59,7 @@ NAME      VERSION   DB_IMAGE                                                    
 3.12.12   3.12.12   ghcr.io/appscode-images/rabbitmq:3.12.12-management-alpine                3h13m
 3.13.2    3.13.2    ghcr.io/appscode-images/rabbitmq:3.13.2-management-alpine                 3h13m
 4.0.4     4.0.4     ghcr.io/appscode-images/rabbitmq:4.0.4-management-alpine                  3h13m
+4.2.4     4.2.4     ghcr.io/appscode-images/rabbitmq:4.2.4-management-alpine                  3h13m
 ```
 
 ## Create a RabbitMQ server

--- a/docs/guides/rabbitmq/scaling/horizontal-scaling/horizontal-scaling.md
+++ b/docs/guides/rabbitmq/scaling/horizontal-scaling/horizontal-scaling.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `RabbitMQ` using a supported version by `KubeDB` 
 
 ### Deploy RabbitMQ 
 
-In this section, we are going to deploy a RabbitMQ. We are going to deploy a `RabbitMQ` with version `3.13.2`. Then, in the next section we will scale the rabbitmq using `RabbitMQOpsRequest` CRD. Below is the YAML of the `RabbitMQ` CR that we are going to create,
+In this section, we are going to deploy a RabbitMQ. We are going to deploy a `RabbitMQ` with version `4.2.4`. Then, in the next section we will scale the rabbitmq using `RabbitMQOpsRequest` CRD. Below is the YAML of the `RabbitMQ` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -51,7 +51,7 @@ metadata:
   name: rabbitmq
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   replicas: 3
   storage:
     accessModes:
@@ -75,7 +75,7 @@ Now, wait until `rabbitmq` has status `Ready`. i.e,
 ```bash
 $ kubectl get rm -n demo
 NAME            TYPE                  VERSION   STATUS   AGE
-rabbitmq        kubedb.com/v1alpha2   3.13.2     Ready    2m
+rabbitmq        kubedb.com/v1alpha2   4.2.4     Ready    2m
 ```
 
 Let's check the number of replicas this rabbitmq has from the RabbitMQ object, number of pods the PetSet have,

--- a/docs/guides/rabbitmq/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/rabbitmq/scaling/vertical-scaling/vertical-scaling.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a  `RabbitMQ` standalone using a supported version 
 
 ### Prepare RabbitMQ Standalone Database
 
-Now, we are going to deploy a `RabbitMQ` standalone database with version `3.13.2`.
+Now, we are going to deploy a `RabbitMQ` standalone database with version `4.2.4`.
 
 ### Deploy RabbitMQ standalone 
 
@@ -55,7 +55,7 @@ metadata:
   name: rm-standalone
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -78,7 +78,7 @@ Now, wait until `mg-standalone` has status `Ready`. i.e,
 ```bash
 $ kubectl get rm -n demo
 NAME            VERSION    STATUS    AGE
-rm-standalone   3.13.2      Ready     5m56s
+rm-standalone   4.2.4      Ready     5m56s
 ```
 
 Let's check the Pod containers resources,

--- a/docs/guides/rabbitmq/tls/tls.md
+++ b/docs/guides/rabbitmq/tls/tls.md
@@ -97,7 +97,7 @@ metadata:
   name: rabbitmq-tls
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   tls:
     issuerRef:
       apiGroup: "cert-manager.io"
@@ -125,7 +125,7 @@ Now, wait until `rabbitmq-tls created` has status `Ready`. i.e,
 $ watch kubectl get rm -n demo
 Every 2.0s: kubectl get rm -n demo
 NAME            VERSION     STATUS     AGE
-rabbitmq-tls    3.13.2      Ready      14s
+rabbitmq-tls    4.2.4      Ready      14s
 ```
 
 ## Cleaning up

--- a/docs/guides/rabbitmq/update-version/update-version.md
+++ b/docs/guides/rabbitmq/update-version/update-version.md
@@ -38,7 +38,7 @@ namespace/demo created
 
 ## Prepare RabbitMQ cluster
 
-Now, we are going to deploy a `RabbitMQ` cluster with version `3.12.12`.
+Now, we are going to deploy a `RabbitMQ` cluster with version `4.0.4`.
 
 ### Deploy RabbitMQ
 
@@ -51,7 +51,7 @@ metadata:
   name: rm-cluster
   namespace: demo
 spec:
-  version: "3.12.12"
+  version: "4.0.4"
   replicas: 3
   storageType: Durable
   storage:
@@ -75,14 +75,14 @@ Now, wait until `rm-cluster` created has status `Ready`. i.e,
 ```bash
 $ kubectl get rm -n demo                                                                                                                                             
 NAME            VERSION    STATUS    AGE
-rm-cluster      3.12.12   Ready     109s
+rm-cluster      4.0.4   Ready     109s
 ```
 
 We are now ready to apply the `RabbitMQOpsRequest` CR to update this database.
 
 ### update RabbitMQ Version
 
-Here, we are going to update `RabbitMQ` cluster from `3.12.12` to `3.13.2`.
+Here, we are going to update `RabbitMQ` cluster from `4.0.4` to `4.2.4`.
 
 #### Create RabbitMQOpsRequest:
 
@@ -99,7 +99,7 @@ spec:
   databaseRef:
     name: rm-cluster
   updateVersion:
-    targetVersion: 3.13.2
+    targetVersion: 4.2.4
   timeout: 5m
   apply: IfReady
 ```
@@ -108,7 +108,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `rm-cluster` RabbitMQ database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `3.13.2`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `4.2.4`.
 - Have a look [here](/docs/guides/rabbitmq/concepts/opsrequest.md#spectimeout) on the respective sections to understand the `readinessCriteria`, `timeout` & `apply` fields.
 
 Let's create the `RabbitMQOpsRequest` CR we have shown above,
@@ -238,13 +238,13 @@ Now, we are going to verify whether the `RabbitMQ` and the related `PetSets` and
 
 ```bash
 $ kubectl get rm -n demo rm-cluster -o=jsonpath='{.spec.version}{"\n"}'
-3.13.2
+4.2.4
 
 $ kubectl get petset -n demo rm-cluster -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-ghcr.io/appscode-images/rabbitmq:3.13.2-management-alpine
+ghcr.io/appscode-images/rabbitmq:4.2.4-management-alpine
 
 $ kubectl get pods -n demo rm-cluster-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-ghcr.io/appscode-images/rabbitmq:3.13.2-management-alpine
+ghcr.io/appscode-images/rabbitmq:4.2.4-management-alpine
 ```
 
 You can see from above, our `RabbitMQ` cluster has been updated with the new version. So, the updateVersion process is successfully completed.

--- a/docs/guides/rabbitmq/volume-expansion/volume-expansion.md
+++ b/docs/guides/rabbitmq/volume-expansion/volume-expansion.md
@@ -54,7 +54,7 @@ standard (default)   kubernetes.io/gce-pd   Delete          Immediate           
 
 We can see from the output the `standard` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We can use it.
 
-Now, we are going to deploy a `RabbitMQ` standalone database with version `3.13.2`.
+Now, we are going to deploy a `RabbitMQ` standalone database with version `4.2.4`.
 
 #### Deploy RabbitMQ standalone
 
@@ -67,7 +67,7 @@ metadata:
   name: rm-standalone
   namespace: demo
 spec:
-  version: "3.13.2"
+  version: "4.2.4"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -90,7 +90,7 @@ Now, wait until `rm-standalone` has status `Ready`. i.e,
 ```bash
 $ kubectl get rm -n demo
 NAME            VERSION     STATUS    AGE
-rm-standalone   3.13.2      Ready     2m53s
+rm-standalone   4.2.4      Ready     2m53s
 ```
 
 Let's check volume size from PetSet, and from the persistent volume,


### PR DESCRIPTION
Bumps the **rabbitmq** example and guide manifests to the latest supported version (`4.2.4`) per the installer `active_versions.json`.

- General "deploy a rabbitmq" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RabbitMQ examples and tutorials across the docs to use version **4.2.4**.
  * Added **4.2.4** to the list of supported RabbitMQ versions.
  * Refreshed example outputs and upgrade steps so they match the newer version throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->