### PR TITLE
Update solr docs examples to latest supported version (9.8.0)

### DIFF
--- a/docs/examples/solr/autoscaler/combined.yaml
+++ b/docs/examples/solr/autoscaler/combined.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/examples/solr/autoscaler/topology.yaml
+++ b/docs/examples/solr/autoscaler/topology.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-cluster
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/examples/solr/configuration/sl-custom-nodeselector.yaml
+++ b/docs/examples/solr/configuration/sl-custom-nodeselector.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-custom-nodeselector
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   podTemplate:
     spec:

--- a/docs/examples/solr/configuration/sl-custom-podtemplate.yaml
+++ b/docs/examples/solr/configuration/sl-custom-podtemplate.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-misc-config
   namespace: demo
 spec:
-  version: "9.6.1"
+  version: "9.8.0"
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/examples/solr/configuration/solr-combined.yaml
+++ b/docs/examples/solr/configuration/solr-combined.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   configuration:
     secretName: sl-combined-custom-config
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/examples/solr/configuration/solr-with-tolerations.yaml
+++ b/docs/examples/solr/configuration/solr-with-tolerations.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-with-toleration
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   podTemplate:
     spec:

--- a/docs/examples/solr/configuration/solr-without-toleration.yaml
+++ b/docs/examples/solr/configuration/solr-without-toleration.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-without-toleration
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/examples/solr/failover/ha_solr.yaml
+++ b/docs/examples/solr/failover/ha_solr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-ha
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   deletionPolicy: WipeOut
   replicas: 3
   zookeeperRef:

--- a/docs/examples/solr/monitoring/solr-builtin.yaml
+++ b/docs/examples/solr/monitoring/solr-builtin.yaml
@@ -4,7 +4,7 @@ metadata:
   name: builtin-prom-sl
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   enableSSL: true
   monitor:

--- a/docs/examples/solr/monitoring/solr-operator.yaml
+++ b/docs/examples/solr/monitoring/solr-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: operator-prom-sl
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   monitor:
     agent: prometheus.io/operator

--- a/docs/examples/solr/quickstart/solr.yaml
+++ b/docs/examples/solr/quickstart/solr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   deletionPolicy: Delete
   replicas: 2
   zookeeperRef:

--- a/docs/examples/solr/reconfigure/solr-combined.yaml
+++ b/docs/examples/solr/reconfigure/solr-combined.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   configuration:
     secretName: sl-combined-custom-config
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/examples/solr/restart/solr-cluster.yaml
+++ b/docs/examples/solr/restart/solr-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-cluster
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/examples/solr/scaling/horizontal/combined/solr.yaml
+++ b/docs/examples/solr/scaling/horizontal/combined/solr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/examples/solr/scaling/horizontal/topology/solr.yaml
+++ b/docs/examples/solr/scaling/horizontal/topology/solr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-cluster
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/examples/solr/scaling/vertical/combined/solr.yaml
+++ b/docs/examples/solr/scaling/vertical/combined/solr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/examples/solr/scaling/vertical/topology/solr.yaml
+++ b/docs/examples/solr/scaling/vertical/topology/solr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-cluster
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/examples/solr/tls/solr-combined.yaml
+++ b/docs/examples/solr/tls/solr-combined.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   replicas: 2
   enableSSL: true
   tls:

--- a/docs/examples/solr/tls/solr-topology.yaml
+++ b/docs/examples/solr/tls/solr-topology.yaml
@@ -19,7 +19,7 @@ spec:
           - localhost
         ipAddresses:
           - "127.0.0.1"
-  version: 9.4.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/examples/solr/update-version/solr.yaml
+++ b/docs/examples/solr/update-version/solr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-cluster
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.7.0
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/examples/solr/update-version/update-version-ops.yaml
+++ b/docs/examples/solr/update-version/update-version-ops.yaml
@@ -8,4 +8,4 @@ spec:
     name: solr-cluster
   type: UpdateVersion
   updateVersion:
-    targetVersion: 9.6.1
+    targetVersion: 9.8.0

--- a/docs/examples/solr/volume-expansion/combined.yaml
+++ b/docs/examples/solr/volume-expansion/combined.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/examples/solr/volume-expansion/topology.yaml
+++ b/docs/examples/solr/volume-expansion/topology.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-cluster
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/guides/solr/autoscaler/compute/combined.md
+++ b/docs/guides/solr/autoscaler/compute/combined.md
@@ -45,7 +45,7 @@ Here, we are going to deploy an `Solr` in combined cluster mode using a supporte
 
 ### Deploy Solr Combined
 
-In this section, we are going to deploy an Solr combined cluster with SolrVersion `9.6.1`.  Then, in the next section, we will set up autoscaling for this database using `SolrAutoscaler` CRD. Below is the YAML of the `Solr` CR that we are going to create,
+In this section, we are going to deploy an Solr combined cluster with SolrVersion `9.8.0`.  Then, in the next section, we will set up autoscaling for this database using `SolrAutoscaler` CRD. Below is the YAML of the `Solr` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -54,7 +54,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/guides/solr/autoscaler/compute/topology.md
+++ b/docs/guides/solr/autoscaler/compute/topology.md
@@ -45,7 +45,7 @@ Here, we are going to deploy an `Solr` topology cluster using a supported versio
 
 #### Deploy Solr Topology Cluster
 
-In this section, we are going to deploy an Solr topology with SolrVersion `9.4.1`. Then, in the next section we will set up autoscaling for this database using `SolrAutoscaler` CRD. Below is the YAML of the `Solr` CR that we are going to create,
+In this section, we are going to deploy an Solr topology with SolrVersion `9.8.0`. Then, in the next section we will set up autoscaling for this database using `SolrAutoscaler` CRD. Below is the YAML of the `Solr` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -54,7 +54,7 @@ metadata:
   name: solr-cluster
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/guides/solr/autoscaler/storage/combined.md
+++ b/docs/guides/solr/autoscaler/storage/combined.md
@@ -58,7 +58,7 @@ Now, we are going to deploy a `Solr` combined cluster using a supported version 
 
 #### Deploy Solr Combined Cluster
 
-In this section, we are going to deploy a solr combined cluster with version `9.6.1`.  Then, in the next section we will set up autoscaling for this database using `SolrAutoscaler` CRD. Below is the YAML of the `Solr` CR that we are going to create,
+In this section, we are going to deploy a solr combined cluster with version `9.8.0`.  Then, in the next section we will set up autoscaling for this database using `SolrAutoscaler` CRD. Below is the YAML of the `Solr` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -67,7 +67,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/guides/solr/autoscaler/storage/topology.md
+++ b/docs/guides/solr/autoscaler/storage/topology.md
@@ -60,7 +60,7 @@ Now, we are going to deploy a `Solr` topology cluster using a supported version 
 
 #### Deploy Solr Topology
 
