### PR TITLE
Update redis docs examples to latest supported version (8.2.2)

### DIFF
--- a/docs/examples/redis/announce/redis.yaml
+++ b/docs/examples/redis/announce/redis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: redis-announce
   namespace: demo
 spec:
-  version: 7.4.0
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/examples/redis/autoscaling/compute/rd-standalone.yaml
+++ b/docs/examples/redis/autoscaling/compute/rd-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rd-standalone
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   storageType: Durable
   storage:
     resources:

--- a/docs/examples/redis/autoscaling/compute/sentinel.yaml
+++ b/docs/examples/redis/autoscaling/compute/sentinel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sen-demo
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   storageType: Durable
   replicas: 3
   storage:

--- a/docs/examples/redis/autoscaling/storage/rd-standalone.yaml
+++ b/docs/examples/redis/autoscaling/storage/rd-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rd-standalone
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   storageType: Durable
   storage:
     storageClassName: topolvm-provisioner

--- a/docs/examples/redis/cli/redis-demo.yaml
+++ b/docs/examples/redis/cli/redis-demo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: redis-demo
   namespace: demo
 spec:
-  version: 6.0.20
+  version: 8.2.2
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/redis/clustering/demo-1.yaml
+++ b/docs/examples/redis/clustering/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: redis-cluster
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/examples/redis/custom-config/redis-custom.yaml
+++ b/docs/examples/redis/custom-config/redis-custom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-redis
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   configuration:
     secretName: rd-configuration
   storage:

--- a/docs/examples/redis/custom-rbac/rd-custom-db-two.yaml
+++ b/docs/examples/redis/custom-rbac/rd-custom-db-two.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minute-redis
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   podTemplate:
     spec:
       serviceAccountName: my-custom-serviceaccount

--- a/docs/examples/redis/custom-rbac/rd-custom-db.yaml
+++ b/docs/examples/redis/custom-rbac/rd-custom-db.yaml
@@ -4,7 +4,7 @@ metadata:
   name: quick-redis
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   podTemplate:
     spec:
       serviceAccountName: my-custom-serviceaccount

--- a/docs/examples/redis/initialization/demo-1.yaml
+++ b/docs/examples/redis/initialization/demo-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rd-init-script
   namespace: demo
 spec:
-  version: 7.2.3
+  version: 8.2.2
   disableAuth: false
   storageType: Durable
   init:

--- a/docs/examples/redis/monitoring/builtin-prom-redis.yaml
+++ b/docs/examples/redis/monitoring/builtin-prom-redis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-redis
   namespace: demo
 spec:
-  version: 6.0.20
+  version: 8.2.2
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/examples/redis/monitoring/coreos-prom-redis.yaml
+++ b/docs/examples/redis/monitoring/coreos-prom-redis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coreos-prom-redis
   namespace: demo
 spec:
-  version: 6.0.20
+  version: 8.2.2
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/examples/redis/private-registry/demo-2.yaml
+++ b/docs/examples/redis/private-registry/demo-2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: redis-pvt-reg
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/redis/quickstart/demo-v1.yaml
+++ b/docs/examples/redis/quickstart/demo-v1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: redis-quickstart
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/redis/quickstart/demo-v1alpha2.yaml
+++ b/docs/examples/redis/quickstart/demo-v1alpha2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: redis-quickstart
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/redis/reconfigure-tls/rd-sentinel.yaml
+++ b/docs/examples/redis/reconfigure-tls/rd-sentinel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rd-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   sentinelRef:
     name: sen-sample

--- a/docs/examples/redis/reconfigure-tls/redis-standalone.yaml
+++ b/docs/examples/redis/reconfigure-tls/redis-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rd-sample
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   mode: Standalone
   storage:
     storageClassName: "standard"

--- a/docs/examples/redis/reconfigure-tls/sentinel.yaml
+++ b/docs/examples/redis/reconfigure-tls/sentinel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sen-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/examples/redis/reconfigure/sample-redis-config.yaml
+++ b/docs/examples/redis/reconfigure/sample-redis-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-redis
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/redis/scaling/horizontal-scaling/rd-cluster.yaml
+++ b/docs/examples/redis/scaling/horizontal-scaling/rd-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: redis-cluster
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/examples/redis/scaling/horizontal-scaling/rd-sentinel.yaml
+++ b/docs/examples/redis/scaling/horizontal-scaling/rd-sentinel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rd-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   sentinelRef:
     name: sen-sample

