### PR TITLE
Update zookeeper docs examples to latest supported version (3.9.1)

### DIFF
--- a/docs/examples/zookeeper/monitoring/builtin-prom-zk.yaml
+++ b/docs/examples/zookeeper/monitoring/builtin-prom-zk.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zookeeper-builtin-prom
   namespace: demo
 spec:
-  version: 3.8.3
+  version: 3.9.1
   replicas: 3
   storage:
     resources:

--- a/docs/examples/zookeeper/monitoring/prom-zk.yaml
+++ b/docs/examples/zookeeper/monitoring/prom-zk.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zookeeper
   namespace: demo
 spec:
-  version: 3.8.3
+  version: 3.9.1
   replicas: 3
   storage:
     resources:

--- a/docs/examples/zookeeper/reconfiguration/sample-zk-configuration.yaml
+++ b/docs/examples/zookeeper/reconfiguration/sample-zk-configuration.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zk-quickstart
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   configuration:

--- a/docs/examples/zookeeper/reconfigure-tls/zookeeper.yaml
+++ b/docs/examples/zookeeper/reconfigure-tls/zookeeper.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zk-quickstart
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:

--- a/docs/examples/zookeeper/restart/zookeeper.yaml
+++ b/docs/examples/zookeeper/restart/zookeeper.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zk-quickstart
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:

--- a/docs/examples/zookeeper/scaling/zookeeper.yaml
+++ b/docs/examples/zookeeper/scaling/zookeeper.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zk-quickstart
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 4
   storage:

--- a/docs/examples/zookeeper/tls/zookeeper-tls.yaml
+++ b/docs/examples/zookeeper/tls/zookeeper-tls.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zk-quickstart
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   enableSSL: true
   tls:
     issuerRef:

--- a/docs/examples/zookeeper/volume-expansion/zookeeper.yaml
+++ b/docs/examples/zookeeper/volume-expansion/zookeeper.yaml
@@ -4,7 +4,7 @@ metadata:
   name: zk-quickstart
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:

--- a/docs/guides/zookeeper/backup/kubestash/auto-backup/examples/sample-zookeeper-2.yaml
+++ b/docs/guides/zookeeper/backup/kubestash/auto-backup/examples/sample-zookeeper-2.yaml
@@ -12,7 +12,7 @@ metadata:
     variables.kubestash.com/targetName: sample-zookeeper-2
     variables.kubestash.com/targetedDatabase: zookeeper
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:

--- a/docs/guides/zookeeper/backup/kubestash/auto-backup/examples/sample-zookeeper.yaml
+++ b/docs/guides/zookeeper/backup/kubestash/auto-backup/examples/sample-zookeeper.yaml
@@ -7,7 +7,7 @@ metadata:
     blueprint.kubestash.com/name: zookeeper-default-backup-blueprint
     blueprint.kubestash.com/namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:

--- a/docs/guides/zookeeper/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/zookeeper/backup/kubestash/auto-backup/index.md
@@ -219,7 +219,7 @@ metadata:
     blueprint.kubestash.com/name: zookeeper-default-backup-blueprint
     blueprint.kubestash.com/namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:
@@ -412,7 +412,7 @@ metadata:
     - kubestash.com/cleanup
   generation: 1
   labels:
-    kubedb.com/db-version: 3.8.3
+    kubedb.com/db-version: 3.9.1
     kubestash.com/app-ref-kind: ZooKeeper
     kubestash.com/app-ref-name: sample-zookeeper
     kubestash.com/app-ref-namespace: demo
@@ -572,7 +572,7 @@ metadata:
     variables.kubestash.com/targetName: sample-zookeeper-2
     variables.kubestash.com/targetedDatabase: zookeeper
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:
@@ -762,7 +762,7 @@ metadata:
     - kubestash.com/cleanup
   generation: 1
   labels:
-    kubedb.com/db-version: 3.8.3
+    kubedb.com/db-version: 3.9.1
     kubestash.com/app-ref-kind: ZooKeeper
     kubestash.com/app-ref-name: sample-zookeeper-2
     kubestash.com/app-ref-namespace: demo

--- a/docs/guides/zookeeper/backup/kubestash/customization/common/sample-zookeeper.yaml
+++ b/docs/guides/zookeeper/backup/kubestash/customization/common/sample-zookeeper.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-zookeeper
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 4
   storage:

--- a/docs/guides/zookeeper/backup/kubestash/logical/examples/restored-zookeeper.yaml
+++ b/docs/guides/zookeeper/backup/kubestash/logical/examples/restored-zookeeper.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restored-zookeeper
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 4
   storage:

--- a/docs/guides/zookeeper/backup/kubestash/logical/examples/sample-zookeeper.yaml
+++ b/docs/guides/zookeeper/backup/kubestash/logical/examples/sample-zookeeper.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-zookeeper
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 4
   storage:

--- a/docs/guides/zookeeper/backup/kubestash/logical/index.md
+++ b/docs/guides/zookeeper/backup/kubestash/logical/index.md
@@ -68,7 +68,7 @@ metadata:
   name: sample-zookeeper
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:
@@ -169,7 +169,7 @@ spec:
   secret:
     name: sample-zookeeper-auth
   type: kubedb.com/zookeeper