-In this section, we are going to deploy a Solr topology cluster with version `9.6.1`.  Then, in the next section we will set up autoscaling for this database using `SolrAutoscaler` CRD. Below is the YAML of the `Solr` CR that we are going to create,
+In this section, we are going to deploy a Solr topology cluster with version `9.8.0`.  Then, in the next section we will set up autoscaling for this database using `SolrAutoscaler` CRD. Below is the YAML of the `Solr` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -69,7 +69,7 @@ metadata:
   name: solr-cluster
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/guides/solr/clustering/combined_cluster.md
+++ b/docs/guides/solr/clustering/combined_cluster.md
@@ -89,7 +89,7 @@ $ kubectl get ZooKeeper -n demo -w
 NAME       TYPE                  VERSION   STATUS   AGE
 zoo-com    kubedb.com/v1alpha2   3.7.2     Ready    13m
 ```
-Here, we are going to create a standalone (ie. `replicas: 1`) Solr cluster. We will use the Solr image provided by the Solr (`9.6.1`) for this demo. To learn more about Solr CR, visit [here](/docs/guides/solr/concepts/solr.md).
+Here, we are going to create a standalone (ie. `replicas: 1`) Solr cluster. We will use the Solr image provided by the Solr (`9.8.0`) for this demo. To learn more about Solr CR, visit [here](/docs/guides/solr/concepts/solr.md).
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -98,7 +98,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   deletionPolicy: DoNotTerminate
   replicas: 2
   enableSSL: true
@@ -252,7 +252,7 @@ $ curl -XGET -k -u 'admin:Xy3ZjyU)~(9IO8_n' "http://localhost:8983/solr/admin/co
 
 ## Create Multi-Node Combined Solr Cluster
 
-Here, we are going to create a multi-node (say `replicas: 2`) Solr cluster. We will use the Solr image provided by the Solr (`9.6.1`) for this demo. To learn more about Solr CR, visit [here](/docs/guides/solr/concepts/solr.md).
+Here, we are going to create a multi-node (say `replicas: 2`) Solr cluster. We will use the Solr image provided by the Solr (`9.8.0`) for this demo. To learn more about Solr CR, visit [here](/docs/guides/solr/concepts/solr.md).
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -261,7 +261,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   deletionPolicy: DoNotTerminate
   replicas: 2
   enableSSL: true

--- a/docs/guides/solr/clustering/topology_cluster.md
+++ b/docs/guides/solr/clustering/topology_cluster.md
@@ -47,7 +47,7 @@ Here, we have `standard` StorageClass in our cluster from [Local Path Provisione
 
 ## Create Solr Topology Cluster
 
-We are going to create a Solr Cluster in topology mode. Our cluster will be composed of 1 overseer nodes, 2 data nodes, 1 coordinator nodes. Here, we are using Solr version ( `9.4.1` ). To learn more about the Solr CR, visit [here](/docs/guides/solr/concepts/solr.md).
+We are going to create a Solr Cluster in topology mode. Our cluster will be composed of 1 overseer nodes, 2 data nodes, 1 coordinator nodes. Here, we are using Solr version ( `9.8.0` ). To learn more about the Solr CR, visit [here](/docs/guides/solr/concepts/solr.md).
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -72,7 +72,7 @@ spec:
       ipAddresses:
       - "127.0.0.1"
   deletionPolicy: DoNotTerminate
-  version: 9.4.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo-com
     namespace: demo
@@ -107,7 +107,7 @@ spec:
 
 Here,
 
-- `spec.version` - is the name of the SolrVersion CR. Here, we are using Solr version `9.4.1`.
+- `spec.version` - is the name of the SolrVersion CR. Here, we are using Solr version `9.8.0`.
 - `spec.enableSSL` - specifies whether the HTTP layer is secured with certificates or not.
 - `spec.storageType` - specifies the type of storage that will be used for Solr database. It can be `Durable` or `Ephemeral`. The default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create the Solr database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.topology` - specifies the node-specific properties for the Solr cluster.

--- a/docs/guides/solr/clustering/yamls/combined-multinode.yaml
+++ b/docs/guides/solr/clustering/yamls/combined-multinode.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   deletionPolicy: DoNotTerminate
   replicas: 2
   enableSSL: true

--- a/docs/guides/solr/clustering/yamls/combined-standalone.yaml
+++ b/docs/guides/solr/clustering/yamls/combined-standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   deletionPolicy: DoNotTerminate
   replicas: 1
   enableSSL: true

--- a/docs/guides/solr/clustering/yamls/topology.yaml
+++ b/docs/guides/solr/clustering/yamls/topology.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   enableSSL: true
   deletionPolicy: DoNotTerminate
-  version: 9.6.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo-com
     namespace: demo

--- a/docs/guides/solr/concepts/appbinding.md
+++ b/docs/guides/solr/concepts/appbinding.md
@@ -67,7 +67,7 @@ spec:
   secret:
     name: solr-dev-admin-cred
   type: kubedb.com/solr