--- a/docs/examples/redis/scaling/horizontal-scaling/sentinel.yaml
+++ b/docs/examples/redis/scaling/horizontal-scaling/sentinel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sen-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 5
   storageType: Durable
   storage:

--- a/docs/examples/redis/scaling/vertical-scaling/rd-cluster.yaml
+++ b/docs/examples/redis/scaling/vertical-scaling/rd-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: redis-cluster
   namespace: demo
 spec:
-  version: 7.0.14
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/examples/redis/scaling/vertical-scaling/rd-sentinel.yaml
+++ b/docs/examples/redis/scaling/vertical-scaling/rd-sentinel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rd-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   sentinelRef:
     name: sen-sample

--- a/docs/examples/redis/scaling/vertical-scaling/rd-standalone.yaml
+++ b/docs/examples/redis/scaling/vertical-scaling/rd-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: redis-quickstart
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/redis/scaling/vertical-scaling/sentinel.yaml
+++ b/docs/examples/redis/scaling/vertical-scaling/sentinel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sen-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/examples/redis/sentinel/new-sentinel.yaml
+++ b/docs/examples/redis/sentinel/new-sentinel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: new-sentinel
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/examples/redis/sentinel/redis.yaml
+++ b/docs/examples/redis/sentinel/redis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rd-demo
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   sentinelRef:
     name: sen-demo

--- a/docs/examples/redis/sentinel/sentinel.yaml
+++ b/docs/examples/redis/sentinel/sentinel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sen-demo
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/examples/redis/tls/rd-cluster-ssl.yaml
+++ b/docs/examples/redis/tls/rd-cluster-ssl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rd-tls
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/examples/redis/tls/rd-sentinel.yaml
+++ b/docs/examples/redis/tls/rd-sentinel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rd-tls
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   mode: Sentinel
   replicas: 3
   sentinelRef:

--- a/docs/examples/redis/tls/rd-standalone-ssl.yaml
+++ b/docs/examples/redis/tls/rd-standalone-ssl.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rd-tls
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   tls:
     issuerRef:
       apiGroup: "cert-manager.io"

--- a/docs/examples/redis/tls/sentinel-ssl.yaml
+++ b/docs/examples/redis/tls/sentinel-ssl.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "6.2.14"
+  version: "8.2.2"
   tls:
     issuerRef:
       apiGroup: "cert-manager.io"

--- a/docs/examples/redis/update-version/rd-cluster.yaml
+++ b/docs/examples/redis/update-version/rd-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: redis-cluster
   namespace: demo
 spec:
-  version: 6.0.20
+  version: 7.4.6
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/examples/redis/update-version/rd-sentinel.yaml
+++ b/docs/examples/redis/update-version/rd-sentinel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rd-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 7.4.6
   replicas: 3
   sentinelRef:
     name: sen-sample

--- a/docs/examples/redis/update-version/rd-standalone.yaml
+++ b/docs/examples/redis/update-version/rd-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: redis-quickstart
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 7.4.6
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/redis/update-version/sentinel.yaml
+++ b/docs/examples/redis/update-version/sentinel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sen-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 7.4.6
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/examples/redis/update-version/update-standalone.yaml
+++ b/docs/examples/redis/update-version/update-standalone.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: redis-quickstart
   updateVersion:
-    targetVersion: 7.0.14
+    targetVersion: 8.2.2

--- a/docs/examples/redis/update-version/update-version.yaml
+++ b/docs/examples/redis/update-version/update-version.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: redis-cluster
   updateVersion:
-    targetVersion: 7.0.14
+    targetVersion: 8.2.2

--- a/docs/examples/redis/update-version/upgrade-redis-sentinel.yaml
+++ b/docs/examples/redis/update-version/upgrade-redis-sentinel.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: rd-sample
   updateVersion:
-    targetVersion: 7.0.4
+    targetVersion: 8.2.2

--- a/docs/examples/redis/update-version/upgrade-sentinel.yaml
+++ b/docs/examples/redis/update-version/upgrade-sentinel.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: sen-sample
   updateVersion:
-    targetVersion: 7.0.14
+    targetVersion: 8.2.2

--- a/docs/examples/redis/volume-expansion/sample-redis.yaml
+++ b/docs/examples/redis/volume-expansion/sample-redis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-redis
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/guides/redis/autoscaler/compute/redis.md
+++ b/docs/guides/redis/autoscaler/compute/redis.md
@@ -45,7 +45,7 @@ Here, we are going to deploy a `Redis` standalone using a supported version by `
 
 #### Deploy Redis standalone
 
-In this section, we are going to deploy a Redis standalone database with version `6.2.14`.  Then, in the next section we will set up autoscaling for this database using `RedisAutoscaler` CRD. Below is the YAML of the `Redis` CR that we are going to create,
+In this section, we are going to deploy a Redis standalone database with version `8.2.2`.  Then, in the next section we will set up autoscaling for this database using `RedisAutoscaler` CRD. Below is the YAML of the `Redis` CR that we are going to create,
 
 > If you want to autoscale Redis in `Cluster` or `Sentinel` mode, just deploy a Redis database in respective Mode and rest of the steps are same.
 
@@ -56,7 +56,7 @@ metadata:
   name: rd-standalone
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   storageType: Durable
   storage:
     resources:

--- a/docs/guides/redis/autoscaler/compute/sentinel.md
+++ b/docs/guides/redis/autoscaler/compute/sentinel.md
@@ -45,7 +45,7 @@ Here, we are going to deploy a `RedisSentinel` instance using a supported versio
 
 #### Deploy Redis standalone
 
-In this section, we are going to deploy a RedisSentinel instance with version `6.2.14`.  Then, in the next section we will set up autoscaling for this database using `RedisSentinelAutoscaler` CRD. Below is the YAML of the `RedisSentinel` CR that we are going to create,
+In this section, we are going to deploy a RedisSentinel instance with version `8.2.2`.  Then, in the next section we will set up autoscaling for this database using `RedisSentinelAutoscaler` CRD. Below is the YAML of the `RedisSentinel` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -54,7 +54,7 @@ metadata:
   name: sen-demo
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   storageType: Durable
   replicas: 3
   storage:

--- a/docs/guides/redis/autoscaler/storage/redis.md
+++ b/docs/guides/redis/autoscaler/storage/redis.md
@@ -63,7 +63,7 @@ Now, we are going to deploy a `Redis` standalone using a supported version by `K
 > If you want to autoscale Redis in `Cluster` or `Sentinel` mode, just deploy a Redis database in respective Mode and rest of the steps are same.
 
 
-In this section, we are going to deploy a Redis standalone database with version `6.2.14`.  Then, in the next section we will set up autoscaling for this database using `RedisAutoscaler` CRD. Below is the YAML of the `Redis` CR that we are going to create,
+In this section, we are going to deploy a Redis standalone database with version `8.2.2`.  Then, in the next section we will set up autoscaling for this database using `RedisAutoscaler` CRD. Below is the YAML of the `Redis` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -72,7 +72,7 @@ metadata:
   name: rd-standalone
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   storageType: Durable
   storage:
     storageClassName: topolvm-provisioner

--- a/docs/guides/redis/backup/kubestash/application-level/index.md
+++ b/docs/guides/redis/backup/kubestash/application-level/index.md
@@ -65,7 +65,7 @@ metadata:
   name: sample-redis
   namespace: demo
 spec:
-  version: 7.4.0
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -175,7 +175,7 @@ spec:
   secret:
     name: sample-redis-auth
   type: kubedb.com/redis
-  version: 7.4.0
+  version: 8.2.2
 ```
 
 KubeStash uses the `AppBinding` CR to connect with the target database. It requires the following two fields to set in AppBinding's `.spec` section.

--- a/docs/guides/redis/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/redis/backup/kubestash/auto-backup/index.md
@@ -218,7 +218,7 @@ metadata:
     blueprint.kubestash.com/name: redis-default-backup-blueprint
     blueprint.kubestash.com/namespace: demo
 spec:
-  version: 7.4.0
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -567,7 +567,7 @@ metadata:
     variables.kubestash.com/namespace: demo
     variables.kubestash.com/targetName: redis-standalone-2
 spec:
-  version: 7.4.0
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/redis/backup/kubestash/logical/index.md
+++ b/docs/guides/redis/backup/kubestash/logical/index.md
@@ -68,7 +68,7 @@ metadata:
   name: redis-cluster
   namespace: demo
 spec:
-  version: 7.4.0
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3
@@ -183,7 +183,7 @@ spec:
   secret:
     name: redis-cluster-auth
   type: kubedb.com/redis
-  version: 7.4.0
+  version: 8.2.2
 ```
 
 KubeStash uses the `AppBinding` CR to connect with the target database. It requires the following two fields to set in AppBinding's `.spec` section.