-  version: 3.8.3
+  version: 3.9.1
 ```
 
 KubeStash uses the `AppBinding` CR to connect with the target database. It requires the following two fields to set in AppBinding's `.spec` section.
@@ -458,7 +458,7 @@ metadata:
     kubestash.com/app-ref-namespace: demo
     kubestash.com/repo-name: s3-zookeeper-repo
   annotations:
-    kubedb.com/db-version: "3.8.3"
+    kubedb.com/db-version: "3.9.1"
   name: s3-zookeeper-repo-sample-zookeeper-backup-frequent-backup-1726572962
   namespace: demo
   ownerReferences:
@@ -539,7 +539,7 @@ metadata:
   name: restored-zookeeper
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:

--- a/docs/guides/zookeeper/monitoring/overview.md
+++ b/docs/guides/zookeeper/monitoring/overview.md
@@ -53,7 +53,7 @@ metadata:
   name: zookeeper
   namespace: demo
 spec:
-  version: 3.8.3
+  version: 3.9.1
   replicas: 3
   storage:
     resources:

--- a/docs/guides/zookeeper/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/zookeeper/monitoring/using-builtin-prometheus.md
@@ -49,7 +49,7 @@ metadata:
   name: zookeeper-builtin-prom
   namespace: demo
 spec:
-  version: 3.8.3
+  version: 3.9.1
   replicas: 3
   storage:
     resources:

--- a/docs/guides/zookeeper/monitoring/using-prometheus-operator.md
+++ b/docs/guides/zookeeper/monitoring/using-prometheus-operator.md
@@ -175,7 +175,7 @@ metadata:
   name: zookeeper
   namespace: demo
 spec:
-  version: 3.8.3
+  version: 3.9.1
   replicas: 3
   storage:
     resources:

--- a/docs/guides/zookeeper/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/zookeeper/reconfigure-tls/reconfigure-tls.md
@@ -48,7 +48,7 @@ metadata:
   name: zk-quickstart
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:

--- a/docs/guides/zookeeper/reconfigure/reconfigure.md
+++ b/docs/guides/zookeeper/reconfigure/reconfigure.md
@@ -40,7 +40,7 @@ Now, we are going to deploy a  `ZooKeeper` cluster using a supported version by 
 
 ### Prepare ZooKeeper Ensemble
 
-Now, we are going to deploy a `ZooKeeper` cluster with version `3.8.3`.
+Now, we are going to deploy a `ZooKeeper` cluster with version `3.9.1`.
 
 ### Deploy ZooKeeper Ensemble
 
@@ -73,7 +73,7 @@ metadata:
   name: zk-quickstart
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   configuration:

--- a/docs/guides/zookeeper/restart/restart.md
+++ b/docs/guides/zookeeper/restart/restart.md
@@ -42,7 +42,7 @@ metadata:
   name: zk-quickstart
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:

--- a/docs/guides/zookeeper/scaling/horizontal-scaling/horizontal-scaling.md
+++ b/docs/guides/zookeeper/scaling/horizontal-scaling/horizontal-scaling.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `ZooKeeper` using a supported version by `KubeDB`
 
 ### Deploy ZooKeeper
 
-In this section, we are going to deploy a ZooKeeper. We are going to deploy a `ZooKeeper` with version `3.8.3`. Then, in the next section we will scale the zookeeper using `ZooKeeperOpsRequest` CRD. Below is the YAML of the `ZooKeeper` CR that we are going to create,
+In this section, we are going to deploy a ZooKeeper. We are going to deploy a `ZooKeeper` with version `3.9.1`. Then, in the next section we will scale the zookeeper using `ZooKeeperOpsRequest` CRD. Below is the YAML of the `ZooKeeper` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -51,7 +51,7 @@ metadata:
   name: zk-quickstart
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:

--- a/docs/guides/zookeeper/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/zookeeper/scaling/vertical-scaling/vertical-scaling.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a  `ZooKeeper` standalone using a supported version
 
 ### Prepare ZooKeeper Standalone Database
 
-Now, we are going to deploy a `ZooKeeper` standalone database with version `3.8.3`.
+Now, we are going to deploy a `ZooKeeper` standalone database with version `3.9.1`.
 
 ### Deploy ZooKeeper standalone
 
@@ -55,7 +55,7 @@ metadata:
   name: zk-quickstart
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:

--- a/docs/guides/zookeeper/tls/configure-ssl.md
+++ b/docs/guides/zookeeper/tls/configure-ssl.md
@@ -97,7 +97,7 @@ metadata:
   name: zk-tls
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   enableSSL: true
   tls:
     issuerRef:

--- a/docs/guides/zookeeper/volume-expansion/volume-expansion.md
+++ b/docs/guides/zookeeper/volume-expansion/volume-expansion.md
@@ -55,7 +55,7 @@ standard-static        driver.standard.io      Delete          Immediate        
 
 We can see from the output the `standard` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We can use it.
 
-Now, we are going to deploy a `ZooKeeper` standalone database with version `3.8.3`.
+Now, we are going to deploy a `ZooKeeper` standalone database with version `3.9.1`.
 
 #### Deploy ZooKeeper Ensemble
 
@@ -68,7 +68,7 @@ metadata:
   name: zk-quickstart
   namespace: demo
 spec:
-  version: "3.8.3"
+  version: "3.9.1"
   adminServerPort: 8080
   replicas: 3
   storage:


### PR DESCRIPTION
Bumps the **zookeeper** example and guide manifests to the latest supported version (`3.9.1`) per the installer `active_versions.json`.

- General "deploy a zookeeper" examples use the latest version.
- Version-upgrade guides keep a nearest-older source and upgrade to the latest (preserved as a real upgrade, not a no-op).
- Illustrative command outputs (`kubectl get ...version` tables, `describe` dumps) and other products'/backend versions are left unchanged.