-  version: 9.4.1
+  version: 9.8.0
 ```
 
 Here, we are going to describe the sections of an `AppBinding` crd.

--- a/docs/guides/solr/concepts/solr.md
+++ b/docs/guides/solr/concepts/solr.md
@@ -88,7 +88,7 @@ spec:
             storage: 1Gi
         storageClassName: standard
       suffix: overseer
-  version: 9.4.1
+  version: 9.8.0
   zookeeperDigestReadonlySecret:
     name: solr-cluster-zk-digest-readonly
   zookeeperDigestSecret:

--- a/docs/guides/solr/concepts/solropsrequests.md
+++ b/docs/guides/solr/concepts/solropsrequests.md
@@ -80,7 +80,7 @@ It specifies the desired version information required for the Solr version updat
 > KubeDB does not support downgrade for Solr.
 
 **Samples:**
-Let's assume we have and Solr cluster of version `9.4.1`. The Solr custom resource is named `solr-cluster` and it's provisioned in demo namespace. Now, you want to update your Solr cluster to `9.6.1`. Apply this YAML to update to your desired version.
+Let's assume we have and Solr cluster of version `9.7.0`. The Solr custom resource is named `solr-cluster` and it's provisioned in demo namespace. Now, you want to update your Solr cluster to `9.8.0`. Apply this YAML to update to your desired version.
 ```yaml
 apiVersion: ops.kubedb.com/v1alpha1
 kind: SolrOpsRequest
@@ -92,7 +92,7 @@ spec:
     name: solr-cluster
   type: UpdateVersion
   updateVersion:
-    targetVersion: 9.6.1
+    targetVersion: 9.8.0
 ```
 
 ### spec.horizontalScaling

--- a/docs/guides/solr/configuration/config-file.md
+++ b/docs/guides/solr/configuration/config-file.md
@@ -39,7 +39,7 @@ Now, we are going to deploy a  `Solr` cluster using a supported version by `Kube
 
 ### Prepare Solr Cluster
 
-Now, we are going to deploy a `Solr` cluster with version `9.6.1`.
+Now, we are going to deploy a `Solr` cluster with version `9.8.0`.
 
 ### Deploy Solr
 
@@ -90,7 +90,7 @@ metadata:
 spec:
   configuration:
     secretName: sl-custom-config
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/guides/solr/configuration/custom-pod-template.md
+++ b/docs/guides/solr/configuration/custom-pod-template.md
@@ -74,7 +74,7 @@ metadata:
   name: solr-misc-config
   namespace: demo
 spec:
-  version: "9.6.1"
+  version: "9.8.0"
   topology:
     data:
       replicas: 1
@@ -262,7 +262,7 @@ metadata:
   name: solr-custom-nodeselector
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   podTemplate:
     spec:
@@ -426,7 +426,7 @@ metadata:
   name: solr-without-toleration
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo
@@ -605,7 +605,7 @@ metadata:
   name: solr-with-toleration
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   podTemplate:
     spec:

--- a/docs/guides/solr/failover/overview.md
+++ b/docs/guides/solr/failover/overview.md
@@ -123,7 +123,7 @@ metadata:
   name: solr-ha
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   deletionPolicy: WipeOut
   replicas: 3
   zookeeperRef:

--- a/docs/guides/solr/monitoring/prometheus-builtin.md
+++ b/docs/guides/solr/monitoring/prometheus-builtin.md
@@ -53,7 +53,7 @@ metadata:
   name: builtin-prom-sl
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   enableSSL: true
   monitor:

--- a/docs/guides/solr/monitoring/prometheus-operator.md
+++ b/docs/guides/solr/monitoring/prometheus-operator.md
@@ -179,7 +179,7 @@ metadata:
   name: operator-prom-sl
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   replicas: 2
   monitor:
     agent: prometheus.io/operator