@@ -572,7 +572,7 @@ metadata:
 spec:
   init:
     waitForInitialRestore: true
-  version: 7.4.0
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/guides/redis/backup/stash/auto-backup/index.md
+++ b/docs/guides/redis/backup/stash/auto-backup/index.md
@@ -131,7 +131,7 @@ metadata:
   annotations:
     stash.appscode.com/backup-blueprint: redis-backup-template
 spec:
-  version: 6.0.20
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -314,7 +314,7 @@ metadata:
     stash.appscode.com/backup-blueprint: redis-backup-template
     stash.appscode.com/schedule: "*/3 * * * *"
 spec:
-  version: 6.0.20
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -491,7 +491,7 @@ metadata:
     stash.appscode.com/backup-blueprint: redis-backup-template
     params.stash.appscode.com/args: "-db 0"
 spec:
-  version: 6.0.20
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/redis/backup/stash/standalone/index.md
+++ b/docs/guides/redis/backup/stash/standalone/index.md
@@ -58,7 +58,7 @@ metadata:
   name: sample-redis
   namespace: demo
 spec:
-  version: 6.0.20
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -219,7 +219,7 @@ clientConfig:
   secret:
     name: sample-redis-auth
   type: kubedb.com/redis
-  version: 6.0.20
+  version: 8.2.2
 ```
 Stash requires the following fields to set in AppBinding's `Spec` section.
 

--- a/docs/guides/redis/clustering/redis-cluster.md
+++ b/docs/guides/redis/clustering/redis-cluster.md
@@ -48,7 +48,7 @@ metadata:
   name: redis-cluster
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3
@@ -175,7 +175,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   deletionPolicy: Halt
-  version: 6.2.14
+  version: 8.2.2
 status:
   conditions:
   - lastTransitionTime: "2023-02-02T11:16:57Z"

--- a/docs/guides/redis/concepts/appbinding.md
+++ b/docs/guides/redis/concepts/appbinding.md
@@ -80,7 +80,7 @@ spec:
   tlsSecret:
     name: redis1-client-cert
   type: kubedb.com/redis
-  version: 6.2.14
+  version: 8.2.2
 ```
 
 Here, we are going to describe the sections of an `AppBinding` crd.

--- a/docs/guides/redis/concepts/redis.md
+++ b/docs/guides/redis/concepts/redis.md
@@ -31,7 +31,7 @@ metadata:
 spec:
   autoOps:
     disabled: true
-  version: 6.2.14
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/guides/redis/concepts/redissentinel.md
+++ b/docs/guides/redis/concepts/redissentinel.md
@@ -31,7 +31,7 @@ metadata:
 spec:
   autoOps:
     disabled: true
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   disableAuth: false
   authSecret:
@@ -399,7 +399,7 @@ metadata:
   name: redis1
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   sentinelRef:
     name: sentinel1

--- a/docs/guides/redis/configuration/redis.md
+++ b/docs/guides/redis/configuration/redis.md
@@ -103,7 +103,7 @@ metadata:
   name: custom-redis
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   configuration:
     secretName: rd-configuration
   storage:

--- a/docs/guides/redis/custom-rbac/using-custom-rbac.md
+++ b/docs/guides/redis/custom-rbac/using-custom-rbac.md
@@ -144,7 +144,7 @@ metadata:
   name: quick-redis
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -194,7 +194,7 @@ metadata:
   name: minute-redis
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   podTemplate:
     spec:
       serviceAccountName: my-custom-serviceaccount

--- a/docs/guides/redis/external-connections/exposure.md
+++ b/docs/guides/redis/external-connections/exposure.md
@@ -220,7 +220,7 @@ metadata:
   name: redis-announce
   namespace: demo
 spec:
-  version: 7.4.0
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/guides/redis/external-connections/initialization.md
+++ b/docs/guides/redis/external-connections/initialization.md
@@ -56,7 +56,7 @@ metadata:
   name: redis-announce
   namespace: demo
 spec:
-  version: 7.4.0
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3
@@ -125,7 +125,7 @@ metadata:
   name: redis
   namespace: demo
 spec:
-  version: 7.4.0
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/guides/redis/initialization/using-script.md
+++ b/docs/guides/redis/initialization/using-script.md
@@ -57,7 +57,7 @@ metadata:
   name: rd-init-script
   namespace: demo
 spec:
-  version: 7.2.3
+  version: 8.2.2
   disableAuth: false
   storageType: Durable
   init:
@@ -269,7 +269,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   terminationPolicy: WipeOut
-  version: 7.2.3
+  version: 8.2.2
 status:
   conditions:
   - lastTransitionTime: "2024-08-06T05:59:40Z"

--- a/docs/guides/redis/monitoring/overview.md
+++ b/docs/guides/redis/monitoring/overview.md
@@ -53,7 +53,7 @@ metadata:
   name: sample-redis
   namespace: databases
 spec:
-  version: 6.0.20
+  version: 8.2.2
   deletionPolicy: WipeOut
   configuration: # configure Redis to use password for authentication
     secretName: redis-config

--- a/docs/guides/redis/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/redis/monitoring/using-builtin-prometheus.md
@@ -49,7 +49,7 @@ metadata:
   name: builtin-prom-redis
   namespace: demo
 spec:
-  version: 6.0.20
+  version: 8.2.2
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/redis/monitoring/using-prometheus-operator.md
+++ b/docs/guides/redis/monitoring/using-prometheus-operator.md
@@ -95,7 +95,7 @@ metadata:
   name: coreos-prom-redis
   namespace: demo
 spec:
-  version: 6.0.20
+  version: 8.2.2
   deletionPolicy: WipeOut
   storage:
     storageClassName: "standard"

--- a/docs/guides/redis/private-registry/using-private-registry.md
+++ b/docs/guides/redis/private-registry/using-private-registry.md
@@ -118,7 +118,7 @@ metadata:
   name: redis-pvt-reg
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/guides/redis/quickstart/overview/redis.md
+++ b/docs/guides/redis/quickstart/overview/redis.md
@@ -86,7 +86,7 @@ metadata:
   name: redis-quickstart
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -110,7 +110,7 @@ metadata:
   name: redis-quickstart
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -298,7 +298,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   deletionPolicy: Delete
-  version: 6.2.14
+  version: 8.2.2
 status:
   conditions:
     - lastTransitionTime: "2022-05-31T04:31:38Z"

--- a/docs/guides/redis/reconfigure-tls/sentinel.md
+++ b/docs/guides/redis/reconfigure-tls/sentinel.md
@@ -49,7 +49,7 @@ metadata:
   name: sen-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   storageType: Durable
   storage:
@@ -88,7 +88,7 @@ metadata:
   name: rd-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   sentinelRef:
     name: sen-sample

--- a/docs/guides/redis/reconfigure-tls/standalone.md
+++ b/docs/guides/redis/reconfigure-tls/standalone.md
@@ -51,7 +51,7 @@ metadata:
   name: rd-sample
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   mode: Standalone
   storage:
     storageClassName: "standard"

--- a/docs/guides/redis/reconfigure/redis.md
+++ b/docs/guides/redis/reconfigure/redis.md
@@ -40,7 +40,7 @@ Now, we are going to deploy a  `Redis` database using a supported version by `Ku
 
 ### Prepare Redis Database
 
-Now, we are going to deploy a `Redis` database with version `6.2.14`.
+Now, we are going to deploy a `Redis` database with version `8.2.2`.
 
 ### Deploy Redis 
 
@@ -68,7 +68,7 @@ metadata:
   name: sample-redis
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/redis/rotateauth/rotateauth.md
+++ b/docs/guides/redis/rotateauth/rotateauth.md
@@ -57,7 +57,7 @@ metadata:
   name: redis-quickstart
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/redis/scaling/horizontal-scaling/cluster.md
+++ b/docs/guides/redis/scaling/horizontal-scaling/cluster.md
@@ -43,7 +43,7 @@ Here, we are going to deploy a `Redis` cluster using a supported version by `Kub
 
 ### Prepare Redis Cluster Database
 
-Now, we are going to deploy a `Redis` cluster database with version `6.2.14`.
+Now, we are going to deploy a `Redis` cluster database with version `8.2.2`.
 
 ### Deploy Redis Cluster 
 
@@ -56,7 +56,7 @@ metadata:
   name: redis-cluster
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/guides/redis/scaling/horizontal-scaling/sentinel.md
+++ b/docs/guides/redis/scaling/horizontal-scaling/sentinel.md
@@ -39,7 +39,7 @@ namespace/demo created
 
 ### Prepare Redis Sentinel Database
 
-Now, we are going to deploy a `RedisSentinel` instance with version `6.2.14` and a `Redis` database with version `6.2.14`. Then, in the next section we are going to apply horizontal scaling on the sentinel and the database using `RedisSentinelOpsRequest` and `RedisOpsRequest` CRO.
+Now, we are going to deploy a `RedisSentinel` instance with version `8.2.2` and a `Redis` database with version `8.2.2`. Then, in the next section we are going to apply horizontal scaling on the sentinel and the database using `RedisSentinelOpsRequest` and `RedisOpsRequest` CRO.
 
 ### Deploy RedisSentinel :
 
@@ -52,7 +52,7 @@ metadata:
   name: sen-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 5
   storageType: Durable
   storage:
@@ -98,7 +98,7 @@ metadata:
   name: rd-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   sentinelRef:
     name: sen-sample

--- a/docs/guides/redis/scaling/vertical-scaling/cluster.md
+++ b/docs/guides/redis/scaling/vertical-scaling/cluster.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `Redis` cluster using a supported version by `Kub
 
 ### Prepare Redis Cluster Database
 
-Now, we are going to deploy a `Redis` cluster database with version `6.2.14`.
+Now, we are going to deploy a `Redis` cluster database with version `8.2.2`.
 
 ### Deploy Redis Cluster 
 
@@ -55,7 +55,7 @@ metadata:
   name: redis-cluster
   namespace: demo
 spec:
-  version: 7.0.14
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/guides/redis/scaling/vertical-scaling/sentinel.md
+++ b/docs/guides/redis/scaling/vertical-scaling/sentinel.md
@@ -39,7 +39,7 @@ namespace/demo created
 
 ### Prepare Redis Sentinel Database
 
-Now, we are going to deploy a `RedisSentinel` instance with version `6.2.14` and a `Redis` database with version `6.2.14`. Then, in the next section we are going to apply vertical scaling on the sentinel and the database using `RedisOpsRequest` CRD
+Now, we are going to deploy a `RedisSentinel` instance with version `8.2.2` and a `Redis` database with version `8.2.2`. Then, in the next section we are going to apply vertical scaling on the sentinel and the database using `RedisOpsRequest` CRD
 
 ### Deploy RedisSentinel :
 
@@ -52,7 +52,7 @@ metadata:
   name: sen-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   storageType: Durable
   storage:
@@ -113,7 +113,7 @@ metadata:
   name: rd-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   sentinelRef:
     name: sen-sample

--- a/docs/guides/redis/scaling/vertical-scaling/standalone.md
+++ b/docs/guides/redis/scaling/vertical-scaling/standalone.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a  `Redis` standalone using a supported version by 
 
 ### Prepare Redis Standalone Database
 
-Now, we are going to deploy a `Redis` standalone database with version `6.2.14`.
+Now, we are going to deploy a `Redis` standalone database with version `8.2.2`.
 
 ### Deploy Redis standalone 
 
@@ -55,7 +55,7 @@ metadata:
   name: redis-quickstart
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/guides/redis/sentinel/redis-sentinel.md
+++ b/docs/guides/redis/sentinel/redis-sentinel.md
@@ -48,7 +48,7 @@ metadata:
   name: sen-demo
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   storageType: Durable
   storage:
@@ -84,7 +84,7 @@ metadata:
   name: rd-demo
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   sentinelRef:
     name: sen-demo
@@ -211,7 +211,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   deletionPolicy: Halt
-  version: 6.2.14
+  version: 8.2.2
 status:
   conditions:
   - lastTransitionTime: "2023-02-03T06:36:16Z"

--- a/docs/guides/redis/sentinel/replacesentinel/replace-sentinel.md
+++ b/docs/guides/redis/sentinel/replacesentinel/replace-sentinel.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a  `Redis` and `RedisSentinel` instance using a sup
 
 ### Prepare RedisSentinel
 
-Now, we are going to deploy a `RedisSentinel` version `6.2.14`.
+Now, we are going to deploy a `RedisSentinel` version `8.2.2`.
 ```yaml
 apiVersion: kubedb.com/v1
 kind: RedisSentinel