--- a/docs/guides/solr/quickstart/overview/index.md
+++ b/docs/guides/solr/quickstart/overview/index.md
@@ -66,7 +66,7 @@ NAME     VERSION   DB_IMAGE                              DEPRECATED   AGE
 
 Notice the `DEPRECATED` column. Here, `true` means that this SolrVersion is deprecated for the current KubeDB version. KubeDB will not work for deprecated SolrVersion.
 
-In this tutorial, we will use `9.4.1` SolrVersion CR to create a Solr cluster.
+In this tutorial, we will use `9.8.0` SolrVersion CR to create a Solr cluster.
 
 > Note: An image with a higher modification tag will have more features and fixes than an image with a lower modification tag. Hence, it is recommended to use SolrVersion CRD with the highest modification tag to take advantage of the latest features. For example, use `9.4.1` over `8.11.2`.
 
@@ -138,7 +138,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   deletionPolicy: Delete
   replicas: 2
   zookeeperRef:
@@ -155,7 +155,7 @@ spec:
 
 Here,
 
-- `spec.version` - is the name of the SolrVersion CR. Here, a Solr of version `9.4.1` will be created.
+- `spec.version` - is the name of the SolrVersion CR. Here, a Solr of version `9.8.0` will be created.
 - `spec.replicas` - specifies the number of Solr nodes.
 - `spec.storageType` - specifies the type of storage that will be used for Solr database. It can be `Durable` or `Ephemeral`. The default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create the Solr database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the Petset created by the KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests. If you don't specify `spec.storageType: Ephemeral`, then this field is required.

--- a/docs/guides/solr/quickstart/overview/yamls/solr/solr.yaml
+++ b/docs/guides/solr/quickstart/overview/yamls/solr/solr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   deletionPolicy: Halt
   replicas: 2
   zookeeperRef:

--- a/docs/guides/solr/reconfigure-tls/solr.md
+++ b/docs/guides/solr/reconfigure-tls/solr.md
@@ -50,7 +50,7 @@ metadata:
 spec:
   enableSSL: true
   deletionPolicy: DoNotTerminate
-  version: 9.6.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo-com
     namespace: demo