@@ -50,7 +50,7 @@ metadata:
   name: sen-demo
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   storageType: Durable
   storage:
@@ -86,7 +86,7 @@ metadata:
   name: rd-demo
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   sentinelRef:
     name: sen-demo
@@ -175,7 +175,7 @@ metadata:
   name: new-sentinel
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   replicas: 3
   storageType: Durable
   storage:

--- a/docs/guides/redis/tls/cluster.md
+++ b/docs/guides/redis/tls/cluster.md
@@ -94,7 +94,7 @@ metadata:
   name: rd-tls
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   mode: Cluster
   cluster:
     shards: 3

--- a/docs/guides/redis/tls/sentinel.md
+++ b/docs/guides/redis/tls/sentinel.md
@@ -99,7 +99,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "6.2.14"
+  version: "8.2.2"
   tls:
     issuerRef:
       apiGroup: "cert-manager.io"
@@ -170,7 +170,7 @@ metadata:
   name: rd-tls
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   mode: Sentinel
   replicas: 3
   sentinelRef:

--- a/docs/guides/redis/tls/standalone.md
+++ b/docs/guides/redis/tls/standalone.md
@@ -94,7 +94,7 @@ metadata:
   name: rd-tls
   namespace: demo
 spec:
-  version: "6.2.14"
+  version: "8.2.2"
   tls:
     issuerRef:
       apiGroup: "cert-manager.io"

--- a/docs/guides/redis/update-version/cluster.md
+++ b/docs/guides/redis/update-version/cluster.md
@@ -39,7 +39,7 @@ namespace/demo created
 
 ### Prepare Redis Cluster Database
 
-Now, we are going to deploy a `Redis` cluster database with version `6.2.14`.
+Now, we are going to deploy a `Redis` cluster database with version `7.4.6`.
 
 ### Deploy Redis cluster :
 
@@ -52,7 +52,7 @@ metadata:
   name: redis-cluster
   namespace: demo
 spec:
-  version: 6.0.20
+  version: 7.4.6
   mode: Cluster
   cluster:
     shards: 3
@@ -87,7 +87,7 @@ We are now ready to apply the `RedisOpsRequest` CR to update this database.
 
 ### Update Redis Version
 
-Here, we are going to update `Redis` cluster from `6.0.20` to `7.0.14`.
+Here, we are going to update `Redis` cluster from `7.4.6` to `8.2.2`.
 
 #### Create RedisOpsRequest:
 
@@ -104,14 +104,14 @@ spec:
   databaseRef:
     name: redis-cluster
   updateVersion:
-    targetVersion: 7.0.14
+    targetVersion: 8.2.2
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `redis-cluster` Redis database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `7.0.14`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `8.2.2`.
 
 Let's create the `RedisOpsRequest` CR we have shown above,
 

--- a/docs/guides/redis/update-version/sentinel.md
+++ b/docs/guides/redis/update-version/sentinel.md
@@ -39,7 +39,7 @@ namespace/demo created
 
 ### Prepare Redis Sentinel Database
 
-Now, we are going to deploy a `RedisSentinel` instance with version `6.2.14` and a `Redis` database with version `6.2.14`. Then, in the next section we will update the version of the sentinel and the database using `RedisOpsRequest` CRD
+Now, we are going to deploy a `RedisSentinel` instance with version `7.4.6` and a `Redis` database with version `7.4.6`. Then, in the next section we will update the version of the sentinel and the database using `RedisOpsRequest` CRD
 
 ### Deploy RedisSentinel :
 