--- a/docs/guides/solr/reconfigure/solr.md
+++ b/docs/guides/solr/reconfigure/solr.md
@@ -41,7 +41,7 @@ Now, we are going to deploy a  `Solr` cluster using a supported version by `Kube
 
 ### Prepare Solr Cluster
 
-Now, we are going to deploy a `Solr` cluster with version `9.6.1`.
+Now, we are going to deploy a `Solr` cluster with version `9.8.0`.
 
 ### Deploy Solr
 
@@ -92,7 +92,7 @@ metadata:
 spec:
 +  configuration:
 +    secretName: sl-custom-config
-  version: 9.6.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/guides/solr/restart/restart.md
+++ b/docs/guides/solr/restart/restart.md
@@ -42,7 +42,7 @@ metadata:
   name: solr-cluster
   namespace: demo
 spec:
-  version: 9.6.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/guides/solr/scaling/horizontal-scaling/combined.md
+++ b/docs/guides/solr/scaling/horizontal-scaling/combined.md
@@ -43,7 +43,7 @@ Here, we are going to deploy a  `Solr` combined cluster using a supported versio
 
 ### Prepare Solr Combined cluster
 
-Now, we are going to deploy a `Solr` combined cluster with version `9.4.1`.
+Now, we are going to deploy a `Solr` combined cluster with version `9.8.0`.
 
 ### Deploy Solr combined cluster
 
@@ -56,7 +56,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/guides/solr/scaling/horizontal-scaling/topology.md
+++ b/docs/guides/solr/scaling/horizontal-scaling/topology.md
@@ -43,7 +43,7 @@ Here, we are going to deploy a `Solr` topology cluster using a supported version
 
 ### Prepare Solr Topology cluster
 
-Now, we are going to deploy a `Solr` topology cluster with version `9.4.1`.
+Now, we are going to deploy a `Solr` topology cluster with version `9.8.0`.
 
 ### Deploy Solr topology cluster
 
@@ -56,7 +56,7 @@ metadata:
   name: solr-cluster
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/guides/solr/scaling/vertical-scaling/combined.md
+++ b/docs/guides/solr/scaling/vertical-scaling/combined.md
@@ -56,7 +56,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/guides/solr/scaling/vertical-scaling/topology.md
+++ b/docs/guides/solr/scaling/vertical-scaling/topology.md
@@ -56,7 +56,7 @@ metadata:
   name: solr-cluster
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/guides/solr/tls/combined.md
+++ b/docs/guides/solr/tls/combined.md
@@ -97,7 +97,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   replicas: 2
   enableSSL: true
   tls:

--- a/docs/guides/solr/tls/topology.md
+++ b/docs/guides/solr/tls/topology.md
@@ -112,7 +112,7 @@ spec:
           - localhost
         ipAddresses:
           - "127.0.0.1"
-  version: 9.4.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo
     namespace: demo

--- a/docs/guides/solr/update-version/update-version.md
+++ b/docs/guides/solr/update-version/update-version.md
@@ -51,7 +51,7 @@ metadata:
   name: solr-cluster
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.7.0
   zookeeperRef:
     name: zoo
     namespace: demo
@@ -105,7 +105,7 @@ We are now ready to apply the `SolrOpsRequest` CR to update.
 
 ### update Solr Version
 
-Here, we are going to update `Solr` from `9.4.1` to `9.6.1`.
+Here, we are going to update `Solr` from `9.7.0` to `9.8.0`.
 
 #### Create SolrOpsRequest:
 
@@ -122,14 +122,14 @@ spec:
     name: solr-cluster
   type: UpdateVersion
   updateVersion:
-    targetVersion: 9.6.1
+    targetVersion: 9.8.0
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `solr-cluster` Solr.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `9.6.1`.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `9.8.0`.
 
 > **Note:** If you want to update combined Solr, you just refer to the `Solr` combined object name in `spec.databaseRef.name`. To create a combined Solr, you can refer to the [Solr Combined](/docs/guides/solr/clustering/combined_cluster.md) guide.
 

--- a/docs/guides/solr/volume-expansion/combined.md
+++ b/docs/guides/solr/volume-expansion/combined.md
@@ -55,7 +55,7 @@ local-path (default)   rancher.io/local-path   Delete          WaitForFirstConsu
 
 We can see from the output the `local-path` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We can use it.
 
-Now, we are going to deploy a `Solr` combined cluster with version `9.4.1`.
+Now, we are going to deploy a `Solr` combined cluster with version `9.8.0`.
 
 ### Deploy Solr
 
@@ -68,7 +68,7 @@ metadata:
   name: solr-combined
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   replicas: 2
   zookeeperRef:
     name: zoo

--- a/docs/guides/solr/volume-expansion/topology.md
+++ b/docs/guides/solr/volume-expansion/topology.md
@@ -55,7 +55,7 @@ local-path (default)   rancher.io/local-path   Delete          WaitForFirstConsu
 
 We can see from the output the `local-path` storage class has `ALLOWVOLUMEEXPANSION` field as false. So, this storage class supports volume expansion. We can use it.
 
-Now, we are going to deploy a `Solr` combined cluster with version `9.4.1`.
+Now, we are going to deploy a `Solr` combined cluster with version `9.8.0`.
 
 ### Deploy Solr
 
@@ -68,7 +68,7 @@ metadata:
   name: solr-cluster
   namespace: demo
 spec:
-  version: 9.4.1
+  version: 9.8.0
   zookeeperRef:
     name: zoo
     namespace: demo


### PR DESCRIPTION
Bumps the **solr** example and guide manifests to the latest supported version (`9.8.0`) per the installer `active_versions.json`.

- General "deploy a solr" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.