@@ -52,7 +52,7 @@ metadata:
   name: sen-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 7.4.6
   replicas: 3
   storageType: Durable
   storage:
@@ -91,7 +91,7 @@ metadata:
   name: rd-sample
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 7.4.6
   replicas: 3
   sentinelRef:
     name: sen-sample
@@ -127,7 +127,7 @@ We are now ready to apply the `RedisSentinelOpsRequest` CR to update the sentine
 
 ### Update RedisSentinel Version
 
-Here, we are going to update `RedisSentinel` standalone from `6.2.14` to `7.0.14`.
+Here, we are going to update `RedisSentinel` standalone from `7.4.6` to `8.2.2`.
 
 #### Create RedisSentinelOpsRequest:
 
@@ -144,14 +144,14 @@ spec:
   databaseRef:
     name: sen-sample
   updateVersion:
-    targetVersion: 7.0.14
+    targetVersion: 8.2.2
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `sen-sample` RedisSentinel instance.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `7.0.14`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `8.2.2`.
 
 Let's create the `RedisSentinelOpsRequest` CR we have shown above,
 
@@ -191,7 +191,7 @@ redis:7.0.14@sha256:dfeb5451fce377ab47c5bb6b6826592eea534279354bbfc3890c0b5e9b57
 You can see from above, our `RedisSentinel` sen-demo has been updated with the new version. So, the UpdateVersion process is successfully completed.
 ### Update Redis Version
 
-Here, we are going to update `Redis` standalone from `6.2.14` to `7.0.4`.
+Here, we are going to update `Redis` standalone from `7.4.6` to `8.2.2`.
 
 #### Create RedispsRequest:
 
@@ -208,14 +208,14 @@ spec:
   databaseRef:
     name: rd-sample
   updateVersion:
-    targetVersion: 7.0.4
+    targetVersion: 8.2.2
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `rd-sample` Redis database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `7.0.14`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `8.2.2`.
 
 Let's create the `RedisOpsRequest` CR we have shown above,
 

--- a/docs/guides/redis/update-version/standalone.md
+++ b/docs/guides/redis/update-version/standalone.md
@@ -38,7 +38,7 @@ namespace/demo created
 
 ### Prepare Redis Standalone Database
 
-Now, we are going to deploy a `Redis` standalone database with version `6.2.14`.
+Now, we are going to deploy a `Redis` standalone database with version `7.4.6`.
 
 ### Deploy Redis standalone :
 
@@ -51,7 +51,7 @@ metadata:
   name: redis-quickstart
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 7.4.6
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -81,7 +81,7 @@ We are now ready to apply the `RedisOpsRequest` CR to update this database.
 
 ### Update Redis Version
 
-Here, we are going to update `Redis` standalone from `6.2.14` to `7.0.14`.
+Here, we are going to update `Redis` standalone from `7.4.6` to `8.2.2`.
 
 #### Create RedisOpsRequest:
 
@@ -98,14 +98,14 @@ spec:
   databaseRef:
     name: redis-quickstart
   updateVersion:
-    targetVersion: 7.0.14
+    targetVersion: 8.2.2
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `redis-quickstart` Redis database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `7.0.14`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `8.2.2`.
 
 Let's create the `RedisOpsRequest` CR we have shown above,
 

--- a/docs/guides/redis/volume-expansion/volume-expansion.md
+++ b/docs/guides/redis/volume-expansion/volume-expansion.md
@@ -54,7 +54,7 @@ topolvm-provisioner   topolvm.cybozu.com      Delete          WaitForFirstConsum
 
 We can see from the output the `topolvm-provisioner` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We will use this storage class. You can install topolvm from [here](https://github.com/topolvm/topolvm).
 
-Now, we are going to deploy a `Redis` database with in `Cluster` Mode version `6.2.14`.
+Now, we are going to deploy a `Redis` database with in `Cluster` Mode version `8.2.2`.
 
 ### Deploy Redis
 
@@ -67,7 +67,7 @@ metadata:
   name: sample-redis
   namespace: demo
 spec:
-  version: 6.2.14
+  version: 8.2.2
   mode: Cluster
   cluster:
     shards: 3


### PR DESCRIPTION
Bumps the **redis** example and guide manifests to the latest supported version (`8.2.2`) per the installer `active_versions.json`.

- General "deploy a redis" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.