### PR TITLE
Add Weaviate guides

### DIFF
--- a/docs/examples/weaviate/autoscaler/compute/weaviate-compute-autoscaler.yaml
+++ b/docs/examples/weaviate/autoscaler/compute/weaviate-compute-autoscaler.yaml
@@ -1,0 +1,21 @@
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: WeaviateAutoscaler
+metadata:
+  name: weaviate-sample-autoscale
+  namespace: demo
+spec:
+  databaseRef:
+    name: weaviate-sample
+  compute:
+    weaviate:
+      trigger: "On"
+      podLifeTimeThreshold: 5m
+      resourceDiffPercentage: 20
+      minAllowed:
+        cpu: 600m
+        memory: 1.2Gi
+      maxAllowed:
+        cpu: 1
+        memory: 2Gi
+      controlledResources: ["cpu", "memory"]
+      containerControlledValues: "RequestsAndLimits"

--- a/docs/examples/weaviate/autoscaler/compute/weaviate.yaml
+++ b/docs/examples/weaviate/autoscaler/compute/weaviate.yaml
@@ -1,0 +1,36 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName:
+       longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3

--- a/docs/examples/weaviate/autoscaler/storage/weaviate-storage-autoscaler.yaml
+++ b/docs/examples/weaviate/autoscaler/storage/weaviate-storage-autoscaler.yaml
@@ -1,0 +1,17 @@
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: WeaviateAutoscaler
+metadata:
+  name: weaviate-storage-autoscaler
+  namespace: demo
+spec:
+  databaseRef:
+    name: weaviate-sample
+  storage:
+    weaviate:
+      trigger: "On"
+      usageThreshold: 20
+      scalingThreshold: 50
+      expansionMode: "Online"
+  opsRequestOptions:
+    apply: IfReady
+    timeout: 10m

--- a/docs/examples/weaviate/autoscaler/storage/weaviate.yaml
+++ b/docs/examples/weaviate/autoscaler/storage/weaviate.yaml
@@ -1,0 +1,36 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName:
+       longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3

--- a/docs/examples/weaviate/configuration/cus-conf.yaml
+++ b/docs/examples/weaviate/configuration/cus-conf.yaml
@@ -1,0 +1,38 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName:
+       longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  configuration:
+    secretName: weaviate-custom-config
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3

--- a/docs/examples/weaviate/configuration/cus-inline-conf.yaml
+++ b/docs/examples/weaviate/configuration/cus-inline-conf.yaml
@@ -1,0 +1,41 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName:
+       longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  configuration:
+    inline:
+      conf.yaml: |-
+        query_defaults:
+          limit: 1000
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3

--- a/docs/examples/weaviate/configuration/weaviate-custom-config-secret.yaml
+++ b/docs/examples/weaviate/configuration/weaviate-custom-config-secret.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+stringData:
+  conf.yaml: |-
+    ---
+    authentication:
+      anonymous_access:
+        enabled: true
+      oidc:
+        enabled: false
+    authorization:
+      admin_list:
+        enabled: false
+      rbac:
+        enabled: false
+
+    query_defaults:
+      limit: 400
+    debug: false
+kind: Secret
+metadata:
+  name: weaviate-custom-config
+  namespace: demo
+  labels:
+    app.kubernetes.io/name: weaviates.kubedb.com  
+    app.kubernetes.io/instance: weaviate-sample

--- a/docs/examples/weaviate/quickstart/weaviate-sample.yaml
+++ b/docs/examples/weaviate/quickstart/weaviate-sample.yaml
@@ -1,0 +1,36 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName:
+       longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3

--- a/docs/examples/weaviate/reconfigure-tls/add-tls.yaml
+++ b/docs/examples/weaviate/reconfigure-tls/add-tls.yaml
@@ -1,0 +1,18 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-add-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: weaviate-sample
+
+  tls:
+    issuerRef:
+      name: weaviate-issuer
+      kind: Issuer
+      apiGroup: cert-manager.io
+
+  timeout: 5m
+  apply: IfReady

--- a/docs/examples/weaviate/reconfigure-tls/remove-tls.yaml
+++ b/docs/examples/weaviate/reconfigure-tls/remove-tls.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-remove
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: weaviate-sample
+  tls:
+    remove: true

--- a/docs/examples/weaviate/reconfigure-tls/rotate-certificate.yaml
+++ b/docs/examples/weaviate/reconfigure-tls/rotate-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-rotate
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: weaviate-sample
+  tls:
+    clientAuth: false
+    rotateCertificates: true

--- a/docs/examples/weaviate/reconfigure-tls/update-issuer.yaml
+++ b/docs/examples/weaviate/reconfigure-tls/update-issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-update-issuer
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: weaviate-sample
+  tls:
+    issuerRef:
+      name: weaviate-new-issuer
+      kind: Issuer
+      apiGroup: "cert-manager.io"

--- a/docs/examples/weaviate/reconfigure-tls/weaviate-new-issuer.yaml
+++ b/docs/examples/weaviate/reconfigure-tls/weaviate-new-issuer.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: weaviate-new-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: weaviate-new-ca

--- a/docs/examples/weaviate/reconfigure-tls/weaviate.yaml
+++ b/docs/examples/weaviate/reconfigure-tls/weaviate.yaml
@@ -1,0 +1,36 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName:
+       longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3

--- a/docs/examples/weaviate/reconfigure/minio-secret.yaml
+++ b/docs/examples/weaviate/reconfigure/minio-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-secret
+  namespace: demo
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: minio
+  AWS_SECRET_ACCESS_KEY: minio123

--- a/docs/examples/weaviate/reconfigure/new-weaviate-config.yaml
+++ b/docs/examples/weaviate/reconfigure/new-weaviate-config.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: new-weaviate-config
+  namespace: demo
+type: Opaque
+stringData:
+  conf.yaml: |-
+    authorization:
+      admin_list:
+        enabled: false
+      rbac:
+        enabled: false
+    cluster:
+      hostname: $(POD_NAME)
+    debug: false
+    persistence:
+      data_path: /var/lib/weaviate
+    query_defaults:
+      limit: 200

--- a/docs/examples/weaviate/reconfigure/ops-request.yaml
+++ b/docs/examples/weaviate/reconfigure/ops-request.yaml
@@ -1,0 +1,22 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: reconfigure
+  namespace: demo
+spec:
+  type: Reconfigure
+  databaseRef:
+    name: weaviate-sample
+  timeout: 3m
+  apply: Always
+
+  configuration:
+    applyConfig:
+      conf.yaml: |-
+        query_defaults:
+          limit: 155
+    configSecret:
+      name: new-weaviate-config
+    backupConfigSecret:
+      name: minio-secret
+      

--- a/docs/examples/weaviate/reconfigure/weaviate.yaml
+++ b/docs/examples/weaviate/reconfigure/weaviate.yaml
@@ -1,0 +1,36 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName:
+       longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3

--- a/docs/examples/weaviate/restart/ops-request.yaml
+++ b/docs/examples/weaviate/restart/ops-request.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: restart
+  namespace: demo
+spec:
+  type: Restart
+  databaseRef:
+    name: weaviate-sample
+  timeout: 3m
+  apply: Always

--- a/docs/examples/weaviate/restart/weaviate.yaml
+++ b/docs/examples/weaviate/restart/weaviate.yaml
@@ -1,0 +1,36 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName:
+       longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3

--- a/docs/examples/weaviate/rotate-auth/ops-request.yaml
+++ b/docs/examples/weaviate/rotate-auth/ops-request.yaml
@@ -1,0 +1,15 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-rotate-auth-generated
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: weaviate-sample
+  authentication:
+    secretRef:
+      kind: Secret
+      name: weaviate-rotate-auth
+  timeout: 5m
+  apply: IfReady

--- a/docs/examples/weaviate/rotate-auth/weaviate-rotate-auth.yaml
+++ b/docs/examples/weaviate/rotate-auth/weaviate-rotate-auth.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  AUTHENTICATION_APIKEY_ALLOWED_KEYS: VTFVenZyVHZuejVNdzljNA==
+kind: Secret
+metadata:
+  name: weaviate-rotate-auth
+  namespace: demo
+type: Opaque

--- a/docs/examples/weaviate/rotate-auth/weaviate.yaml
+++ b/docs/examples/weaviate/rotate-auth/weaviate.yaml
@@ -1,0 +1,36 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName:
+       longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3

--- a/docs/examples/weaviate/scaling/horizontal-scaling/scale-down.yaml
+++ b/docs/examples/weaviate/scaling/horizontal-scaling/scale-down.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-scale-down
+  namespace: demo
+spec:
+  type: HorizontalScaling
+  databaseRef:
+    name: weaviate-sample
+  horizontalScaling:
+    node: 2

--- a/docs/examples/weaviate/scaling/horizontal-scaling/scale-up.yaml
+++ b/docs/examples/weaviate/scaling/horizontal-scaling/scale-up.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-scale-up
+  namespace: demo
+spec:
+  type: HorizontalScaling
+  databaseRef:
+    name: weaviate-sample
+  horizontalScaling:
+    node: 5

--- a/docs/examples/weaviate/scaling/horizontal-scaling/weaviate.yaml
+++ b/docs/examples/weaviate/scaling/horizontal-scaling/weaviate.yaml
@@ -1,0 +1,36 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName:
+       longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3

--- a/docs/examples/weaviate/scaling/vertical-scaling/ops-request.yaml
+++ b/docs/examples/weaviate/scaling/vertical-scaling/ops-request.yaml
@@ -1,0 +1,20 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-vertical-scale
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: weaviate-sample
+  verticalScaling:
+    node:
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "1"
+        limits:
+          memory: "2Gi"
+          cpu: "1"
+  timeout: 5m
+  apply: IfReady

--- a/docs/examples/weaviate/scaling/vertical-scaling/weaviate.yaml
+++ b/docs/examples/weaviate/scaling/vertical-scaling/weaviate.yaml
@@ -1,0 +1,36 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName:
+       longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3

--- a/docs/examples/weaviate/storage-migration/ops-request.yaml
+++ b/docs/examples/weaviate/storage-migration/ops-request.yaml
@@ -1,0 +1,13 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: storage-migration
+  namespace: demo
+spec:
+  type: StorageMigration
+  databaseRef:
+    name: weaviate-sample
+  timeout: 10m 
+  migration:
+    storageClassName: local-path
+    oldPVReclaimPolicy: Delete

--- a/docs/examples/weaviate/storage-migration/weaviate.yaml
+++ b/docs/examples/weaviate/storage-migration/weaviate.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 2
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 3Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/weaviate/tls/issuer.yaml
+++ b/docs/examples/weaviate/tls/issuer.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: weaviate-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: weaviate-ca

--- a/docs/examples/weaviate/tls/tls.yaml
+++ b/docs/examples/weaviate/tls/tls.yaml
@@ -1,0 +1,42 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName:
+       longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: weaviate-issuer
+    clientAuth: true
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3

--- a/docs/examples/weaviate/volume-expansion/ops-request.yaml
+++ b/docs/examples/weaviate/volume-expansion/ops-request.yaml
@@ -1,0 +1,12 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wv-volume-expansion-offline
+  namespace: demo
+spec:
+  type: VolumeExpansion
+  databaseRef:
+    name: weaviate-sample
+  volumeExpansion:
+    node: 3Gi
+    mode: Offline

--- a/docs/examples/weaviate/volume-expansion/weaviate.yaml
+++ b/docs/examples/weaviate/volume-expansion/weaviate.yaml
@@ -1,0 +1,36 @@
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName:
+       longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3

--- a/docs/guides/weaviate/README.md
+++ b/docs/guides/weaviate/README.md
@@ -1,0 +1,54 @@
+---
+title: Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-readme
+    name: Weaviate
+    parent: weaviate-guides
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+url: /docs/{{ .version }}/guides/weaviate/
+aliases:
+  - /docs/{{ .version }}/guides/weaviate/README/
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Overview
+
+Weaviate is an open-source, AI-native vector database that stores both objects and their vector embeddings, enabling fast semantic search, hybrid search, and retrieval-augmented generation (RAG) at scale. KubeDB supports provisioning and management of Weaviate clusters directly inside Kubernetes, bringing production-grade vector search infrastructure to your cluster with minimal operational overhead. Deploy Weaviate with multiple replicas to achieve horizontal scalability, replication, and high availability for large embedding workloads. KubeDB automates cluster lifecycle management tasks such as deployment, scaling, custom configuration, TLS, authentication rotation, volume expansion, storage migration, and autoscaling, simplifying operations for machine learning and semantic search applications. With seamless Kubernetes integration, users can efficiently run and manage resilient Weaviate deployments for modern AI and retrieval-augmented generation (RAG) workloads.
+
+## Supported Weaviate Features
+
+| Features                        | Availability |
+|---------------------------------|:------------:|
+| Clustered (Multi-node) provisioning |   &#10003;   |
+| Custom Configuration            |   &#10003;   |
+| TLS                             |   &#10003;   |
+| Authentication (API key)        |   &#10003;   |
+| Reconfigure                     |   &#10003;   |
+| Reconfigure TLS                 |   &#10003;   |
+| Rotate Authentication           |   &#10003;   |
+| Restart                         |   &#10003;   |
+| Vertical Scaling                |   &#10003;   |
+| Horizontal Scaling              |   &#10003;   |
+| Volume Expansion                |   &#10003;   |
+| Storage Migration               |   &#10003;   |
+| Compute Autoscaler              |   &#10003;   |
+| Storage Autoscaler              |   &#10003;   |
+
+## Supported Weaviate Versions
+
+KubeDB supports the following Weaviate versions.
+- `1.33.1`
+
+> The listed versions are the ones shipped with the `WeaviateVersion` catalog in your KubeDB installation. Run `kubectl get weaviateversions` to see the versions available in your cluster.
+
+## User Guide
+
+- [Quickstart Weaviate](/docs/guides/weaviate/quickstart/quickstart.md) with KubeDB operator.
+- Use [custom configuration](/docs/guides/weaviate/configuration/using-config-file.md) for Weaviate.
+- Secure your cluster with [TLS](/docs/guides/weaviate/tls/overview.md).
+- Run day-2 operations with [Ops Requests](/docs/guides/weaviate/restart/restart.md) and [Autoscaler](/docs/guides/weaviate/autoscaler/compute/compute-autoscale.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/weaviate/_index.md
+++ b/docs/guides/weaviate/_index.md
@@ -1,0 +1,10 @@
+---
+title: Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-guides
+    name: Weaviate
+    parent: guides
+    weight: 17
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/autoscaler/_index.md
+++ b/docs/guides/weaviate/autoscaler/_index.md
@@ -1,0 +1,10 @@
+---
+title: Autoscaler
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler
+    name: Autoscaler
+    parent: weaviate-guides
+    weight: 140
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/autoscaler/compute/_index.md
+++ b/docs/guides/weaviate/autoscaler/compute/_index.md
@@ -1,0 +1,10 @@
+---
+title: Compute Autoscaling
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler-compute
+    name: Compute Autoscaling
+    parent: weaviate-autoscaler
+    weight: 10
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/autoscaler/compute/compute-autoscale.md
+++ b/docs/guides/weaviate/autoscaler/compute/compute-autoscale.md
@@ -1,0 +1,186 @@
+---
+title: Weaviate Compute Autoscaler
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler-compute-description
+    name: Autoscale Compute Resources
+    parent: weaviate-autoscaler-compute
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Autoscaling the Compute Resource of a Weaviate Database
+
+This guide will show you how to use `KubeDB` to auto-scale the compute resources (CPU and Memory) of a Weaviate database.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster.
+
+- Install `KubeDB` Provisioner, Ops-Manager, and Autoscaler operators in your cluster following the steps [here](/docs/setup/README.md).
+
+- Install `Metrics Server` from [here](https://github.com/kubernetes-sigs/metrics-server#installation). The compute autoscaler relies on metrics to make recommendations.
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Compute Autoscaling Overview](/docs/guides/weaviate/autoscaler/compute/overview.md)
+  - [Vertical Scaling](/docs/guides/weaviate/scaling/vertical-scaling/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Autoscaling of Database
+
+Here, we are going to deploy a `Weaviate` database and then set up autoscaling with a `WeaviateAutoscaler`.
+
+### Deploy Weaviate Database
+
+In this section, we are going to deploy a Weaviate database with `500m` CPU and `1Gi` memory. Below is the YAML of the `Weaviate` CR that we are going to create:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Weaviate` CR and wait for it to become `Ready`. Then check the current container resources:
+
+```bash
+$ kubectl get pod -n demo weaviate-sample-0 -o jsonpath='{.spec.containers[0].resources}'
+{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}
+```
+
+### Create WeaviateAutoscaler
+
+Now, we are going to set up compute resource autoscaling using a `WeaviateAutoscaler` object. Note the resource knob is under `spec.compute.weaviate`:
+
+```yaml
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: WeaviateAutoscaler
+metadata:
+  name: weaviate-sample-autoscale
+  namespace: demo
+spec:
+  databaseRef:
+    name: weaviate-sample
+  compute:
+    weaviate:
+      trigger: "On"
+      podLifeTimeThreshold: 5m
+      resourceDiffPercentage: 20
+      minAllowed:
+        cpu: 600m
+        memory: 1.2Gi
+      maxAllowed:
+        cpu: 1
+        memory: 2Gi
+      controlledResources: ["cpu", "memory"]
+      containerControlledValues: "RequestsAndLimits"
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are performing compute autoscaling on the `weaviate-sample` database.
+- `spec.compute.weaviate.trigger` enables compute resource autoscaling for the Weaviate nodes.
+- `spec.compute.weaviate.podLifeTimeThreshold` specifies the minimum age of a Pod before a resource update can be recommended.
+- `spec.compute.weaviate.resourceDiffPercentage` specifies the minimum percentage difference required before applying a new recommendation.
+- `spec.compute.weaviate.minAllowed` / `maxAllowed` specify the lower and upper bounds of the autoscaled resources.
+- `spec.compute.weaviate.controlledResources` specifies the resources that will be auto-scaled.
+- `spec.compute.weaviate.containerControlledValues` specifies whether both requests and limits are controlled.
+
+Let's create the `WeaviateAutoscaler`:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/autoscaler/compute/weaviate-compute-autoscaler.yaml
+weaviateautoscaler.autoscaling.kubedb.com/weaviate-sample-autoscale created
+```
+
+### Verify Autoscaling
+
+Let's describe the `WeaviateAutoscaler`. Because the initial resources (`500m`/`1Gi`) are below the `minAllowed` floor (`600m`/`1.2Gi`), the autoscaler quickly produces a recommendation:
+
+```bash
+$ kubectl describe weaviateautoscaler -n demo weaviate-sample-autoscale
+...
+Status:
+  Vpas:
+    Conditions:
+      Status:  True
+      Type:    RecommendationProvided
+    Recommendation:
+      Container Recommendations:
+        Container Name:  weaviate
+        Lower Bound:
+          Cpu:     600m
+          Memory:  1288490188800m
+        Target:
+          Cpu:     600m
+          Memory:  1288490188800m
+        Upper Bound:
+          Cpu:     1
+          Memory:  2Gi
+```
+
+After the `podLifeTimeThreshold` passes, the autoscaler operator creates a `WeaviateOpsRequest` of type `VerticalScaling`:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo
+NAME                           TYPE              STATUS       AGE
+wvops-weaviate-sample-0oyvzl   VerticalScaling   Successful   119s
+```
+
+```bash
+$ kubectl get weaviateopsrequest -n demo wvops-weaviate-sample-0oyvzl -o jsonpath='{.spec.verticalScaling}'
+{"node":{"resources":{"limits":{"cpu":"600m","memory":"1288490188"},"requests":{"cpu":"600m","memory":"1288490188"}}}}
+```
+
+Once the ops request completes, verify the updated resources on the pods:
+
+```bash
+$ kubectl get pod -n demo weaviate-sample-0 -o jsonpath='{.spec.containers[0].resources}'
+{"limits":{"cpu":"600m","memory":"1288490188"},"requests":{"cpu":"600m","memory":"1288490188"}}
+```
+
+The compute resources of the Weaviate database have been autoscaled up to the `minAllowed` floor (`600m` CPU / `1.2Gi` memory). When the actual usage grows, the autoscaler will continue to recommend higher resources (up to `maxAllowed`).
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete weaviateautoscaler -n demo weaviate-sample-autoscale
+$ kubectl delete weaviate -n demo weaviate-sample
+$ kubectl delete ns demo
+```

--- a/docs/guides/weaviate/autoscaler/compute/overview.md
+++ b/docs/guides/weaviate/autoscaler/compute/overview.md
@@ -1,0 +1,48 @@
+---
+title: Weaviate Compute Autoscaling Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler-compute-overview
+    name: Overview
+    parent: weaviate-autoscaler-compute
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate Compute Resource Autoscaling
+
+This guide will give you an overview of how KubeDB autoscales the compute resources (CPU and Memory) of a `Weaviate` cluster using a `WeaviateAutoscaler`.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Vertical Scaling](/docs/guides/weaviate/scaling/vertical-scaling/overview.md)
+
+## How Compute Autoscaling Works
+
+KubeDB provides a `WeaviateAutoscaler` CRD to automatically scale the compute resources of a Weaviate cluster. It is backed by a `VerticalPodAutoscaler` (VPA) that observes the actual resource usage of the Weaviate pods (requires `metrics-server`).
+
+The compute autoscaling process consists of the following steps:
+
+1. The user creates a `WeaviateAutoscaler` CR with a `spec.compute.weaviate` block describing the trigger, the min/max allowed resources, and the controlled resources.
+
+2. The `KubeDB` Autoscaler operator creates a `VerticalPodAutoscaler` for the cluster and watches the recommendations it produces.
+
+3. When the recommended resources differ from the current resources by more than `resourceDiffPercentage` (and the pods are older than `podLifeTimeThreshold`), the Autoscaler operator creates a `WeaviateOpsRequest` of type `VerticalScaling`.
+
+4. The `KubeDB` Ops Manager applies the `VerticalScaling` ops request, updating the pod resources within the `minAllowed`/`maxAllowed` bounds.
+
+The relevant fields under `spec.compute.weaviate` are:
+
+- `trigger` — `On` or `Off`, enables/disables compute autoscaling.
+- `podLifeTimeThreshold` — the minimum age of a Pod before a recommendation can be applied.
+- `resourceDiffPercentage` — the minimum percentage change required before a new recommendation is applied.
+- `minAllowed` / `maxAllowed` — the lower and upper bounds for the autoscaled resources.
+- `controlledResources` — the resource types to autoscale (e.g. `cpu`, `memory`).
+- `containerControlledValues` — whether to control `RequestsAndLimits` or just `Requests`.
+
+In the next doc, we are going to show a step-by-step guide on autoscaling the compute resources of a Weaviate cluster.

--- a/docs/guides/weaviate/autoscaler/storage/_index.md
+++ b/docs/guides/weaviate/autoscaler/storage/_index.md
@@ -1,0 +1,10 @@
+---
+title: Storage Autoscaling
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler-storage
+    name: Storage Autoscaling
+    parent: weaviate-autoscaler
+    weight: 20
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/autoscaler/storage/overview.md
+++ b/docs/guides/weaviate/autoscaler/storage/overview.md
@@ -1,0 +1,46 @@
+---
+title: Weaviate Storage Autoscaling Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler-storage-overview
+    name: Overview
+    parent: weaviate-autoscaler-storage
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate Storage Autoscaling
+
+This guide will give you an overview of how KubeDB autoscales the storage of a `Weaviate` cluster using a `WeaviateAutoscaler`.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Volume Expansion](/docs/guides/weaviate/volume-expansion/overview.md)
+
+## How Storage Autoscaling Works
+
+KubeDB provides a `WeaviateAutoscaler` CRD to automatically expand the storage of a Weaviate cluster when the volumes start filling up. Storage autoscaling requires a `StorageClass` that supports volume expansion (`allowVolumeExpansion: true`).
+
+The storage autoscaling process consists of the following steps:
+
+1. The user creates a `WeaviateAutoscaler` CR with a `spec.storage.weaviate` block describing the trigger, the usage threshold, and the scaling factor.
+
+2. The `KubeDB` Autoscaler operator watches the PVC usage of the Weaviate pods.
+
+3. When a volume's used space crosses `usageThreshold` (a percentage of the volume capacity), the Autoscaler operator creates a `WeaviateOpsRequest` of type `VolumeExpansion`, increasing the volume size by `scalingThreshold` percent.
+
+4. The `KubeDB` Ops Manager applies the `VolumeExpansion` ops request, expanding the PVCs.
+
+The relevant fields under `spec.storage.weaviate` are:
+
+- `trigger` — `On` or `Off`, enables/disables storage autoscaling.
+- `usageThreshold` — the percentage of used space that triggers expansion.
+- `scalingThreshold` — the percentage by which the volume is expanded each time.
+- `expansionMode` — `Online` or `Offline`.
+
+In the next doc, we are going to show a step-by-step guide on autoscaling the storage of a Weaviate cluster.

--- a/docs/guides/weaviate/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/weaviate/autoscaler/storage/storage-autoscale.md
@@ -1,0 +1,192 @@
+---
+title: Weaviate Storage Autoscaler
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-autoscaler-storage-description
+    name: Autoscale Storage
+    parent: weaviate-autoscaler-storage
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Storage Autoscaling of a Weaviate Database
+
+This guide will show you how to use `KubeDB` to auto-scale the storage of a Weaviate database when the volumes start filling up.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster.
+
+- Install `KubeDB` Provisioner, Ops-Manager, and Autoscaler operators in your cluster following the steps [here](/docs/setup/README.md).
+
+- You must have a `StorageClass` that supports **volume expansion** (`allowVolumeExpansion: true`). Storage autoscaling expands the existing PVCs in place.
+
+- Storage autoscaling reacts to the volume-usage metric (`volume_used_percentage`) exposed through KubeDB's metrics API. Make sure the KubeDB metrics stack is installed and serving this metric in your cluster.
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Storage Autoscaling Overview](/docs/guides/weaviate/autoscaler/storage/overview.md)
+  - [Volume Expansion](/docs/guides/weaviate/volume-expansion/overview.md)
+
+To keep everything isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Storage Autoscaling of Database
+
+Here, we are going to deploy a `Weaviate` database and then set up storage autoscaling with a `WeaviateAutoscaler`.
+
+### Deploy Weaviate Database
+
+In this section, we are going to deploy a Weaviate database with `1Gi` of storage on a volume-expansion-capable StorageClass (`longhorn`):
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Weaviate` CR and wait for it to become `Ready`. Then check the current storage:
+
+```bash
+$ kubectl get pvc -n demo -o custom-columns=NAME:.metadata.name,SIZE:.status.capacity.storage
+NAME                     SIZE
+data-weaviate-sample-0   1Gi
+data-weaviate-sample-1   1Gi
+data-weaviate-sample-2   1Gi
+```
+
+### Create WeaviateAutoscaler
+
+Now, we are going to set up storage autoscaling using a `WeaviateAutoscaler` object. Note the storage knob is under `spec.storage.weaviate`:
+
+```yaml
+apiVersion: autoscaling.kubedb.com/v1alpha1
+kind: WeaviateAutoscaler
+metadata:
+  name: weaviate-storage-autoscaler
+  namespace: demo
+spec:
+  databaseRef:
+    name: weaviate-sample
+  storage:
+    weaviate:
+      trigger: "On"
+      usageThreshold: 20
+      scalingThreshold: 50
+      expansionMode: "Online"
+  opsRequestOptions:
+    apply: IfReady
+    timeout: 10m
+```
+
+Here,
+
+- `spec.databaseRef.name` specifies that we are performing storage autoscaling on the `weaviate-sample` database.
+- `spec.storage.weaviate.trigger` enables storage autoscaling for the Weaviate nodes.
+- `spec.storage.weaviate.usageThreshold` specifies the used-space percentage (here, `20%`) that triggers an expansion.
+- `spec.storage.weaviate.scalingThreshold` specifies the percentage by which the volume is expanded each time (here, `50%`).
+- `spec.storage.weaviate.expansionMode` specifies whether the expansion is `Online` or `Offline`.
+- `spec.opsRequestOptions` controls how the generated ops request is applied (`apply: IfReady`) and its timeout.
+
+Let's create the `WeaviateAutoscaler`:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/autoscaler/storage/weaviate-storage-autoscaler.yaml
+weaviateautoscaler.autoscaling.kubedb.com/weaviate-storage-autoscaler created
+```
+
+### Verify Autoscaler is Set Up
+
+Let's describe the `WeaviateAutoscaler` to confirm it is configured and watching the volumes:
+
+```bash
+$ kubectl describe weaviateautoscaler -n demo weaviate-storage-autoscaler
+Name:         weaviate-storage-autoscaler
+Namespace:    demo
+API Version:  autoscaling.kubedb.com/v1alpha1
+Kind:         WeaviateAutoscaler
+Metadata:
+  Owner References:
+    API Version:           kubedb.com/v1alpha2
+    Controller:            true
+    Kind:                  Weaviate
+    Name:                  weaviate-sample
+Spec:
+  Database Ref:
+    Name:  weaviate-sample
+  Ops Request Options:
+    Apply:        IfReady
+    Max Retries:  1
+    Timeout:      10m0s
+  Storage:
+    Weaviate:
+      Expansion Mode:  Online
+      Scaling Threshold:  50
+      Trigger:            On
+      Usage Threshold:    20
+Events:                   <none>
+```
+
+The autoscaler is now watching the PVC usage of the Weaviate pods.
+
+### Trigger an Expansion
+
+When a volume's used space crosses the `usageThreshold` (20%), the autoscaler operator creates a `WeaviateOpsRequest` of type `VolumeExpansion` that grows the volume by `scalingThreshold` (50%). For example, after writing enough data to fill more than 20% of a `1Gi` volume:
+
+```bash
+# usage on each node's data volume crosses 20%
+$ kubectl exec -n demo weaviate-sample-0 -c weaviate -- df -h /var/lib/weaviate
+Filesystem                Size      Used Available Use% Mounted on
+/dev/longhorn/pvc-...   973.4M    401.7M    555.7M  42% /var/lib/weaviate
+```
+
+the autoscaler creates a `VolumeExpansion` ops request:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo
+NAME                                TYPE              STATUS       AGE
+wvops-weaviate-sample-xxxxxx        VolumeExpansion   Successful   3m
+```
+
+and the PVCs are expanded (here, from `1Gi` to `1.5Gi` — a 50% increase):
+
+```bash
+$ kubectl get pvc -n demo -o custom-columns=NAME:.metadata.name,SIZE:.status.capacity.storage
+NAME                     SIZE
+data-weaviate-sample-0   1531584Ki
+data-weaviate-sample-1   1531584Ki
+data-weaviate-sample-2   1531584Ki
+```
+
+> **Note:** The auto-trigger relies on the `volume_used_percentage` metric being available through KubeDB's metrics API. If that metric is not exposed in your cluster, the autoscaler will stay configured and watching but will not generate an ops request. The underlying `VolumeExpansion` mechanism it uses is the same one demonstrated step-by-step in the [Volume Expansion](/docs/guides/weaviate/volume-expansion/volume-expansion.md) guide.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete weaviateautoscaler -n demo weaviate-storage-autoscaler
+$ kubectl delete weaviate -n demo weaviate-sample
+$ kubectl delete ns demo
+```

--- a/docs/guides/weaviate/concepts/_index.md
+++ b/docs/guides/weaviate/concepts/_index.md
@@ -1,0 +1,10 @@
+---
+title: Concepts
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-concepts
+    name: Concepts
+    parent: weaviate-guides
+    weight: 20
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/concepts/catalog.md
+++ b/docs/guides/weaviate/concepts/catalog.md
@@ -1,0 +1,65 @@
+---
+title: WeaviateVersion CRD
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-concepts-catalog
+    name: WeaviateVersion
+    parent: weaviate-concepts
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# WeaviateVersion
+
+## What is WeaviateVersion
+
+`WeaviateVersion` is a Kubernetes `Custom Resource Definitions` (CRD). It provides a declarative way to specify the docker images and other version-specific metadata used to deploy a Weaviate database with the KubeDB operator.
+
+When you install KubeDB, a `WeaviateVersion` CR is created for each supported Weaviate version. You must specify the name of a `WeaviateVersion` CR in `spec.version` of your `Weaviate` object.
+
+## WeaviateVersion Spec
+
+Below is an example `WeaviateVersion` object:
+
+```yaml
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: WeaviateVersion
+metadata:
+  name: 1.33.1
+spec:
+  db:
+    image: ghcr.io/appscode-images/weaviate:1.33.1
+  version: 1.33.1
+```
+
+### metadata.name
+
+`metadata.name` is the name of the `WeaviateVersion` CR. You specify this name in `spec.version` of your `Weaviate` object.
+
+### spec.version
+
+`spec.version` is the actual Weaviate version released by the Weaviate project.
+
+### spec.db.image
+
+`spec.db.image` is the docker image used to create the Weaviate database pods.
+
+### spec.deprecated
+
+`spec.deprecated` (optional, boolean) indicates whether this `WeaviateVersion` is deprecated. KubeDB will not provision a database with a deprecated version.
+
+## List available versions
+
+```bash
+$ kubectl get weaviateversions
+NAME     VERSION   DB_IMAGE                                  DEPRECATED   AGE
+1.33.1   1.33.1    ghcr.io/appscode-images/weaviate:1.33.1                34h
+```
+
+## Next Steps
+
+- Learn about the [Weaviate CRD](/docs/guides/weaviate/concepts/weaviate.md).
+- Deploy your first Weaviate database with the [Quickstart](/docs/guides/weaviate/quickstart/quickstart.md).

--- a/docs/guides/weaviate/concepts/weaviate.md
+++ b/docs/guides/weaviate/concepts/weaviate.md
@@ -1,0 +1,130 @@
+---
+title: Weaviate CRD
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-concepts-weaviate
+    name: Weaviate
+    parent: weaviate-concepts
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate
+
+## What is Weaviate
+
+`Weaviate` is a Kubernetes `Custom Resource Definitions` (CRD). It provides declarative configuration for [Weaviate](https://weaviate.io/) in a Kubernetes native way. You only need to describe the desired database configuration in a `Weaviate` object, and the KubeDB operator will create Kubernetes objects in the desired state for you.
+
+## Weaviate Spec
+
+As with all other Kubernetes objects, a Weaviate needs `apiVersion`, `kind`, and `metadata` fields. It also needs a `.spec` section. Below is an example `Weaviate` object.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  authSecret:
+    name: weaviate-sample-auth
+  configuration:
+    secretName: weaviate-custom-config
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: weaviate-issuer
+    clientAuth: true
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3
+```
+
+### spec.version
+
+`spec.version` is a required field specifying the name of the [WeaviateVersion](/docs/guides/weaviate/concepts/catalog.md) CR where the docker images are specified. Run `kubectl get weaviateversions` to list the versions available in your cluster.
+
+### spec.replicas
+
+`spec.replicas` specifies the number of nodes (pods) in the Weaviate cluster. A multi-node cluster lets Weaviate replicate collections across nodes for high availability.
+
+### spec.replication
+
+`spec.replication.factor` configures the default replication factor for collections (between `1` and `5`). `1` means no replication (default); `2`–`3` are typical for production high availability.
+
+### spec.storageType
+
+`spec.storageType` can be `Durable` or `Ephemeral`. `Durable` uses a `PersistentVolumeClaim` to persist data; `Ephemeral` uses an `emptyDir` that is lost when the pod is deleted.
+
+### spec.storage
+
+If `spec.storageType` is `Durable`, then `spec.storage` is required. It accepts a standard `PersistentVolumeClaimSpec`:
+
+- `spec.storage.storageClassName` — the name of the `StorageClass` used to provision the PVCs.
+- `spec.storage.accessModes` — the PVC access modes (e.g. `ReadWriteOnce`).
+- `spec.storage.resources` — the storage request for each node.
+
+### spec.disableSecurity
+
+`spec.disableSecurity` (default `false`) disables API-key authentication when set to `true`. When security is enabled (the default), KubeDB generates an API key.
+
+### spec.authSecret
+
+`spec.authSecret` references the Secret holding the Weaviate API-key credentials. If not provided, KubeDB creates one named `<database-name>-auth` containing the standard Weaviate API-key environment variables (`AUTHENTICATION_APIKEY_ENABLED`, `AUTHENTICATION_APIKEY_ALLOWED_KEYS`, and `AUTHENTICATION_APIKEY_USERS`). You can rotate it with a [RotateAuth](/docs/guides/weaviate/rotate-auth/rotate-auth.md) ops request.
+
+### spec.configuration
+
+`spec.configuration` provides a custom Weaviate configuration (the `conf.yaml` file). It can be supplied either through a Secret (`spec.configuration.secretName`) or inline (`spec.configuration.inline`). See [Using Custom Configuration File](/docs/guides/weaviate/configuration/using-config-file.md).
+
+### spec.tls
+
+`spec.tls` enables TLS encryption using [cert-manager](https://cert-manager.io/). It references an `Issuer`/`ClusterIssuer` through `spec.tls.issuerRef`, and `spec.tls.clientAuth` controls whether mutual TLS (client certificate authentication) is required. See [Weaviate TLS](/docs/guides/weaviate/tls/overview.md).
+
+### spec.podTemplate
+
+`spec.podTemplate` lets you customize the pod specification for the Weaviate pods — container resources, security context, scheduling, environment variables, etc.
+
+### spec.serviceTemplates
+
+`spec.serviceTemplates` allows customizing the Kubernetes Services that KubeDB creates for the Weaviate cluster.
+
+### spec.deletionPolicy
+
+`spec.deletionPolicy` controls what happens to the database resources when the `Weaviate` object is deleted. The available options are `DoNotTerminate`, `Halt`, `Delete`, and `WipeOut`. See the [Quickstart](/docs/guides/weaviate/quickstart/quickstart.md#database-deletionpolicy) for details.
+
+### spec.healthChecker
+
+`spec.healthChecker` configures how KubeDB health-checks the database. It has `periodSeconds`, `timeoutSeconds`, and `failureThreshold` fields.
+
+## Next Steps
+
+- Learn how to use KubeDB to run a Weaviate database [here](/docs/guides/weaviate/quickstart/quickstart.md).
+- Detail concepts of [WeaviateVersion object](/docs/guides/weaviate/concepts/catalog.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/weaviate/configuration/_index.md
+++ b/docs/guides/weaviate/configuration/_index.md
@@ -1,0 +1,10 @@
+---
+title: Custom Configuration
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-configuration
+    name: Custom Configuration
+    parent: weaviate-guides
+    weight: 40
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/configuration/using-config-file.md
+++ b/docs/guides/weaviate/configuration/using-config-file.md
@@ -1,0 +1,226 @@
+---
+title: Run Weaviate with Custom Configuration
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-using-config-file
+    name: Config File
+    parent: weaviate-configuration
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Using Custom Configuration File
+
+KubeDB supports providing custom configuration for Weaviate. This tutorial will show you how to use KubeDB to run a Weaviate database with a custom configuration.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Now, install the KubeDB operator in your cluster following the steps [here](/docs/setup/README.md).
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/configuration](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/configuration) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Overview
+
+KubeDB supports providing custom configuration for Weaviate through `spec.configuration`. Weaviate reads its configuration from a single `conf.yaml` file (passed to the server via `--config-file`). KubeDB mounts your configuration at `/weaviate-config/conf.yaml` inside the pods.
+
+There are two ways to supply the configuration:
+
+| Method | Field |
+|--------|-------|
+| **Config Secret** | `spec.configuration.secretName` |
+| **Inline Config**  | `spec.configuration.inline` |
+
+In both cases the configuration is provided under the `conf.yaml` key. KubeDB merges your settings with the cluster-specific values it needs (such as `cluster.hostname` and `persistence.data_path`).
+
+To know more about configuring Weaviate, see the [Weaviate environment/config reference](https://weaviate.io/developers/weaviate/config-refs/env-vars).
+
+## Custom Configuration via Config Secret
+
+At first, create a Secret with your custom configuration under the `conf.yaml` key. Below is the YAML of the `Secret` that we are going to create:
+
+```yaml
+apiVersion: v1
+stringData:
+  conf.yaml: |-
+    ---
+    authentication:
+      anonymous_access:
+        enabled: true
+      oidc:
+        enabled: false
+    authorization:
+      admin_list:
+        enabled: false
+      rbac:
+        enabled: false
+
+    query_defaults:
+      limit: 400
+    debug: false
+kind: Secret
+metadata:
+  name: weaviate-custom-config
+  namespace: demo
+  labels:
+    app.kubernetes.io/name: weaviates.kubedb.com
+    app.kubernetes.io/instance: weaviate-sample
+type: Opaque
+```
+
+Let's create the `Secret`:
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/configuration/weaviate-custom-config-secret.yaml
+secret/weaviate-custom-config created
+```
+
+Now, create the `Weaviate` CR specifying the `spec.configuration.secretName` field:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  configuration:
+    secretName: weaviate-custom-config
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/configuration/cus-conf.yaml
+weaviate.kubedb.com/weaviate-sample created
+```
+
+Now, wait a few minutes. KubeDB operator will create the necessary PVC, PetSet, services, and secrets. Let's check the status:
+
+```bash
+$ kubectl get weaviate -n demo
+NAME              TYPE                  VERSION   STATUS   AGE
+weaviate-sample   kubedb.com/v1alpha2   1.33.1    Ready    66s
+
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=weaviate-sample
+NAME                READY   STATUS    RESTARTS   AGE
+weaviate-sample-0   1/1     Running   0          65s
+weaviate-sample-1   1/1     Running   0          50s
+weaviate-sample-2   1/1     Running   0          38s
+```
+
+Now, let's verify that the custom configuration has been applied by checking the config file inside the pod:
+
+```bash
+$ kubectl exec -n demo weaviate-sample-0 -c weaviate -- cat /weaviate-config/conf.yaml/conf.yaml
+authentication:
+  anonymous_access:
+    enabled: true
+  oidc:
+    enabled: false
+authorization:
+  admin_list:
+    enabled: false
+  rbac:
+    enabled: false
+cluster:
+  hostname: $(POD_NAME)
+debug: false
+persistence:
+  data_path: /var/lib/weaviate
+query_defaults:
+  limit: 400
+```
+
+The output confirms the database is running with our custom `query_defaults.limit: 400` and `anonymous_access` settings. KubeDB has merged in the cluster-specific `cluster.hostname` and `persistence.data_path` values.
+
+## Inline Configuration
+
+You can also provide custom configuration inline within the `Weaviate` CR using `spec.configuration.inline`. This is useful for simple config changes without creating a separate Secret. The configuration is still provided under the `conf.yaml` key.
+
+Below is an example YAML of a `Weaviate` CR with inline configuration:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  configuration:
+    inline:
+      conf.yaml: |-
+        query_defaults:
+          limit: 1000
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/configuration/cus-inline-conf.yaml
+weaviate.kubedb.com/weaviate-sample created
+```
+
+Wait until the cluster is `Ready`, then verify the inline configuration has been applied:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.configuration}'
+{"inline":{"conf.yaml":"query_defaults:\n  limit: 1000"}}
+
+$ kubectl exec -n demo weaviate-sample-0 -c weaviate -- cat /weaviate-config/conf.yaml/conf.yaml
+authorization:
+  admin_list:
+    enabled: false
+  rbac:
+    enabled: false
+cluster:
+  hostname: $(POD_NAME)
+debug: false
+persistence:
+  data_path: /var/lib/weaviate
+query_defaults:
+  limit: 1000
+```
+
+The output confirms the database is running with our inline `query_defaults.limit: 1000` setting.
+
+> **Tip:** You can change the configuration of a running Weaviate cluster (and even reference a replacement config Secret) without recreating it using a `Reconfigure` ops request. See [Reconfigure Weaviate](/docs/guides/weaviate/reconfigure/reconfigure.md).
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete weaviate -n demo weaviate-sample
+$ kubectl delete secret -n demo weaviate-custom-config
+$ kubectl delete ns demo
+```

--- a/docs/guides/weaviate/quickstart/_index.md
+++ b/docs/guides/weaviate/quickstart/_index.md
@@ -1,0 +1,10 @@
+---
+title: Quickstart
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-quickstart
+    name: Quickstart
+    parent: weaviate-guides
+    weight: 15
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/quickstart/quickstart.md
+++ b/docs/guides/weaviate/quickstart/quickstart.md
@@ -1,0 +1,553 @@
+---
+title: Weaviate Quickstart
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-quickstart-overview
+    name: Overview
+    parent: weaviate-quickstart
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Running Weaviate
+
+This tutorial will show you how to use KubeDB to run a [Weaviate](https://weaviate.io/) vector database.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Now, install KubeDB operator in your cluster following the steps [here](/docs/setup/README.md) and make sure to include the Weaviate feature gate during installation.
+
+- To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/quickstart](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/quickstart) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Find Available StorageClass
+
+We will need to provide a `StorageClass` in the Weaviate CR specification. Check the available `StorageClass` in your cluster using the following command:
+
+```bash
+$ kubectl get storageclass
+NAME                   PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+local-path (default)   rancher.io/local-path   Delete          WaitForFirstConsumer   false                  38h
+longhorn               driver.longhorn.io      Delete          Immediate              true                   6m27s
+longhorn-static        driver.longhorn.io      Delete          Immediate              true                   6m23s
+```
+
+Here, we have the `longhorn` StorageClass in our cluster. It supports volume expansion, which is required by some of the day-2 operations (such as Volume Expansion and Storage Autoscaling) shown in later guides.
+
+## Find Available WeaviateVersion
+
+When you install KubeDB, it creates a `WeaviateVersion` CR for each supported Weaviate version. Let's check the available `WeaviateVersion`s:
+
+```bash
+$ kubectl get weaviateversions
+NAME     VERSION   DB_IMAGE                                  DEPRECATED   AGE
+1.33.1   1.33.1    ghcr.io/appscode-images/weaviate:1.33.1                34h
+```
+
+Notice the `DEPRECATED` column. `true` means that the `WeaviateVersion` is deprecated for the current KubeDB version and KubeDB will not work for that version.
+
+In this tutorial, we will use the `1.33.1` WeaviateVersion CR to create a Weaviate cluster.
+
+## Create a Weaviate Database
+
+KubeDB implements a `Weaviate` CRD to define the specification of a Weaviate database.
+
+Below is the `Weaviate` object created in this tutorial:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          securityContext:
+            runAsNonRoot: false
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+  deletionPolicy: WipeOut
+  healthChecker:
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/quickstart/weaviate-sample.yaml
+weaviate.kubedb.com/weaviate-sample created
+```
+
+Here,
+
+- `spec.version` is the name of the `WeaviateVersion` CR where the Docker images are specified. In this tutorial, a Weaviate `1.33.1` cluster is created.
+- `spec.replicas` specifies the number of Weaviate nodes that form the cluster. A multi-node cluster lets Weaviate replicate collections across nodes for high availability.
+- `spec.storageType` can be `Durable` or `Ephemeral`. `Durable` uses a PersistentVolumeClaim; `Ephemeral` uses an `emptyDir`.
+- `spec.storage` specifies the size and StorageClass of the PVC that will be dynamically allocated to store data for each Weaviate pod. This storage spec will be passed to the PetSet created by the KubeDB operator to run database pods.
+- `spec.deletionPolicy` specifies what KubeDB should do when a user tries to delete the `Weaviate` CR. Deletion policy `DoNotTerminate` prevents deletion of this object if the admission webhook is enabled.
+
+> **Note:** `spec.storage` section is used to create PVC for the database pods. Specify only `requests`, not `limits` — a PVC does not resize automatically.
+
+Now, let's watch the progress of creating the `Weaviate` cluster:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample -w
+NAME              TYPE                  VERSION   STATUS         AGE
+weaviate-sample   kubedb.com/v1alpha2   1.33.1    Provisioning   6s
+weaviate-sample   kubedb.com/v1alpha2   1.33.1    Provisioning   2m
+weaviate-sample   kubedb.com/v1alpha2   1.33.1    Ready          5m21s
+```
+
+## Describe Weaviate
+
+Let's describe the `Weaviate` object to see its current state:
+
+```bash
+$ kubectl describe weaviate -n demo weaviate-sample
+Name:         weaviate-sample
+Namespace:    demo
+Labels:       <none>
+Annotations:  <none>
+API Version:  kubedb.com/v1alpha2
+Kind:         Weaviate
+Metadata:
+  Creation Timestamp:  2026-06-30T17:23:54Z
+  Finalizers:
+    kubedb.com/weaviate
+  Generation:        3
+  Resource Version:  61772
+  UID:               ac548e5a-1d08-4ca6-946e-cdd0a34a2d92
+Spec:
+  Auth Secret:
+    Active From:    2026-06-30T17:23:54Z
+    API Group:      
+    Kind:           
+    Name:           weaviate-sample-auth
+  Deletion Policy:  WipeOut
+  Health Checker:
+    Failure Threshold:  3
+    Period Seconds:     10
+    Timeout Seconds:    10
+  Pod Template:
+    Controller:
+    Metadata:
+    Spec:
+      Containers:
+        Name:  weaviate
+        Resources:
+          Limits:
+            Cpu:     500m
+            Memory:  1Gi
+          Requests:
+            Cpu:     500m
+            Memory:  1Gi
+        Security Context:
+          Allow Privilege Escalation:  false
+          Capabilities:
+            Drop:
+              ALL
+          Run As Non Root:  false
+          Seccomp Profile:
+            Type:  RuntimeDefault
+      Pod Placement Policy:
+        Name:  default
+      Security Context:
+  Replicas:  3
+  Storage:
+    Access Modes:
+      ReadWriteOnce
+    Resources:
+      Requests:
+        Storage:         1Gi
+    Storage Class Name:  longhorn
+  Storage Type:          Durable
+  Version:               1.33.1
+Status:
+  Conditions:
+    Last Transition Time:  2026-06-30T17:23:54Z
+    Message:               The KubeDB operator has started the provisioning of Weaviate demo/weaviate-sample
+    Observed Generation:   1
+    Reason:                DatabaseProvisioningStartedSuccessfully
+    Status:                True
+    Type:                  ProvisioningStarted
+    Last Transition Time:  2026-06-30T17:28:43Z
+    Message:               All replicas are ready
+    Observed Generation:   3
+    Reason:                AllReplicasReady
+    Status:                True
+    Type:                  ReplicaReady
+    Last Transition Time:  2026-06-30T17:28:54Z
+    Message:               The Weaviate: demo/weaviate-sample is accepting client requests
+    Observed Generation:   3
+    Reason:                DatabaseAcceptingConnectionRequest
+    Status:                True
+    Type:                  AcceptingConnection
+    Last Transition Time:  2026-06-30T17:28:55Z
+    Message:               The Weaviate: demo/weaviate-sample is ready.
+    Observed Generation:   3
+    Reason:                ReadinessCheckSucceeded
+    Status:                True
+    Type:                  Ready
+    Last Transition Time:  2026-06-30T17:28:55Z
+    Message:               The Weaviate demo/weaviate-sample is successfully provisioned.
+    Observed Generation:   3
+    Reason:                DatabaseSuccessfullyProvisioned
+    Status:                True
+    Type:                  Provisioned
+  Phase:                   Ready
+Events:                    <none>
+```
+
+## Find Underlying Kubernetes Resources
+
+KubeDB operator creates a PetSet, PVCs, Services, and Secrets for the Weaviate database. Let's check them:
+
+```bash
+$ kubectl get petset -n demo weaviate-sample
+NAME              AGE
+weaviate-sample   5m19s
+
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=weaviate-sample
+NAME                READY   STATUS    RESTARTS   AGE
+weaviate-sample-0   1/1     Running   0          62s
+weaviate-sample-1   1/1     Running   0          55s
+weaviate-sample-2   1/1     Running   0          44s
+
+$ kubectl get pvc -n demo
+NAME                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
+data-weaviate-sample-0   Bound    pvc-b8b6d9e6-634f-4ead-b1fd-1bfe549976e4   1Gi        RWO            longhorn       <unset>                 5m18s
+data-weaviate-sample-1   Bound    pvc-4e9329c0-8a3d-4402-919c-afa4fe2144c9   1Gi        RWO            longhorn       <unset>                 56s
+data-weaviate-sample-2   Bound    pvc-a846947c-212f-4aea-92a7-c8f88ae7f463   1Gi        RWO            longhorn       <unset>                 45s
+
+$ kubectl get service -n demo
+NAME                   TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)                                         AGE
+weaviate-sample        ClusterIP   10.43.98.199   <none>        8080/TCP,50051/TCP,7102/TCP,7103/TCP,8300/TCP   5m23s
+weaviate-sample-pods   ClusterIP   None           <none>        8080/TCP,50051/TCP,7102/TCP,7103/TCP,8300/TCP   5m23s
+```
+
+KubeDB creates two services for a Weaviate cluster:
+
+- `weaviate-sample` — the primary `ClusterIP` service used by clients. It exposes the REST API (`8080`, or `8443` when TLS is enabled), the gRPC API (`50051`), and the internal cluster ports.
+- `weaviate-sample-pods` — a headless (governing) service used for stable per-pod DNS within the cluster.
+
+The internal ports are: `8080` (HTTP REST), `50051` (gRPC), `8300` (raft consensus), `7102` (gossip), and `7103` (cluster data).
+
+## Verify Weaviate YAML Output
+
+KubeDB operator sets the `status.phase` to `Ready` once the database is successfully created and is able to accept client connections. Run the following command to see the modified Weaviate object:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample -o yaml
+```
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  creationTimestamp: "2026-06-30T17:23:54Z"
+  finalizers:
+  - kubedb.com/weaviate
+  generation: 3
+  name: weaviate-sample
+  namespace: demo
+  resourceVersion: "61772"
+  uid: ac548e5a-1d08-4ca6-946e-cdd0a34a2d92
+spec:
+  authSecret:
+    activeFrom: "2026-06-30T17:23:54Z"
+    apiGroup: ""
+    kind: ""
+    name: weaviate-sample-auth
+  deletionPolicy: WipeOut
+  healthChecker:
+    failureThreshold: 3
+    periodSeconds: 10
+    timeoutSeconds: 10
+  podTemplate:
+    controller: {}
+    metadata: {}
+    spec:
+      containers:
+      - name: weaviate
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 1Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: false
+          seccompProfile:
+            type: RuntimeDefault
+      podPlacementPolicy:
+        name: default
+      securityContext: {}
+  replicas: 3
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+    storageClassName: longhorn
+  storageType: Durable
+  version: 1.33.1
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-30T17:23:54Z"
+    message: The KubeDB operator has started the provisioning of Weaviate demo/weaviate-sample
+    observedGeneration: 1
+    reason: DatabaseProvisioningStartedSuccessfully
+    status: "True"
+    type: ProvisioningStarted
+  - lastTransitionTime: "2026-06-30T17:28:43Z"
+    message: All replicas are ready
+    observedGeneration: 3
+    reason: AllReplicasReady
+    status: "True"
+    type: ReplicaReady
+  - lastTransitionTime: "2026-06-30T17:28:54Z"
+    message: 'The Weaviate: demo/weaviate-sample is accepting client requests'
+    observedGeneration: 3
+    reason: DatabaseAcceptingConnectionRequest
+    status: "True"
+    type: AcceptingConnection
+  - lastTransitionTime: "2026-06-30T17:28:55Z"
+    message: 'The Weaviate: demo/weaviate-sample is ready.'
+    observedGeneration: 3
+    reason: ReadinessCheckSucceeded
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2026-06-30T17:28:55Z"
+    message: The Weaviate demo/weaviate-sample is successfully provisioned.
+    observedGeneration: 3
+    reason: DatabaseSuccessfullyProvisioned
+    status: "True"
+    type: Provisioned
+  phase: Ready
+```
+
+## Connect to Weaviate
+
+By default, KubeDB enables API-key authentication for the Weaviate cluster and stores the generated key in a Secret named `<database-name>-auth`. Let's check it:
+
+```bash
+$ kubectl get secret -n demo weaviate-sample-auth -o yaml
+```
+```yaml
+apiVersion: v1
+data:
+  AUTHENTICATION_APIKEY_ALLOWED_KEYS: dnpXU2ppUkdOTkVaRXl0Ug==
+  AUTHENTICATION_APIKEY_ENABLED: dHJ1ZQ==
+  AUTHENTICATION_APIKEY_USERS: YWRtaW4=
+kind: Secret
+metadata:
+  annotations:
+    kubedb.com/auth-active-from: "2026-06-30T17:23:54Z"
+  creationTimestamp: "2026-06-30T17:23:54Z"
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: weaviate-sample
+    app.kubernetes.io/managed-by: kubedb.com
+    app.kubernetes.io/name: weaviates.kubedb.com
+  name: weaviate-sample-auth
+  namespace: demo
+  ownerReferences:
+  - apiVersion: kubedb.com/v1alpha2
+    blockOwnerDeletion: true
+    controller: true
+    kind: Weaviate
+    name: weaviate-sample
+    uid: ac548e5a-1d08-4ca6-946e-cdd0a34a2d92
+  resourceVersion: "60964"
+  uid: ca1779b9-b1ba-4635-a769-6cee4f998384
+type: Opaque
+```
+
+The Secret stores the standard Weaviate API-key environment variables: `AUTHENTICATION_APIKEY_ENABLED`, `AUTHENTICATION_APIKEY_ALLOWED_KEYS` (the API key itself), and `AUTHENTICATION_APIKEY_USERS` (the bound user, `admin`).
+
+Now, let's connect to the Weaviate cluster using port forwarding. In one terminal, start the port-forward:
+
+```bash
+$ kubectl port-forward -n demo svc/weaviate-sample 8080:8080
+Forwarding from 127.0.0.1:8080 -> 8080
+```
+
+In another terminal, export the API key and call the REST API:
+
+```bash
+$ export WEAVIATE_API_KEY=$(kubectl get secret -n demo weaviate-sample-auth -o jsonpath='{.data.AUTHENTICATION_APIKEY_ALLOWED_KEYS}' | base64 -d)
+
+$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/v1/.well-known/ready \
+  -H "Authorization: Bearer $WEAVIATE_API_KEY"
+200
+```
+
+Check the cluster nodes — all three should report `HEALTHY`:
+
+```bash
+$ curl -s http://localhost:8080/v1/nodes -H "Authorization: Bearer $WEAVIATE_API_KEY" | jq
+{
+  "nodes": [
+    {"name": "weaviate-sample-0", "status": "HEALTHY", "version": "1.33.1", "gitHash": "c87f308", "batchStats": {"queueLength": 0, "ratePerSecond": 0}, "shards": null},
+    {"name": "weaviate-sample-1", "status": "HEALTHY", "version": "1.33.1", "gitHash": "c87f308", "batchStats": {"queueLength": 0, "ratePerSecond": 0}, "shards": null},
+    {"name": "weaviate-sample-2", "status": "HEALTHY", "version": "1.33.1", "gitHash": "c87f308", "batchStats": {"queueLength": 0, "ratePerSecond": 0}, "shards": null}
+  ]
+}
+```
+
+Let's create a collection (class) and then read the schema back:
+
+```bash
+$ curl -s -X POST http://localhost:8080/v1/schema \
+  -H "Authorization: Bearer $WEAVIATE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"class":"Article","vectorizer":"none"}'
+{"class":"Article","invertedIndexConfig":{...},"multiTenancyConfig":{"enabled":false},...}
+
+$ curl -s http://localhost:8080/v1/schema -H "Authorization: Bearer $WEAVIATE_API_KEY" | jq '.classes[].class'
+"Article"
+```
+
+The collection was created and is served by the cluster.
+
+## AppBinding
+
+KubeDB creates an AppBinding CR that holds the necessary information to connect with the database.
+
+```bash
+$ kubectl get appbinding -n demo
+NAME              TYPE                  VERSION   AGE
+weaviate-sample   kubedb.com/weaviate   1.33.1    5m20s
+
+$ kubectl get appbinding -n demo weaviate-sample -o yaml
+```
+
+```yaml
+apiVersion: appcatalog.appscode.com/v1alpha1
+kind: AppBinding
+metadata:
+  creationTimestamp: "2026-06-30T17:23:57Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: weaviate-sample
+    app.kubernetes.io/managed-by: kubedb.com
+    app.kubernetes.io/name: weaviates.kubedb.com
+  name: weaviate-sample
+  namespace: demo
+  ownerReferences:
+  - apiVersion: kubedb.com/v1alpha2
+    blockOwnerDeletion: true
+    controller: true
+    kind: Weaviate
+    name: weaviate-sample
+    uid: ac548e5a-1d08-4ca6-946e-cdd0a34a2d92
+  resourceVersion: "60960"
+  uid: 73731c82-f346-4424-be73-05e2ea6e3ebd
+spec:
+  appRef:
+    apiGroup: kubedb.com
+    kind: Weaviate
+    name: weaviate-sample
+    namespace: demo
+  clientConfig:
+    service:
+      name: weaviate-sample
+      port: 8080
+      scheme: http
+  secret:
+    apiGroup: ""
+    kind: ""
+    name: weaviate-sample-auth
+  type: kubedb.com/weaviate
+  version: 1.33.1
+```
+
+You can use this AppBinding to connect with the Weaviate cluster from external applications, including KubeStash for backup and restore.
+
+## Database DeletionPolicy
+
+This field regulates the deletion process of the related resources when the `Weaviate` object is deleted. The available options are:
+
+**DoNotTerminate:**
+
+When `deletionPolicy` is set to `DoNotTerminate`, KubeDB prevents deletion of the database using admission webhooks. If you try to delete it, you will get an error:
+
+```bash
+$ kubectl patch -n demo weaviate/weaviate-sample -p '{"spec":{"deletionPolicy":"DoNotTerminate"}}' --type="merge"
+weaviate.kubedb.com/weaviate-sample patched
+
+$ kubectl delete weaviate -n demo weaviate-sample
+The Weaviate "weaviate-sample" is invalid: spec.deletionPolicy: Invalid value: "weaviate-sample": Can not delete as deletionPolicy is set to "DoNotTerminate"
+```
+
+**Halt:**
+
+When `deletionPolicy` is set to `Halt`, KubeDB deletes the `Weaviate` object and its pods but keeps the `PVCs` and `Secrets` intact. This allows you to recreate the database later using the same data.
+
+**Delete:**
+
+When `deletionPolicy` is set to `Delete`, KubeDB deletes the `Weaviate` object, pods, and `PVCs` but keeps the `Secrets`. This allows you to restore the database from a previously taken backup.
+
+**WipeOut:**
+
+When `deletionPolicy` is set to `WipeOut`, KubeDB deletes all resources of this database (pods, PVCs, Secrets, snapshots, etc.). There is no option to recreate the database once deleted with this policy.
+
+```bash
+$ kubectl patch -n demo weaviate/weaviate-sample -p '{"spec":{"deletionPolicy":"WipeOut"}}' --type="merge"
+weaviate.kubedb.com/weaviate-sample patched
+```
+
+> Be careful when using `WipeOut` — there is no way to recover the database after deletion.
+
+## Next Steps
+
+- Use [custom configuration](/docs/guides/weaviate/configuration/using-config-file.md) for your Weaviate cluster.
+- Encrypt traffic with [TLS](/docs/guides/weaviate/tls/overview.md).
+- Run day-2 operations: [Restart](/docs/guides/weaviate/restart/restart.md), [Reconfigure](/docs/guides/weaviate/reconfigure/reconfigure.md), [Volume Expansion](/docs/guides/weaviate/volume-expansion/volume-expansion.md), [Vertical Scaling](/docs/guides/weaviate/scaling/vertical-scaling/vertical-scaling.md), [Horizontal Scaling](/docs/guides/weaviate/scaling/horizontal-scaling/horizontal-scaling.md), [Rotate Authentication](/docs/guides/weaviate/rotate-auth/rotate-auth.md), and [Storage Migration](/docs/guides/weaviate/storage-migration/storage-migration.md).
+- Automatically scale your cluster with the [Compute Autoscaler](/docs/guides/weaviate/autoscaler/compute/compute-autoscale.md) and [Storage Autoscaler](/docs/guides/weaviate/autoscaler/storage/storage-autoscale.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+kubectl delete weaviate -n demo weaviate-sample
+kubectl delete ns demo
+```

--- a/docs/guides/weaviate/reconfigure-tls/_index.md
+++ b/docs/guides/weaviate/reconfigure-tls/_index.md
@@ -1,0 +1,10 @@
+---
+title: Reconfigure TLS
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-reconfigure-tls
+    name: Reconfigure TLS
+    parent: weaviate-guides
+    weight: 80
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/reconfigure-tls/overview.md
+++ b/docs/guides/weaviate/reconfigure-tls/overview.md
@@ -1,0 +1,44 @@
+---
+title: Weaviate Reconfigure TLS Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-reconfigure-tls-overview
+    name: Overview
+    parent: weaviate-reconfigure-tls
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Reconfigure Weaviate TLS
+
+This guide will give you an overview of how KubeDB Ops Manager reconfigures the TLS configuration of a `Weaviate` cluster — adding TLS, rotating certificates, updating the issuer, and removing TLS.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Weaviate TLS](/docs/guides/weaviate/tls/overview.md)
+
+## How Reconfigure TLS Process Works
+
+Weaviate TLS uses [cert-manager](https://cert-manager.io/) to issue the server and client certificates. The TLS configuration is referenced through `spec.tls` on the `Weaviate` object.
+
+The reconfigure TLS process consists of the following steps:
+
+1. The user creates a `WeaviateOpsRequest` CR of type `ReconfigureTLS` referencing the `Weaviate` database. The `spec.tls` field describes the desired change:
+   - **Add / Update TLS** — provide `spec.tls.issuerRef` (and optionally `clientAuth`) to enable TLS or switch to a new issuer.
+   - **Rotate certificates** — set `spec.tls.rotateCertificates: true` to re-issue the certificates.
+   - **Remove TLS** — set `spec.tls.remove: true` to disable TLS.
+
+2. `KubeDB` Ops Manager watches for the `WeaviateOpsRequest` CR and halts the `Weaviate` object.
+
+3. For add/rotate/update operations, the Ops Manager creates or re-issues the `server` and `client` certificates through cert-manager and waits for them to be ready. For remove, it deletes the certificate references.
+
+4. The Ops Manager updates the PetSet and restarts the pods one by one so they pick up the new TLS configuration. When TLS is enabled, the REST service port switches from `8080` (http) to `8443` (https); when removed, it switches back.
+
+5. After successfully reconfiguring TLS, the `KubeDB` Ops Manager resumes the `Weaviate` object so that the `KubeDB` Provisioner operator resumes its usual operations.
+
+In the next doc, we are going to show a step-by-step guide on reconfiguring TLS for a Weaviate cluster.

--- a/docs/guides/weaviate/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/weaviate/reconfigure-tls/reconfigure-tls.md
@@ -1,0 +1,338 @@
+---
+title: Reconfigure Weaviate TLS
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-reconfigure-tls-cluster
+    name: Reconfigure TLS
+    parent: weaviate-reconfigure-tls
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Reconfigure Weaviate TLS (Transport Encryption)
+
+This guide will show you how to use the `KubeDB` Ops Manager to add TLS to a running Weaviate cluster, rotate its certificates, update its issuer, and finally remove TLS.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster.
+
+- Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
+
+- Install [cert-manager](https://cert-manager.io/docs/installation/) in your cluster — Weaviate TLS is issued through cert-manager.
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Reconfigure TLS Overview](/docs/guides/weaviate/reconfigure-tls/overview.md)
+
+To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/reconfigure-tls](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/reconfigure-tls) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Weaviate without TLS
+
+Deploy a Weaviate cluster without TLS and wait for it to become `Ready`. The REST service is served over plain HTTP on port `8080`:
+
+```bash
+$ kubectl get svc -n demo weaviate-sample -o jsonpath='{range .spec.ports[*]}{.name}={.port} {end}'
+http=8080 grpc=50051 gossip=7102 data=7103 raft=8300
+```
+
+## Create an Issuer
+
+Weaviate TLS is issued through cert-manager. First, create a CA secret and an `Issuer` named `weaviate-issuer` in the `demo` namespace:
+
+```bash
+$ openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
+    -keyout weaviate-ca.key -out weaviate-ca.crt -subj "/CN=weaviate-ca"
+
+$ kubectl create secret tls weaviate-ca \
+    --cert=weaviate-ca.crt --key=weaviate-ca.key -n demo
+secret/weaviate-ca created
+```
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: weaviate-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: weaviate-ca
+```
+
+```bash
+$ kubectl apply -f issuer.yaml
+issuer.cert-manager.io/weaviate-issuer created
+
+$ kubectl get issuer -n demo
+NAME              READY   AGE
+weaviate-issuer   True    3s
+```
+
+## Add TLS to the Cluster
+
+Now, create a `ReconfigureTLS` OpsRequest that points at the issuer:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-add-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: weaviate-sample
+  tls:
+    issuerRef:
+      name: weaviate-issuer
+      kind: Issuer
+      apiGroup: cert-manager.io
+  timeout: 5m
+  apply: IfReady
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/reconfigure-tls/add-tls.yaml
+weaviateopsrequest.ops.kubedb.com/weaviate-add-tls created
+```
+
+The Ops Manager issues the certificates and restarts the pods.
+
+```bash
+$ kubectl get weaviateopsrequest -n demo weaviate-add-tls
+NAME               TYPE             STATUS       AGE
+weaviate-add-tls   ReconfigureTLS   Successful   2m
+```
+
+The `status.conditions` show the certificates being synced and the pods restarted:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo weaviate-add-tls -o yaml
+...
+status:
+  conditions:
+  - message: Weaviate ops-request has started to reconfigure tls for Weaviate nodes
+    reason: ReconfigureTLS
+    status: "True"
+    type: ReconfigureTLS
+  - message: get certificate; ConditionStatus:True
+    status: "True"
+    type: GetCertificate
+  - message: Successfully synced all certificates
+    reason: CertificateSynced
+    status: "True"
+    type: CertificateSynced
+  - message: successfully reconciled the Weaviate with tls configuration
+    reason: UpdatePetSets
+    status: "True"
+    type: UpdatePetSets
+  - message: Successfully restarted all nodes
+    reason: RestartNodes
+    status: "True"
+    type: RestartNodes
+  - message: Successfully completed reconfigureTLS for Weaviate.
+    reason: Successful
+    status: "True"
+    type: Successful
+  observedGeneration: 1
+  phase: Successful
+```
+
+Verify that the REST service now serves HTTPS on port `8443` and the certificates were created:
+
+```bash
+$ kubectl get svc -n demo weaviate-sample -o jsonpath='{range .spec.ports[*]}{.name}={.port} {end}'
+https=8443 grpc=50051 gossip=7102 data=7103 raft=8300
+
+$ kubectl get certificate -n demo
+NAME                          READY   SECRET                        AGE
+weaviate-sample-client-cert   True    weaviate-sample-client-cert   84s
+weaviate-sample-server-cert   True    weaviate-sample-server-cert   84s
+```
+
+The cluster requires client certificate authentication (mTLS) by default. You can connect like this:
+
+```bash
+$ kubectl get secret -n demo weaviate-sample-client-cert -o jsonpath='{.data.ca\.crt}'  | base64 -d > ca.crt
+$ kubectl get secret -n demo weaviate-sample-client-cert -o jsonpath='{.data.tls\.crt}' | base64 -d > client.crt
+$ kubectl get secret -n demo weaviate-sample-client-cert -o jsonpath='{.data.tls\.key}' | base64 -d > client.key
+
+$ kubectl port-forward -n demo svc/weaviate-sample 8443:8443
+# in another terminal
+$ curl -s -o /dev/null -w "%{http_code}\n" --cacert ca.crt --cert client.crt --key client.key \
+    https://localhost:8443/v1/.well-known/ready -H "Authorization: Bearer <api-key>"
+200
+```
+
+## Rotate Certificates
+
+To re-issue the certificates (for example, before they expire), create a `ReconfigureTLS` OpsRequest with `rotateCertificates: true`. This example also disables client-certificate authentication by setting `clientAuth: false`:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-rotate
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: weaviate-sample
+  tls:
+    clientAuth: false
+    rotateCertificates: true
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/reconfigure-tls/rotate-certificate.yaml
+weaviateopsrequest.ops.kubedb.com/wvops-rotate created
+
+$ kubectl get weaviateopsrequest -n demo wvops-rotate
+NAME           TYPE             STATUS       AGE
+wvops-rotate   ReconfigureTLS   Successful   2m
+```
+
+Verify that the server certificate has a newer validity window:
+
+```bash
+$ kubectl get secret -n demo weaviate-sample-server-cert -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -subject -dates
+subject=CN=weaviate-sample
+notBefore=Jun 30 17:52:42 2026 GMT
+notAfter=Sep 28 17:52:42 2026 GMT
+```
+
+## Update the Issuer
+
+You can switch the cluster to a different cert-manager issuer. First, create the new CA secret and the `weaviate-new-issuer`:
+
+```bash
+$ openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
+    -keyout weaviate-new-ca.key -out weaviate-new-ca.crt -subj "/CN=weaviate-new-ca"
+
+$ kubectl create secret tls weaviate-new-ca \
+    --cert=weaviate-new-ca.crt --key=weaviate-new-ca.key -n demo
+secret/weaviate-new-ca created
+```
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: weaviate-new-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: weaviate-new-ca
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/reconfigure-tls/weaviate-new-issuer.yaml
+issuer.cert-manager.io/weaviate-new-issuer created
+```
+
+Now, create a `ReconfigureTLS` OpsRequest that points at the new issuer:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-update-issuer
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: weaviate-sample
+  tls:
+    issuerRef:
+      name: weaviate-new-issuer
+      kind: Issuer
+      apiGroup: "cert-manager.io"
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/reconfigure-tls/update-issuer.yaml
+weaviateopsrequest.ops.kubedb.com/wvops-update-issuer created
+
+$ kubectl get weaviateopsrequest -n demo wvops-update-issuer
+NAME                  TYPE             STATUS       AGE
+wvops-update-issuer   ReconfigureTLS   Successful   2m
+```
+
+Verify that the server certificate is now signed by the new CA:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.tls.issuerRef.name}'
+weaviate-new-issuer
+
+$ kubectl get secret -n demo weaviate-sample-server-cert -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -issuer
+issuer=CN=weaviate-new-ca
+```
+
+## Remove TLS
+
+Finally, to disable TLS, create a `ReconfigureTLS` OpsRequest with `remove: true`:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-remove
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: weaviate-sample
+  tls:
+    remove: true
+```
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/reconfigure-tls/remove-tls.yaml
+weaviateopsrequest.ops.kubedb.com/wvops-remove created
+
+$ kubectl get weaviateopsrequest -n demo wvops-remove
+NAME           TYPE             STATUS       AGE
+wvops-remove   ReconfigureTLS   Successful   2m
+```
+
+Verify that the service is back to plain HTTP on port `8080`, the `spec.tls` field is cleared, and the certificate secrets are gone:
+
+```bash
+$ kubectl get svc -n demo weaviate-sample -o jsonpath='{range .spec.ports[*]}{.name}={.port} {end}'
+http=8080 grpc=50051 gossip=7102 data=7103 raft=8300
+
+$ kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.tls}'
+
+$ kubectl get secret -n demo | grep weaviate-sample-.*cert
+# (no cert secrets)
+```
+
+TLS has been added, rotated, re-issued with a new CA, and finally removed — all without recreating the database.
+
+## Next Steps
+
+- Detail concepts of [Weaviate object](/docs/guides/weaviate/concepts/weaviate.md).
+- Provision a cluster with TLS from the start: [Weaviate TLS](/docs/guides/weaviate/tls/overview.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).
+
+## Cleaning up
+
+To cleanup the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete weaviateopsrequest -n demo weaviate-add-tls wvops-rotate wvops-update-issuer wvops-remove
+$ kubectl delete weaviate -n demo weaviate-sample
+$ kubectl delete issuer -n demo weaviate-issuer weaviate-new-issuer
+$ kubectl delete ns demo
+```

--- a/docs/guides/weaviate/reconfigure/_index.md
+++ b/docs/guides/weaviate/reconfigure/_index.md
@@ -1,0 +1,10 @@
+---
+title: Reconfigure
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-reconfigure
+    name: Reconfigure
+    parent: weaviate-guides
+    weight: 70
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/reconfigure/overview.md
+++ b/docs/guides/weaviate/reconfigure/overview.md
@@ -1,0 +1,46 @@
+---
+title: Weaviate Reconfigure Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-reconfigure-overview
+    name: Overview
+    parent: weaviate-reconfigure
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Reconfigure Weaviate
+
+This guide will give you an overview of how KubeDB Ops Manager reconfigures a `Weaviate` cluster.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Custom Configuration](/docs/guides/weaviate/configuration/using-config-file.md)
+
+## How Reconfigure Process Works
+
+The reconfigure process consists of the following steps:
+
+1. At first, a user creates a `Weaviate` CR (optionally with a custom configuration).
+
+2. `KubeDB` provisioner operator watches for the `Weaviate` CR and creates a `PetSet` and related necessary resources.
+
+3. Then, in order to change the configuration of the `Weaviate` cluster, the user creates a `WeaviateOpsRequest` CR with the desired configuration. The new configuration can be provided in one or more of the following ways:
+   - `spec.configuration.configSecret` — a reference to a `Secret` holding the full `conf.yaml`.
+   - `spec.configuration.applyConfig` — inline `conf.yaml` content that is merged on top of the existing configuration.
+   - `spec.configuration.backupConfigSecret` — a reference to a `Secret` holding backup-related credentials.
+
+4. `KubeDB` Ops Manager watches for the `WeaviateOpsRequest` CR.
+
+5. When it finds one, it halts the `Weaviate` object so that the `KubeDB` provisioner operator doesn't perform any operation on the `Weaviate` during the reconfigure process.
+
+6. Then the `KubeDB` Ops Manager prepares the new configuration, updates the PetSet, and restarts the pods one by one so they pick up the new configuration.
+
+7. After successfully reconfiguring, the `KubeDB` Ops Manager updates the `Weaviate` object to reflect the new configuration and resumes the `Weaviate` object so that the `KubeDB` Provisioner operator resumes its usual operations.
+
+In the next doc, we are going to show a step-by-step guide on reconfiguring a Weaviate cluster.

--- a/docs/guides/weaviate/reconfigure/reconfigure.md
+++ b/docs/guides/weaviate/reconfigure/reconfigure.md
@@ -1,0 +1,243 @@
+---
+title: Reconfigure Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-reconfigure-cluster
+    name: Reconfigure
+    parent: weaviate-reconfigure
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Reconfigure Weaviate
+
+This guide will show you how to use the `KubeDB` Ops Manager to reconfigure a Weaviate cluster.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster.
+
+- Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Custom Configuration](/docs/guides/weaviate/configuration/using-config-file.md)
+  - [Reconfigure Overview](/docs/guides/weaviate/reconfigure/overview.md)
+
+To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/reconfigure](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/reconfigure) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Weaviate
+
+In this section, we are going to deploy a Weaviate cluster. We will reconfigure it in the next step.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Weaviate` CR and wait for it to become `Ready`.
+
+## Prepare Reconfigure Helper Resources
+
+The reconfigure operation in this example references a configuration `Secret` and a backup-credentials `Secret`. Let's create them first.
+
+The new configuration Secret (`conf.yaml` as the key):
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: new-weaviate-config
+  namespace: demo
+type: Opaque
+stringData:
+  conf.yaml: |-
+    authorization:
+      admin_list:
+        enabled: false
+      rbac:
+        enabled: false
+    cluster:
+      hostname: $(POD_NAME)
+    debug: false
+    persistence:
+      data_path: /var/lib/weaviate
+    query_defaults:
+      limit: 200
+```
+
+The backup-credentials Secret:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-secret
+  namespace: demo
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: minio
+  AWS_SECRET_ACCESS_KEY: minio123
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/reconfigure/new-weaviate-config.yaml
+secret/new-weaviate-config created
+
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/reconfigure/minio-secret.yaml
+secret/minio-secret created
+```
+
+## Apply Reconfigure OpsRequest
+
+Now, we are going to reconfigure the cluster. The OpsRequest below references the new configuration Secret, applies an inline `applyConfig` (which is merged on top), and sets a backup-credentials Secret.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: reconfigure
+  namespace: demo
+spec:
+  type: Reconfigure
+  databaseRef:
+    name: weaviate-sample
+  timeout: 3m
+  apply: Always
+  configuration:
+    applyConfig:
+      conf.yaml: |-
+        query_defaults:
+          limit: 155
+    configSecret:
+      name: new-weaviate-config
+    backupConfigSecret:
+      name: minio-secret
+```
+
+- `spec.type` specifies that this is a `Reconfigure` operation.
+- `spec.configuration.configSecret` references the `Secret` holding the new `conf.yaml`.
+- `spec.configuration.applyConfig` provides inline configuration that is merged on top of the configuration from the Secret. Here it overrides `query_defaults.limit` to `155`.
+- `spec.configuration.backupConfigSecret` references a `Secret` holding backup credentials.
+
+Let's create the `WeaviateOpsRequest` CR:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/reconfigure/ops-request.yaml
+weaviateopsrequest.ops.kubedb.com/reconfigure created
+```
+
+The Ops Manager prepares the new configuration, updates the PetSet, and restarts the pods one by one.
+
+```bash
+$ kubectl get weaviateopsrequest -n demo reconfigure
+NAME          TYPE          STATUS       AGE
+reconfigure   Reconfigure   Successful   83s
+```
+
+Let's check the `status.conditions` of the `WeaviateOpsRequest`:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo reconfigure -o yaml
+...
+status:
+  conditions:
+  - message: Weaviate ops-request has started to reconfigure Weaviate nodes
+    reason: Reconfigure
+    status: "True"
+    type: Reconfigure
+  - message: Successfully prepared user provided apply configs
+    reason: PrepareApplyConfig
+    status: "True"
+    type: PrepareApplyConfig
+  - message: successfully reconciled the Weaviate with new configure
+    reason: UpdatePetSets
+    status: "True"
+    type: UpdatePetSets
+  - message: get pod; ConditionStatus:True; PodName:weaviate-sample-0
+    status: "True"
+    type: GetPod--weaviate-sample-0
+  - message: evict pod; ConditionStatus:True; PodName:weaviate-sample-0
+    status: "True"
+    type: EvictPod--weaviate-sample-0
+  - message: running pod; ConditionStatus:True; PodName:weaviate-sample-0
+    status: "True"
+    type: RunningPod--weaviate-sample-0
+  - message: get pod; ConditionStatus:True; PodName:weaviate-sample-1
+    status: "True"
+    type: GetPod--weaviate-sample-1
+  - message: evict pod; ConditionStatus:True; PodName:weaviate-sample-1
+    status: "True"
+    type: EvictPod--weaviate-sample-1
+  - message: running pod; ConditionStatus:True; PodName:weaviate-sample-1
+    status: "True"
+    type: RunningPod--weaviate-sample-1
+  - message: Successfully restarted all nodes
+    reason: RestartNodes
+    status: "True"
+    type: RestartNodes
+  - message: Successfully completed reconfigure Weaviate
+    reason: Successful
+    status: "True"
+    type: Successful
+  observedGeneration: 1
+  phase: Successful
+```
+
+Now, let's verify that the new configuration has been applied to the `Weaviate` object:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.configuration}' | jq
+{
+  "backupConfigSecret": {
+    "name": "minio-secret"
+  },
+  "inline": {
+    "conf.yaml": "query_defaults:\n    limit: 155\n"
+  },
+  "secretName": "new-weaviate-config"
+}
+```
+
+The reconfigure operation has been applied successfully.
+
+## Next Steps
+
+- Detail concepts of [Weaviate object](/docs/guides/weaviate/concepts/weaviate.md).
+- Learn how to supply a [custom configuration](/docs/guides/weaviate/configuration/using-config-file.md) at provisioning time.
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).
+
+## Cleaning up
+
+To cleanup the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete weaviateopsrequest -n demo reconfigure
+$ kubectl delete weaviate -n demo weaviate-sample
+$ kubectl delete ns demo
+```

--- a/docs/guides/weaviate/restart/_index.md
+++ b/docs/guides/weaviate/restart/_index.md
@@ -1,0 +1,10 @@
+---
+title: Restart
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-restart
+    name: Restart
+    parent: weaviate-guides
+    weight: 90
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/restart/restart.md
+++ b/docs/guides/weaviate/restart/restart.md
@@ -1,0 +1,214 @@
+---
+title: Restart Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-restart-overview
+    name: Restart Weaviate
+    parent: weaviate-restart
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Restart Weaviate
+
+KubeDB supports restarting the Weaviate database via a `WeaviateOpsRequest`. Restarting is useful if some pods are stuck in a non-running phase or are not working correctly. This tutorial will show you how to use that.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+- Now, install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Weaviate Quickstart](/docs/guides/weaviate/quickstart/quickstart.md)
+
+To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/restart](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/restart) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Weaviate
+
+In this section, we are going to deploy a Weaviate database using KubeDB.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Weaviate` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/restart/weaviate.yaml
+weaviate.kubedb.com/weaviate-sample created
+```
+
+Now, wait until `weaviate-sample` has status `Ready`:
+
+```bash
+$ kubectl get weaviate -n demo
+NAME              TYPE                  VERSION   STATUS   AGE
+weaviate-sample   kubedb.com/v1alpha2   1.33.1    Ready    5m
+```
+
+## Apply Restart OpsRequest
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: restart
+  namespace: demo
+spec:
+  type: Restart
+  databaseRef:
+    name: weaviate-sample
+  timeout: 3m
+  apply: Always
+```
+
+- `spec.type` specifies the type of the OpsRequest.
+- `spec.databaseRef` holds the name of the Weaviate database. The db should be available in the same namespace as the OpsRequest.
+- `spec.timeout` is the maximum time the ops-manager waits for the request to complete before it is marked as failed.
+- `spec.apply` controls when the operation is applied. `Always` applies it even if the database is not `Ready`; `IfReady` applies it only when the database is `Ready`.
+
+Let's create the `WeaviateOpsRequest` CR we have shown above,
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/restart/ops-request.yaml
+weaviateopsrequest.ops.kubedb.com/restart created
+```
+
+Now the Ops-manager operator will restart the Weaviate pods one by one, waiting for each pod to come back to `Running` state before proceeding to the next.
+
+```bash
+$ kubectl get weaviateopsrequest -n demo restart
+NAME      TYPE      STATUS       AGE
+restart   Restart   Successful   92s
+```
+
+```bash
+$ kubectl get weaviateopsrequest -n demo restart -o yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  creationTimestamp: "2026-06-30T17:32:30Z"
+  generation: 1
+  name: restart
+  namespace: demo
+  resourceVersion: "62408"
+  uid: f47ef99e-0a20-46d8-abf6-4dc40c65e2ff
+spec:
+  apply: Always
+  databaseRef:
+    name: weaviate-sample
+  maxRetries: 1
+  timeout: 3m
+  type: Restart
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-30T17:32:30Z"
+    message: Weaviate ops-request has started to restart ops nodes
+    observedGeneration: 1
+    reason: Restart
+    status: "True"
+    type: Restart
+  - lastTransitionTime: "2026-06-30T17:32:42Z"
+    message: get pod; ConditionStatus:True; PodName:weaviate-sample-0
+    observedGeneration: 1
+    status: "True"
+    type: GetPod--weaviate-sample-0
+  - lastTransitionTime: "2026-06-30T17:32:43Z"
+    message: evict pod; ConditionStatus:True; PodName:weaviate-sample-0
+    observedGeneration: 1
+    status: "True"
+    type: EvictPod--weaviate-sample-0
+  - lastTransitionTime: "2026-06-30T17:32:57Z"
+    message: running pod; ConditionStatus:True; PodName:weaviate-sample-0
+    observedGeneration: 1
+    status: "True"
+    type: RunningPod--weaviate-sample-0
+  - lastTransitionTime: "2026-06-30T17:33:02Z"
+    message: get pod; ConditionStatus:True; PodName:weaviate-sample-1
+    observedGeneration: 1
+    status: "True"
+    type: GetPod--weaviate-sample-1
+  - lastTransitionTime: "2026-06-30T17:33:02Z"
+    message: evict pod; ConditionStatus:True; PodName:weaviate-sample-1
+    observedGeneration: 1
+    status: "True"
+    type: EvictPod--weaviate-sample-1
+  - lastTransitionTime: "2026-06-30T17:33:17Z"
+    message: running pod; ConditionStatus:True; PodName:weaviate-sample-1
+    observedGeneration: 1
+    status: "True"
+    type: RunningPod--weaviate-sample-1
+  - lastTransitionTime: "2026-06-30T17:33:22Z"
+    message: get pod; ConditionStatus:True; PodName:weaviate-sample-2
+    observedGeneration: 1
+    status: "True"
+    type: GetPod--weaviate-sample-2
+  - lastTransitionTime: "2026-06-30T17:33:22Z"
+    message: evict pod; ConditionStatus:True; PodName:weaviate-sample-2
+    observedGeneration: 1
+    status: "True"
+    type: EvictPod--weaviate-sample-2
+  - lastTransitionTime: "2026-06-30T17:33:37Z"
+    message: running pod; ConditionStatus:True; PodName:weaviate-sample-2
+    observedGeneration: 1
+    status: "True"
+    type: RunningPod--weaviate-sample-2
+  - lastTransitionTime: "2026-06-30T17:33:42Z"
+    message: Successfully Restarted Weaviate nodes
+    observedGeneration: 1
+    reason: RestartNodes
+    status: "True"
+    type: RestartNodes
+  - lastTransitionTime: "2026-06-30T17:33:43Z"
+    message: Controller has successfully restart the Weaviate replicas
+    observedGeneration: 1
+    reason: Successful
+    status: "True"
+    type: Successful
+  observedGeneration: 1
+  phase: Successful
+```
+
+## Next Steps
+
+- Detail concepts of [Weaviate object](/docs/guides/weaviate/concepts/weaviate.md).
+- Learn about [Reconfigure](/docs/guides/weaviate/reconfigure/reconfigure.md) and other day-2 operations.
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).
+
+## Cleaning up
+
+To cleanup the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete weaviateopsrequest -n demo restart
+$ kubectl delete weaviate -n demo weaviate-sample
+$ kubectl delete ns demo
+```

--- a/docs/guides/weaviate/rotate-auth/_index.md
+++ b/docs/guides/weaviate/rotate-auth/_index.md
@@ -1,0 +1,10 @@
+---
+title: Rotate Authentication
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-rotate-auth
+    name: Rotate Authentication
+    parent: weaviate-guides
+    weight: 100
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/rotate-auth/overview.md
+++ b/docs/guides/weaviate/rotate-auth/overview.md
@@ -1,0 +1,43 @@
+---
+title: Weaviate Rotate Authentication Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-rotate-auth-overview
+    name: Overview
+    parent: weaviate-rotate-auth
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Rotate Authentication of Weaviate
+
+This guide will give you an overview of how KubeDB Ops Manager rotates the API-key authentication of a `Weaviate` cluster.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Weaviate Quickstart](/docs/guides/weaviate/quickstart/quickstart.md)
+
+## How Rotate Authentication Process Works
+
+By default, KubeDB enables API-key authentication for a Weaviate cluster and stores the generated key in a Secret named `<database-name>-auth`. Rotating authentication replaces this key.
+
+The rotate authentication process consists of the following steps:
+
+1. The user creates a `WeaviateOpsRequest` CR of type `RotateAuth` referencing the `Weaviate` database. There are two modes:
+   - **Operator-generated key** — when no `spec.authentication.secretRef` is provided, the Ops Manager generates a brand-new random API key.
+   - **User-provided key** — when `spec.authentication.secretRef` is provided, the Ops Manager uses the key from the referenced Secret.
+
+2. `KubeDB` Ops Manager watches for the `WeaviateOpsRequest` CR and halts the `Weaviate` object.
+
+3. The Ops Manager updates the auth Secret with the new key. It also keeps the previous key in a `*-PREV` data field so that in-flight clients still using the old key have a short grace window, and it records the `activeFrom` timestamp.
+
+4. The Ops Manager updates the PetSet and restarts the pods one by one so they pick up the new key.
+
+5. After successfully rotating the key, the `KubeDB` Ops Manager resumes the `Weaviate` object so that the `KubeDB` Provisioner operator resumes its usual operations.
+
+In the next doc, we are going to show a step-by-step guide on rotating the authentication of a Weaviate cluster.

--- a/docs/guides/weaviate/rotate-auth/rotate-auth.md
+++ b/docs/guides/weaviate/rotate-auth/rotate-auth.md
@@ -1,0 +1,211 @@
+---
+title: Rotate Authentication for Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-rotate-auth-description
+    name: Rotate Auth
+    parent: weaviate-rotate-auth
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Rotate Authentication for Weaviate
+
+This guide will show you how to use the `KubeDB` Ops Manager to rotate the API-key authentication of a Weaviate cluster.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster.
+
+- Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Rotate Authentication Overview](/docs/guides/weaviate/rotate-auth/overview.md)
+
+To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/rotate-auth](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/rotate-auth) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Weaviate
+
+Deploy a Weaviate cluster and wait for it to become `Ready`. By default, KubeDB generates an API key and stores it in the `weaviate-sample-auth` Secret:
+
+```bash
+$ kubectl get secret -n demo weaviate-sample-auth -o jsonpath='{.data.AUTHENTICATION_APIKEY_ALLOWED_KEYS}' | base64 -d
+vzWSjiRGNNEZEytR
+```
+
+You can confirm this key works through a port-forward:
+
+```bash
+$ kubectl port-forward -n demo svc/weaviate-sample 8080:8080
+# in another terminal
+$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/v1/schema \
+  -H "Authorization: Bearer vzWSjiRGNNEZEytR"
+200
+```
+
+## Rotate Auth with a User-provided Secret
+
+You can rotate the API key to a value you control by providing a Secret with the new key under the `AUTHENTICATION_APIKEY_ALLOWED_KEYS` data field.
+
+First, create the Secret holding the new key:
+
+```yaml
+apiVersion: v1
+data:
+  AUTHENTICATION_APIKEY_ALLOWED_KEYS: VTFVenZyVHZuejVNdzljNA==
+kind: Secret
+metadata:
+  name: weaviate-rotate-auth
+  namespace: demo
+type: Opaque
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/rotate-auth/weaviate-rotate-auth.yaml
+secret/weaviate-rotate-auth created
+```
+
+Now, create the `RotateAuth` OpsRequest referencing that Secret:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-rotate-auth-generated
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: weaviate-sample
+  authentication:
+    secretRef:
+      kind: Secret
+      name: weaviate-rotate-auth
+  timeout: 5m
+  apply: IfReady
+```
+
+- `spec.type` specifies that this is a `RotateAuth` operation.
+- `spec.authentication.secretRef.name` references the Secret holding the new API key. If you omit this field, the Ops Manager generates a brand-new random key instead.
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/rotate-auth/ops-request.yaml
+weaviateopsrequest.ops.kubedb.com/weaviate-rotate-auth-generated created
+```
+
+The Ops Manager updates the credentials and restarts the pods one by one.
+
+```bash
+$ kubectl get weaviateopsrequest -n demo weaviate-rotate-auth-generated
+NAME                             TYPE         STATUS       AGE
+weaviate-rotate-auth-generated   RotateAuth   Successful   70s
+```
+
+Let's check the `status.conditions` of the `WeaviateOpsRequest`:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo weaviate-rotate-auth-generated -o yaml
+...
+status:
+  conditions:
+  - message: Weaviate ops-request has started to rotate auth for Weaviate nodes
+    reason: RotateAuth
+    status: "True"
+    type: RotateAuth
+  - message: Successfully referenced the user provided authSecret
+    reason: UpdateCredential
+    status: "True"
+    type: UpdateCredential
+  - message: successfully reconciled the Weaviate with new configuration
+    reason: UpdatePetSets
+    status: "True"
+    type: UpdatePetSets
+  - message: get pod; ConditionStatus:True; PodName:weaviate-sample-0
+    status: "True"
+    type: GetPod--weaviate-sample-0
+  - message: evict pod; ConditionStatus:True; PodName:weaviate-sample-0
+    status: "True"
+    type: EvictPod--weaviate-sample-0
+  - message: running pod; ConditionStatus:True; PodName:weaviate-sample-0
+    status: "True"
+    type: RunningPod--weaviate-sample-0
+  - message: get pod; ConditionStatus:True; PodName:weaviate-sample-1
+    status: "True"
+    type: GetPod--weaviate-sample-1
+  - message: evict pod; ConditionStatus:True; PodName:weaviate-sample-1
+    status: "True"
+    type: EvictPod--weaviate-sample-1
+  - message: running pod; ConditionStatus:True; PodName:weaviate-sample-1
+    status: "True"
+    type: RunningPod--weaviate-sample-1
+  - message: Successfully Restarted Pods after rotating auth
+    reason: RestartNodes
+    status: "True"
+    type: RestartNodes
+  - message: Successfully completed rotating auth for Weaviate
+    reason: Successful
+    status: "True"
+    type: Successful
+  observedGeneration: 1
+  phase: Successful
+```
+
+## Verify Authentication Rotated
+
+After the rotation, the `Weaviate` object now references the provided Secret, and the Ops Manager has enriched it with the previous key (under `*-PREV`), the enabled flag, and the bound user:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.authSecret}'
+{"activeFrom":"2026-06-30T17:47:20Z","apiGroup":"","externallyManaged":true,"kind":"","name":"weaviate-rotate-auth"}
+
+$ kubectl get secret -n demo weaviate-rotate-auth -o go-template='{{ range $k, $v := .data }}{{ $k }}: {{ $v | base64decode }}{{ "\n" }}{{ end }}'
+AUTHENTICATION_APIKEY_ALLOWED_KEYS: U1UzvrTvnz5Mw9c4
+AUTHENTICATION_APIKEY_ALLOWED_KEYS-PREV: vzWSjiRGNNEZEytR
+AUTHENTICATION_APIKEY_ENABLED: true
+AUTHENTICATION_APIKEY_USERS: admin
+```
+
+Let's confirm that the new key works and the old key is rejected:
+
+```bash
+$ kubectl port-forward -n demo svc/weaviate-sample 8080:8080
+# in another terminal
+$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/v1/schema \
+  -H "Authorization: Bearer U1UzvrTvnz5Mw9c4"
+200
+
+$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/v1/schema \
+  -H "Authorization: Bearer vzWSjiRGNNEZEytR"
+401
+```
+
+The new key returns `200` while the old key now returns `401` — the authentication has been rotated successfully.
+
+> **Tip:** To let the operator generate a fresh random key instead of supplying your own, omit `spec.authentication` from the OpsRequest. KubeDB will generate a new key and update the `<database-name>-auth` Secret in place.
+
+## Next Steps
+
+- Detail concepts of [Weaviate object](/docs/guides/weaviate/concepts/weaviate.md).
+- Encrypt traffic with [TLS](/docs/guides/weaviate/tls/overview.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).
+
+## Cleaning up
+
+To cleanup the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete weaviateopsrequest -n demo weaviate-rotate-auth-generated
+$ kubectl delete weaviate -n demo weaviate-sample
+$ kubectl delete ns demo
+```

--- a/docs/guides/weaviate/scaling/_index.md
+++ b/docs/guides/weaviate/scaling/_index.md
@@ -1,0 +1,10 @@
+---
+title: Scaling
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-scaling
+    name: Scaling
+    parent: weaviate-guides
+    weight: 130
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/scaling/horizontal-scaling/_index.md
+++ b/docs/guides/weaviate/scaling/horizontal-scaling/_index.md
@@ -1,0 +1,10 @@
+---
+title: Horizontal Scaling
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-horizontal-scaling
+    name: Horizontal Scaling
+    parent: weaviate-scaling
+    weight: 10
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/scaling/horizontal-scaling/horizontal-scaling.md
+++ b/docs/guides/weaviate/scaling/horizontal-scaling/horizontal-scaling.md
@@ -1,0 +1,266 @@
+---
+title: Scale Weaviate Horizontally
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-horizontal-scaling-ops
+    name: Scale Horizontally
+    parent: weaviate-horizontal-scaling
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Horizontal Scale Weaviate Cluster
+
+This guide will show you how to use the `KubeDB` Ops Manager to scale the number of nodes of a Weaviate cluster up and down.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster.
+
+- Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Horizontal Scaling Overview](/docs/guides/weaviate/scaling/horizontal-scaling/overview.md)
+
+To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/scaling/horizontal-scaling](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/scaling/horizontal-scaling) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Weaviate
+
+In this section, we are going to deploy a Weaviate cluster with `3` nodes.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Weaviate` CR and wait for it to become `Ready`:
+
+```bash
+$ kubectl get weaviate -n demo
+NAME              TYPE                  VERSION   STATUS   AGE
+weaviate-sample   kubedb.com/v1alpha2   1.33.1    Ready    5m
+
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=weaviate-sample
+NAME                READY   STATUS    RESTARTS   AGE
+weaviate-sample-0   1/1     Running   0          5m
+weaviate-sample-1   1/1     Running   0          5m
+weaviate-sample-2   1/1     Running   0          5m
+```
+
+## Scale Up
+
+Here, we are going to scale up the cluster from `3` nodes to `5` nodes.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-scale-up
+  namespace: demo
+spec:
+  type: HorizontalScaling
+  databaseRef:
+    name: weaviate-sample
+  horizontalScaling:
+    node: 5
+```
+
+- `spec.type` specifies that this is a `HorizontalScaling` operation.
+- `spec.horizontalScaling.node` specifies the desired number of nodes after scaling.
+
+Let's create the `WeaviateOpsRequest` CR:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/scaling/horizontal-scaling/scale-up.yaml
+weaviateopsrequest.ops.kubedb.com/weaviate-scale-up created
+```
+
+The Ops Manager adds the new nodes, waits for them to join and sync the schema, and rebalances the shard replicas.
+
+```bash
+$ kubectl get weaviateopsrequest -n demo weaviate-scale-up
+NAME                TYPE                STATUS       AGE
+weaviate-scale-up   HorizontalScaling   Successful   3m
+
+$ kubectl get weaviateopsrequest -n demo weaviate-scale-up -o yaml
+...
+status:
+  conditions:
+  - message: Weaviate ops-request has started horizontal scaling
+    reason: HorizontalScaling
+    status: "True"
+    type: HorizontalScaling
+  - message: patch petset; ConditionStatus:True
+    status: "True"
+    type: PatchPetset
+  - message: is node in cluster; ConditionStatus:True
+    status: "True"
+    type: IsNodeInCluster
+  - message: successfully restarted new Weaviate pods for schema sync
+    reason: RestartNodes
+    status: "True"
+    type: RestartNodes
+  - message: successfully rebalanced Weaviate shard replicas
+    reason: RebalanceShards
+    status: "True"
+    type: RebalanceShards
+  - message: Successfully scaled up nodes
+    reason: HorizontalScaleUp
+    status: "True"
+    type: HorizontalScaleUp
+  - message: successfully reconciled Weaviate with new replica count
+    reason: UpdatePetSets
+    status: "True"
+    type: UpdatePetSets
+  - message: Horizontal scaling completed
+    reason: Successful
+    status: "True"
+    type: Successful
+  observedGeneration: 1
+  phase: Successful
+```
+
+Verify the new node count:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=weaviate-sample
+NAME                READY   STATUS    RESTARTS   AGE
+weaviate-sample-0   1/1     Running   0          3m51s
+weaviate-sample-1   1/1     Running   0          3m11s
+weaviate-sample-2   1/1     Running   0          2m31s
+weaviate-sample-3   1/1     Running   0          56s
+weaviate-sample-4   1/1     Running   0          44s
+
+$ kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.replicas}'
+5
+```
+
+## Scale Down
+
+Now, let's scale the cluster back down from `5` nodes to `2` nodes.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: weaviate-scale-down
+  namespace: demo
+spec:
+  type: HorizontalScaling
+  databaseRef:
+    name: weaviate-sample
+  horizontalScaling:
+    node: 2
+```
+
+Let's create the `WeaviateOpsRequest` CR:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/scaling/horizontal-scaling/scale-down.yaml
+weaviateopsrequest.ops.kubedb.com/weaviate-scale-down created
+```
+
+The Ops Manager moves the shards off the nodes that are going away before removing them.
+
+```bash
+$ kubectl get weaviateopsrequest -n demo weaviate-scale-down
+NAME                  TYPE                STATUS       AGE
+weaviate-scale-down   HorizontalScaling   Successful   3m
+
+$ kubectl get weaviateopsrequest -n demo weaviate-scale-down -o yaml
+...
+status:
+  conditions:
+  - message: Weaviate ops-request has started horizontal scaling
+    reason: HorizontalScaling
+    status: "True"
+    type: HorizontalScaling
+  - message: move shards; ConditionStatus:True; PodName:weaviate-sample-4
+    status: "True"
+    type: MoveShards--weaviate-sample-4
+  - message: delete pvc; ConditionStatus:True; PodName:weaviate-sample-4
+    status: "True"
+    type: DeletePvc--weaviate-sample-4
+  - message: move shards; ConditionStatus:True; PodName:weaviate-sample-3
+    status: "True"
+    type: MoveShards--weaviate-sample-3
+  - message: delete pvc; ConditionStatus:True; PodName:weaviate-sample-3
+    status: "True"
+    type: DeletePvc--weaviate-sample-3
+  - message: move shards; ConditionStatus:True; PodName:weaviate-sample-2
+    status: "True"
+    type: MoveShards--weaviate-sample-2
+  - message: delete pvc; ConditionStatus:True; PodName:weaviate-sample-2
+    status: "True"
+    type: DeletePvc--weaviate-sample-2
+  - message: Successfully scaled down nodes
+    reason: HorizontalScaleDown
+    status: "True"
+    type: HorizontalScaleDown
+  - message: successfully reconciled Weaviate with new replica count
+    reason: UpdatePetSets
+    status: "True"
+    type: UpdatePetSets
+  - message: Horizontal scaling completed
+    reason: Successful
+    status: "True"
+    type: Successful
+  observedGeneration: 1
+  phase: Successful
+```
+
+Verify the node count again:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=weaviate-sample
+NAME                READY   STATUS    RESTARTS   AGE
+weaviate-sample-0   1/1     Running   0          7m27s
+weaviate-sample-1   1/1     Running   0          6m47s
+
+$ kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.replicas}'
+2
+```
+
+The cluster has been scaled horizontally — first up to `5` nodes, then back down to `2`.
+
+## Next Steps
+
+- Detail concepts of [Weaviate object](/docs/guides/weaviate/concepts/weaviate.md).
+- [Vertical Scaling](/docs/guides/weaviate/scaling/vertical-scaling/vertical-scaling.md) of a Weaviate cluster.
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete weaviateopsrequest -n demo weaviate-scale-up weaviate-scale-down
+$ kubectl delete weaviate -n demo weaviate-sample
+$ kubectl delete ns demo
+```

--- a/docs/guides/weaviate/scaling/horizontal-scaling/overview.md
+++ b/docs/guides/weaviate/scaling/horizontal-scaling/overview.md
@@ -1,0 +1,45 @@
+---
+title: Weaviate Horizontal Scaling Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-horizontal-scaling-overview
+    name: Overview
+    parent: weaviate-horizontal-scaling
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Horizontal Scaling Weaviate
+
+This guide will give you an overview of how KubeDB Ops Manager scales the number of nodes (replicas) of a `Weaviate` cluster.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Weaviate Quickstart](/docs/guides/weaviate/quickstart/quickstart.md)
+
+## How Horizontal Scaling Process Works
+
+The horizontal scaling process consists of the following steps:
+
+1. At first, a user creates a `Weaviate` CR.
+
+2. `KubeDB` provisioner operator watches for the `Weaviate` CR and creates a `PetSet` and related necessary resources.
+
+3. Then, in order to scale the number of nodes of the `Weaviate` cluster, the user creates a `WeaviateOpsRequest` CR with the desired node count.
+
+4. `KubeDB` Ops Manager watches for the `WeaviateOpsRequest` CR.
+
+5. When it finds one, it halts the `Weaviate` object so that the `KubeDB` provisioner operator doesn't perform any operation on the `Weaviate` during the scaling process.
+
+6. To **scale up**, the Ops Manager increases the replica count of the PetSet, waits for the new nodes to join the cluster and sync the schema, and then rebalances the shard replicas across the enlarged cluster.
+
+7. To **scale down**, the Ops Manager rebalances shard replicas off the nodes that are going away, then decreases the replica count of the PetSet and removes the surplus nodes.
+
+8. After successfully scaling, the `KubeDB` Ops Manager updates the `Weaviate` object's replica count to reflect the updated state and resumes the `Weaviate` object so that the `KubeDB` Provisioner operator resumes its usual operations.
+
+In the next doc, we are going to show a step-by-step guide on scaling a Weaviate cluster horizontally.

--- a/docs/guides/weaviate/scaling/vertical-scaling/_index.md
+++ b/docs/guides/weaviate/scaling/vertical-scaling/_index.md
@@ -1,0 +1,10 @@
+---
+title: Vertical Scaling
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-vertical-scaling
+    name: Vertical Scaling
+    parent: weaviate-scaling
+    weight: 20
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/scaling/vertical-scaling/overview.md
+++ b/docs/guides/weaviate/scaling/vertical-scaling/overview.md
@@ -1,0 +1,47 @@
+---
+title: Weaviate Vertical Scaling Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-vertical-scaling-overview
+    name: Overview
+    parent: weaviate-vertical-scaling
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Vertical Scaling Weaviate
+
+This guide will give you an overview of how KubeDB Ops Manager updates the resources (for example Memory, CPU etc.) of a `Weaviate` cluster.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Weaviate Quickstart](/docs/guides/weaviate/quickstart/quickstart.md)
+
+## How Vertical Scaling Process Works
+
+The vertical scaling process consists of the following steps:
+
+1. At first, a user creates a `Weaviate` CR.
+
+2. `KubeDB` provisioner operator watches for the `Weaviate` CR.
+
+3. When the operator finds a `Weaviate` CR, it creates a `PetSet` and related necessary resources like secret, service, etc.
+
+4. Then, in order to update the resources (for example `CPU`, `Memory` etc.) of the `Weaviate` cluster, the user creates a `WeaviateOpsRequest` CR with the desired resources.
+
+5. `KubeDB` Ops Manager watches for the `WeaviateOpsRequest` CR.
+
+6. When it finds one, it halts the `Weaviate` object so that the `KubeDB` provisioner operator doesn't perform any operation on the `Weaviate` during the scaling process.
+
+7. Then the KubeDB Ops-manager operator updates the resources of the PetSet's Pods to reach the desired state, restarting the pods one at a time.
+
+8. After successfully updating the resources of the PetSet's Pods, the `KubeDB` Ops Manager updates the `Weaviate` object resources to reflect the updated state.
+
+9. After successfully updating the `Weaviate` resources, the `KubeDB` Ops Manager resumes the `Weaviate` object so that the `KubeDB` Provisioner operator resumes its usual operations.
+
+In the next doc, we are going to show a step-by-step guide on updating the resources of a Weaviate database using the vertical scaling operation.

--- a/docs/guides/weaviate/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/weaviate/scaling/vertical-scaling/vertical-scaling.md
@@ -1,0 +1,237 @@
+---
+title: Scale Weaviate Vertically
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-vertical-scaling-ops
+    name: Scale Vertically
+    parent: weaviate-vertical-scaling
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Vertical Scale Weaviate Cluster
+
+This guide will show you how to use the `KubeDB` Ops Manager to update the resources (CPU and Memory) of a Weaviate cluster.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster.
+
+- Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Vertical Scaling Overview](/docs/guides/weaviate/scaling/vertical-scaling/overview.md)
+
+To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/scaling/vertical-scaling](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/scaling/vertical-scaling) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Weaviate
+
+In this section, we are going to deploy a Weaviate cluster using KubeDB. Then, in the next section we will update the resources using a `WeaviateOpsRequest`.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  podTemplate:
+    spec:
+      containers:
+        - name: weaviate
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Weaviate` CR and wait for it to become `Ready`:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/scaling/vertical-scaling/weaviate.yaml
+weaviate.kubedb.com/weaviate-sample created
+
+$ kubectl get weaviate -n demo
+NAME              TYPE                  VERSION   STATUS   AGE
+weaviate-sample   kubedb.com/v1alpha2   1.33.1    Ready    5m
+```
+
+Let's check the current resources of one of the pods:
+
+```bash
+$ kubectl get pod -n demo weaviate-sample-0 -o jsonpath='{.spec.containers[0].resources}'
+{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}
+```
+
+## Apply Vertical Scaling on the Weaviate Cluster
+
+Here, we are going to update the resources of the cluster to meet the resources after vertical scaling.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-vertical-scale
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: weaviate-sample
+  verticalScaling:
+    node:
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "1"
+        limits:
+          memory: "2Gi"
+          cpu: "1"
+  timeout: 5m
+  apply: IfReady
+```
+
+- `spec.type` specifies that this is a `VerticalScaling` operation.
+- `spec.databaseRef.name` specifies that we are performing the operation on `weaviate-sample`.
+- `spec.verticalScaling.node` specifies the desired resources for the Weaviate nodes after scaling.
+
+Let's create the `WeaviateOpsRequest` CR:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/scaling/vertical-scaling/ops-request.yaml
+weaviateopsrequest.ops.kubedb.com/wvops-vertical-scale created
+```
+
+The Ops Manager will update the PetSet resources and restart the pods one by one to apply the new resources.
+
+```bash
+$ kubectl get weaviateopsrequest -n demo wvops-vertical-scale
+NAME                   TYPE              STATUS       AGE
+wvops-vertical-scale   VerticalScaling   Successful   2m
+```
+
+Let's look at the `status.conditions` of the `WeaviateOpsRequest`:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo wvops-vertical-scale -o yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wvops-vertical-scale
+  namespace: demo
+spec:
+  apply: IfReady
+  databaseRef:
+    name: weaviate-sample
+  maxRetries: 1
+  timeout: 5m
+  type: VerticalScaling
+  verticalScaling:
+    node:
+      resources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: "1"
+          memory: 2Gi
+status:
+  conditions:
+  - message: Weaviate ops-request has started to vertically scaling the Weaviate nodes
+    reason: VerticalScaling
+    status: "True"
+    type: VerticalScaling
+  - message: Successfully updated PetSets Resources
+    reason: UpdatePetSets
+    status: "True"
+    type: UpdatePetSets
+  - message: get pod; ConditionStatus:True; PodName:weaviate-sample-0
+    status: "True"
+    type: GetPod--weaviate-sample-0
+  - message: evict pod; ConditionStatus:True; PodName:weaviate-sample-0
+    status: "True"
+    type: EvictPod--weaviate-sample-0
+  - message: running pod; ConditionStatus:True; PodName:weaviate-sample-0
+    status: "True"
+    type: RunningPod--weaviate-sample-0
+  - message: get pod; ConditionStatus:True; PodName:weaviate-sample-1
+    status: "True"
+    type: GetPod--weaviate-sample-1
+  - message: evict pod; ConditionStatus:True; PodName:weaviate-sample-1
+    status: "True"
+    type: EvictPod--weaviate-sample-1
+  - message: running pod; ConditionStatus:True; PodName:weaviate-sample-1
+    status: "True"
+    type: RunningPod--weaviate-sample-1
+  - message: get pod; ConditionStatus:True; PodName:weaviate-sample-2
+    status: "True"
+    type: GetPod--weaviate-sample-2
+  - message: evict pod; ConditionStatus:True; PodName:weaviate-sample-2
+    status: "True"
+    type: EvictPod--weaviate-sample-2
+  - message: running pod; ConditionStatus:True; PodName:weaviate-sample-2
+    status: "True"
+    type: RunningPod--weaviate-sample-2
+  - message: Successfully Restarted Pods With Resources
+    reason: RestartPods
+    status: "True"
+    type: RestartPods
+  - message: Successfully completed the vertical scaling for Weaviate
+    reason: Successful
+    status: "True"
+    type: Successful
+  observedGeneration: 1
+  phase: Successful
+```
+
+Now, let's verify the resources of the cluster have been updated:
+
+```bash
+$ kubectl get pod -n demo weaviate-sample-0 -o jsonpath='{.spec.containers[0].resources}'
+{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"1","memory":"2Gi"}}
+
+$ kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.podTemplate.spec.containers[0].resources}'
+{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"1","memory":"2Gi"}}
+```
+
+The resources have been updated successfully.
+
+## Next Steps
+
+- Detail concepts of [Weaviate object](/docs/guides/weaviate/concepts/weaviate.md).
+- [Horizontal Scaling](/docs/guides/weaviate/scaling/horizontal-scaling/horizontal-scaling.md) of a Weaviate cluster.
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete weaviateopsrequest -n demo wvops-vertical-scale
+$ kubectl delete weaviate -n demo weaviate-sample
+$ kubectl delete ns demo
+```

--- a/docs/guides/weaviate/storage-migration/_index.md
+++ b/docs/guides/weaviate/storage-migration/_index.md
@@ -1,0 +1,10 @@
+---
+title: Storage Migration
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-storage-migration
+    name: Storage Migration
+    parent: weaviate-guides
+    weight: 110
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/storage-migration/overview.md
+++ b/docs/guides/weaviate/storage-migration/overview.md
@@ -1,0 +1,43 @@
+---
+title: Weaviate Storage Migration Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-storage-migration-overview
+    name: Overview
+    parent: weaviate-storage-migration
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate StorageClass Migration
+
+This guide will give you an overview of how KubeDB Ops Manager migrates a `Weaviate` cluster from one `StorageClass` to another.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Weaviate Quickstart](/docs/guides/weaviate/quickstart/quickstart.md)
+
+## How Storage Migration Process Works
+
+Storage migration moves the data of a Weaviate cluster from its current `StorageClass` onto a new one — for example, migrating from a cloud-provider block storage to [Longhorn](https://longhorn.io/), or vice-versa.
+
+The storage migration process consists of the following steps:
+
+1. The user creates a `WeaviateOpsRequest` CR of type `StorageMigration` referencing the `Weaviate` database. The `spec.migration` field specifies the target `storageClassName` and the reclaim policy (`oldPVReclaimPolicy`) to apply to the old PersistentVolumes.
+
+2. `KubeDB` Ops Manager watches for the `WeaviateOpsRequest` CR and halts the `Weaviate` object.
+
+3. For each node, the Ops Manager provisions a new PVC on the target `StorageClass`, copies the data from the old volume to the new volume, and re-points the node at the new volume.
+
+4. The old PersistentVolumes are handled according to `spec.migration.oldPVReclaimPolicy` (for example `Delete`).
+
+5. The Ops Manager updates the `Weaviate` object's `spec.storage.storageClassName` to the new `StorageClass` and resumes the `Weaviate` object so that the `KubeDB` Provisioner operator resumes its usual operations.
+
+> **Note:** The target `StorageClass` must be different from the current one. If the database is already running on the target `StorageClass`, there is nothing to migrate.
+
+In the next doc, we are going to show a step-by-step guide on migrating the StorageClass of a Weaviate cluster.

--- a/docs/guides/weaviate/storage-migration/storage-migration.md
+++ b/docs/guides/weaviate/storage-migration/storage-migration.md
@@ -1,0 +1,191 @@
+---
+title: Weaviate Storage Migration
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-storage-migration-cluster
+    name: Storage Migration
+    parent: weaviate-storage-migration
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate StorageClass Migration
+
+This guide will show you how to use the `KubeDB` Ops Manager to migrate a Weaviate cluster from one `StorageClass` to another.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster.
+
+- Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
+
+- You need at least two `StorageClass`es in your cluster — the one the database currently runs on, and the one you want to migrate to. Verify with:
+
+  ```bash
+  $ kubectl get storageclass
+  NAME                   PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+  local-path (default)   rancher.io/local-path   Delete          WaitForFirstConsumer   false                  38h
+  longhorn               driver.longhorn.io      Delete          Immediate              true                   30m
+  ```
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Storage Migration Overview](/docs/guides/weaviate/storage-migration/overview.md)
+
+To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/storage-migration](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/storage-migration) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Weaviate
+
+In this section, we are going to deploy a Weaviate cluster on the `longhorn` StorageClass. We will migrate it to `local-path` in the next step.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 2
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 3Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Weaviate` CR and wait for it to become `Ready`. Then check the current StorageClass of the PVCs:
+
+```bash
+$ kubectl get pvc -n demo -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,SIZE:.status.capacity.storage
+NAME                     SC         SIZE
+data-weaviate-sample-0   longhorn   3Gi
+data-weaviate-sample-1   longhorn   3Gi
+```
+
+The cluster is currently running on the `longhorn` StorageClass.
+
+## Apply StorageMigration OpsRequest
+
+Now, we are going to migrate the cluster from `longhorn` to `local-path`.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: storage-migration
+  namespace: demo
+spec:
+  type: StorageMigration
+  databaseRef:
+    name: weaviate-sample
+  timeout: 10m
+  migration:
+    storageClassName: local-path
+    oldPVReclaimPolicy: Delete
+```
+
+- `spec.type` specifies that this is a `StorageMigration` operation.
+- `spec.migration.storageClassName` specifies the target `StorageClass`. It must be different from the current one.
+- `spec.migration.oldPVReclaimPolicy` specifies the reclaim policy applied to the old PersistentVolumes after migration (here, `Delete`).
+
+Let's create the `WeaviateOpsRequest` CR:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/storage-migration/ops-request.yaml
+weaviateopsrequest.ops.kubedb.com/storage-migration created
+```
+
+For each node, the Ops Manager provisions a new PVC on the target StorageClass, runs a migrator job to copy the data, deletes the old PVC, and re-points the node at the new volume.
+
+```bash
+$ kubectl get weaviateopsrequest -n demo storage-migration
+NAME                TYPE               STATUS       AGE
+storage-migration   StorageMigration   Successful   6m
+```
+
+Let's look at the (abbreviated) `status.conditions` of the `WeaviateOpsRequest`:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo storage-migration -o yaml
+...
+status:
+  conditions:
+  - message: StorageClass migration is in progress
+    reason: Running
+    status: "True"
+    type: Running
+  - message: get storage class; ConditionStatus:True
+    status: "True"
+    type: GetStorageClass
+  - message: 'p v c created; ConditionStatus:True; PodName:data-migrate-weaviate-sample-0'
+    status: "True"
+    type: PVCCreated--data-migrate-weaviate-sample-0
+  - message: 'job created; ConditionStatus:True; PodName:migrator-weaviate-sample-0'
+    status: "True"
+    type: JobCreated--migrator-weaviate-sample-0
+  - message: PVC Migration Completed for weaviate-sample-0
+    reason: PodMigrationCompleted-weaviate-sample-0
+    status: "True"
+    type: PodMigrationCompleted-weaviate-sample-0
+  - message: PVC Migration Completed for weaviate-sample-1
+    reason: PodMigrationCompleted-weaviate-sample-1
+    status: "True"
+    type: PodMigrationCompleted-weaviate-sample-1
+  - message: Successfully migrated StorageClass for Weaviate
+    reason: StorageMigration
+    status: "True"
+    type: StorageMigration
+  - message: Successfully Migrated Weaviate StorageClass for demo/weaviate-sample
+    reason: Successful
+    status: "True"
+    type: Successful
+  observedGeneration: 1
+  phase: Successful
+```
+
+## Verify the StorageClass Migrated Successfully
+
+Verify that the PVCs are now on the `local-path` StorageClass and the database is back to `Ready`:
+
+```bash
+$ kubectl get pvc -n demo -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,SIZE:.status.capacity.storage
+NAME                     SC           SIZE
+data-weaviate-sample-0   local-path   3Gi
+data-weaviate-sample-1   local-path   3Gi
+
+$ kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.storage.storageClassName}{"  "}{.status.phase}'
+local-path  Ready
+```
+
+The StorageClass has been migrated from `longhorn` to `local-path` successfully.
+
+## Next Steps
+
+- Detail concepts of [Weaviate object](/docs/guides/weaviate/concepts/weaviate.md).
+- Expand the volume of a cluster: [Volume Expansion](/docs/guides/weaviate/volume-expansion/volume-expansion.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete weaviateopsrequest -n demo storage-migration
+$ kubectl delete weaviate -n demo weaviate-sample
+$ kubectl delete ns demo
+```

--- a/docs/guides/weaviate/tls/_index.md
+++ b/docs/guides/weaviate/tls/_index.md
@@ -1,0 +1,10 @@
+---
+title: TLS
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-tls
+    name: TLS
+    parent: weaviate-guides
+    weight: 50
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/tls/configure-tls.md
+++ b/docs/guides/weaviate/tls/configure-tls.md
@@ -1,0 +1,220 @@
+---
+title: Configure TLS for Weaviate
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-tls-configure
+    name: Configure TLS
+    parent: weaviate-tls
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Configure TLS for Weaviate
+
+This tutorial will show you how to provision a Weaviate cluster with TLS enabled from the start, using KubeDB and cert-manager.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster.
+
+- Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
+
+- Install [cert-manager](https://cert-manager.io/docs/installation/) in your cluster — Weaviate TLS is issued through cert-manager.
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Weaviate TLS Overview](/docs/guides/weaviate/tls/overview.md)
+
+To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/tls](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/tls) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Create an Issuer
+
+Weaviate TLS is issued through cert-manager. First, create a self-signed CA and a `Secret` that holds it:
+
+```bash
+$ openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
+    -keyout weaviate-ca.key -out weaviate-ca.crt -subj "/CN=weaviate-ca"
+
+$ kubectl create secret tls weaviate-ca \
+    --cert=weaviate-ca.crt --key=weaviate-ca.key -n demo
+secret/weaviate-ca created
+```
+
+Now, create an `Issuer` named `weaviate-issuer` that references this CA secret:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: weaviate-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: weaviate-ca
+```
+
+```bash
+$ kubectl apply -f issuer.yaml
+issuer.cert-manager.io/weaviate-issuer created
+
+$ kubectl get issuer -n demo
+NAME              READY   AGE
+weaviate-issuer   True    3s
+```
+
+## Deploy Weaviate with TLS
+
+Now, create a `Weaviate` CR with `spec.tls` referencing the issuer. Setting `clientAuth: true` requires clients to present a valid client certificate (mutual TLS):
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: weaviate-issuer
+    clientAuth: true
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/tls/tls.yaml
+weaviate.kubedb.com/weaviate-sample created
+```
+
+Wait until the cluster becomes `Ready`:
+
+```bash
+$ kubectl get weaviate -n demo
+NAME              TYPE                  VERSION   STATUS   AGE
+weaviate-sample   kubedb.com/v1alpha2   1.33.1    Ready    73s
+
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=weaviate-sample
+NAME                READY   STATUS    RESTARTS   AGE
+weaviate-sample-0   1/1     Running   0          71s
+weaviate-sample-1   1/1     Running   0          59s
+weaviate-sample-2   1/1     Running   0          45s
+```
+
+## Verify TLS Resources
+
+KubeDB created cert-manager `Certificate` resources and the corresponding TLS secrets (a `server` and a `client` certificate):
+
+```bash
+$ kubectl get certificate -n demo
+NAME                          READY   SECRET                        AGE
+weaviate-sample-client-cert   True    weaviate-sample-client-cert   73s
+weaviate-sample-server-cert   True    weaviate-sample-server-cert   73s
+
+$ kubectl get secret -n demo | grep weaviate-sample
+weaviate-sample-auth          Opaque              3      73s
+weaviate-sample-client-cert   kubernetes.io/tls   4      73s
+weaviate-sample-d25c86        Opaque              1      73s
+weaviate-sample-server-cert   kubernetes.io/tls   3      73s
+```
+
+The `spec.tls` block on the `Weaviate` object reflects the TLS configuration:
+
+```bash
+$ kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.tls}' | jq
+{
+  "certificates": [
+    {"alias": "server", "secretName": "weaviate-sample-server-cert"},
+    {"alias": "client", "secretName": "weaviate-sample-client-cert"}
+  ],
+  "clientAuth": true,
+  "issuerRef": {
+    "apiGroup": "cert-manager.io",
+    "kind": "Issuer",
+    "name": "weaviate-issuer"
+  }
+}
+```
+
+With TLS enabled, the REST service is served over HTTPS on port `8443` instead of plain HTTP on `8080`:
+
+```bash
+$ kubectl get svc -n demo weaviate-sample -o jsonpath='{range .spec.ports[*]}{.name}={.port} {end}'
+https=8443 grpc=50051 gossip=7102 data=7103 raft=8300
+```
+
+You can inspect the issued server certificate:
+
+```bash
+$ kubectl get secret -n demo weaviate-sample-server-cert -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -subject -issuer -dates
+subject=CN=weaviate-sample
+issuer=CN=weaviate-ca
+notBefore=Jun 30 18:07:40 2026 GMT
+notAfter=Sep 28 18:07:40 2026 GMT
+```
+
+## Connect over TLS
+
+Because `clientAuth` is enabled, clients must present the client certificate. Extract the certificates from the `client` secret and connect through a port-forward:
+
+```bash
+$ kubectl get secret -n demo weaviate-sample-client-cert -o jsonpath='{.data.ca\.crt}'  | base64 -d > ca.crt
+$ kubectl get secret -n demo weaviate-sample-client-cert -o jsonpath='{.data.tls\.crt}' | base64 -d > client.crt
+$ kubectl get secret -n demo weaviate-sample-client-cert -o jsonpath='{.data.tls\.key}' | base64 -d > client.key
+
+$ export WEAVIATE_API_KEY=$(kubectl get secret -n demo weaviate-sample-auth -o jsonpath='{.data.AUTHENTICATION_APIKEY_ALLOWED_KEYS}' | base64 -d)
+
+$ kubectl port-forward -n demo svc/weaviate-sample 8443:8443
+# in another terminal
+$ curl -s -o /dev/null -w "%{http_code}\n" \
+    --cacert ca.crt --cert client.crt --key client.key \
+    https://localhost:8443/v1/.well-known/ready \
+    -H "Authorization: Bearer $WEAVIATE_API_KEY"
+200
+
+$ curl -s --cacert ca.crt --cert client.crt --key client.key \
+    https://localhost:8443/v1/nodes \
+    -H "Authorization: Bearer $WEAVIATE_API_KEY" | jq '.nodes[] | {name, status}'
+{"name": "weaviate-sample-0", "status": "HEALTHY"}
+{"name": "weaviate-sample-1", "status": "HEALTHY"}
+{"name": "weaviate-sample-2", "status": "HEALTHY"}
+```
+
+All three nodes are reachable over the TLS-encrypted, mutually-authenticated REST endpoint.
+
+## Next Steps
+
+- Detail concepts of [Weaviate object](/docs/guides/weaviate/concepts/weaviate.md).
+- Add, rotate, or remove TLS on a running cluster: [Reconfigure TLS](/docs/guides/weaviate/reconfigure-tls/reconfigure-tls.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).
+
+## Cleaning up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete weaviate -n demo weaviate-sample
+$ kubectl delete issuer -n demo weaviate-issuer
+$ kubectl delete secret -n demo weaviate-ca
+$ kubectl delete ns demo
+```

--- a/docs/guides/weaviate/tls/overview.md
+++ b/docs/guides/weaviate/tls/overview.md
@@ -1,0 +1,64 @@
+---
+title: Weaviate TLS Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-tls-overview
+    name: Overview
+    parent: weaviate-tls
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate TLS Encryption
+
+**Prerequisite:** To configure TLS in `Weaviate`, `KubeDB` uses `cert-manager` to issue certificates. So first you have to make sure that the cluster has `cert-manager` installed. Install `cert-manager` in your cluster following the steps [here](https://cert-manager.io/docs/installation/).
+
+To issue a certificate, the following CRDs of `cert-manager` are used:
+
+- `Issuer/ClusterIssuer`: Issuers and ClusterIssuers represent certificate authorities (CAs) that are able to generate signed certificates by honoring certificate signing requests. All cert-manager certificates require a referenced issuer that is in a ready condition to attempt to honor the request. You can learn more details [here](https://cert-manager.io/docs/concepts/issuer/).
+
+- `Certificate`: cert-manager has the concept of Certificates that define a desired x509 certificate which will be renewed and kept up to date. You can learn more details [here](https://cert-manager.io/docs/concepts/certificate/).
+
+**Weaviate CRD Specification:**
+
+KubeDB uses the following CRD fields to enable TLS encryption in `Weaviate`.
+
+- `spec:`
+  - `tls:`
+    - `issuerRef`
+    - `certificates`
+    - `clientAuth`
+
+`KubeDB` uses the `Issuer` or `ClusterIssuer` referenced in the `tls.issuerRef` field to generate the certificate secrets. These certificate secrets (the `server` and `client` certificates, each holding `ca.crt`, `tls.crt`, and `tls.key`) are used to configure the `Weaviate` server. When TLS is enabled, the REST service is served over HTTPS on port `8443` (instead of plain HTTP on `8080`).
+
+Here,
+
+- `issuerRef` is a reference to the `Issuer` or `ClusterIssuer` CR of [cert-manager](https://cert-manager.io/docs/concepts/issuer/) that will be used by `KubeDB` to generate the necessary certificates.
+  - `apiGroup` is the group name of the resource that is being referenced. Currently, the only supported value is `cert-manager.io`.
+  - `kind` is the type of resource that is being referenced. `KubeDB` supports both `Issuer` and `ClusterIssuer` as values for this field.
+  - `name` is the name of the resource (`Issuer` or `ClusterIssuer`) being referenced.
+
+- `certificates` (optional) is a list of additional certificate specifications used to configure the Weaviate server. You can specify custom `dnsNames`, `ipAddresses`, and `subject` for the certificates.
+
+- `clientAuth` (optional) controls whether the REST HTTPS listener requires clients to present a valid client certificate (mutual TLS). When unset or `true`, client certificate authentication is enforced; set it to `false` to allow clients to connect without a client certificate.
+
+## How TLS Configures in Weaviate
+
+Deploying Weaviate with TLS configuration consists of the following steps:
+
+1. At first, a user creates an `Issuer/ClusterIssuer` CR.
+
+2. Then the user creates a `Weaviate` CR which refers to the `Issuer/ClusterIssuer` CR created in the previous step through `spec.tls.issuerRef`.
+
+3. `KubeDB-Provisioner` operator watches for the `Weaviate` CR.
+
+4. `KubeDB` Ops-manager operator creates `Certificate` resources by using the `tls.issuerRef` and `tls.certificates` specification from the `Weaviate` CR.
+
+5. `cert-manager` watches for the certificates and issues the certificate secrets (`server` and `client`) that hold the actual certificates signed by the CA.
+
+6. `KubeDB-Provisioner` operator watches for the certificate secrets and configures the `Weaviate` PetSet so that the database serves traffic over TLS.
+
+In the next doc, we are going to show a step-by-step guide on how to configure a `Weaviate` database with TLS.

--- a/docs/guides/weaviate/volume-expansion/_index.md
+++ b/docs/guides/weaviate/volume-expansion/_index.md
@@ -1,0 +1,10 @@
+---
+title: Volume Expansion
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-volume-expansion
+    name: Volume Expansion
+    parent: weaviate-guides
+    weight: 120
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/weaviate/volume-expansion/overview.md
+++ b/docs/guides/weaviate/volume-expansion/overview.md
@@ -1,0 +1,52 @@
+---
+title: Weaviate Volume Expansion Overview
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-volume-expansion-overview
+    name: Overview
+    parent: weaviate-volume-expansion
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Weaviate Volume Expansion
+
+This guide will give you an overview of how KubeDB Ops Manager expands the volume of a `Weaviate` cluster.
+
+## Before You Begin
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Weaviate Quickstart](/docs/guides/weaviate/quickstart/quickstart.md)
+
+## How Volume Expansion Process Works
+
+The volume expansion process consists of the following steps:
+
+1. At first, a user creates a `Weaviate` CR.
+
+2. `KubeDB` provisioner operator watches for the `Weaviate` CR.
+
+3. When the operator finds a `Weaviate` CR, it creates a `PetSet` and related necessary resources, and provisions a `PersistentVolumeClaim` (PVC) for each node.
+
+4. Then, in order to expand the volume of the `Weaviate` cluster, the user creates a `WeaviateOpsRequest` CR with the desired volume size.
+
+5. `KubeDB` Ops Manager watches for the `WeaviateOpsRequest` CR.
+
+6. When it finds one, it halts the `Weaviate` object so that the `KubeDB` provisioner operator doesn't perform any operation on the `Weaviate` during the volume expansion process.
+
+7. Then the `KubeDB` Ops Manager expands the PVCs to reach the desired size. Volume expansion requires a `StorageClass` that supports volume expansion (`allowVolumeExpansion: true`).
+
+8. After successfully expanding the PVCs, the `KubeDB` Ops Manager updates the `Weaviate` object's storage to reflect the updated state.
+
+9. After successfully updating the storage, the `KubeDB` Ops Manager resumes the `Weaviate` object so that the `KubeDB` Provisioner operator resumes its usual operations.
+
+Volume expansion can be performed in two modes:
+
+- **Online** — the volume is expanded without restarting the pods (requires a CSI driver that supports online expansion).
+- **Offline** — the pods are recreated to apply the expanded volume.
+
+In the next doc, we are going to show a step-by-step guide on expanding the volume of a Weaviate cluster using the volume expansion operation.

--- a/docs/guides/weaviate/volume-expansion/volume-expansion.md
+++ b/docs/guides/weaviate/volume-expansion/volume-expansion.md
@@ -1,0 +1,215 @@
+---
+title: Expand Weaviate Volume
+menu:
+  docs_{{ .version }}:
+    identifier: weaviate-volume-expansion-cluster
+    name: Volume Expansion
+    parent: weaviate-volume-expansion
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Expand Weaviate Volume
+
+This guide will show you how to use the `KubeDB` Ops Manager to expand the volume of a Weaviate cluster.
+
+## Before You Begin
+
+- At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster.
+
+- Install `KubeDB` in your cluster following the steps [here](/docs/setup/README.md).
+
+- You need a `StorageClass` that supports volume expansion. Verify with:
+
+  ```bash
+  $ kubectl get storageclass
+  NAME                   PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+  local-path (default)   rancher.io/local-path   Delete          WaitForFirstConsumer   false                  38h
+  longhorn               driver.longhorn.io      Delete          Immediate              true                   30m
+  ```
+
+  Here, the `longhorn` StorageClass has `ALLOWVOLUMEEXPANSION` set to `true`.
+
+- You should be familiar with the following `KubeDB` concepts:
+  - [Weaviate](/docs/guides/weaviate/concepts/weaviate.md)
+  - [Volume Expansion Overview](/docs/guides/weaviate/volume-expansion/overview.md)
+
+To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/weaviate/volume-expansion](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/weaviate/volume-expansion) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Deploy Weaviate
+
+In this section, we are going to deploy a Weaviate cluster with `1Gi` storage using the `longhorn` StorageClass.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Weaviate
+metadata:
+  name: weaviate-sample
+  namespace: demo
+spec:
+  version: 1.33.1
+  replicas: 3
+  storageType: Durable
+  storage:
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+Let's create the `Weaviate` CR and wait for it to become `Ready`. Then check the PVCs:
+
+```bash
+$ kubectl get pvc -n demo
+NAME                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
+data-weaviate-sample-0   Bound    pvc-b8b6d9e6-634f-4ead-b1fd-1bfe549976e4   1Gi        RWO            longhorn       <unset>                 5m
+data-weaviate-sample-1   Bound    pvc-4e9329c0-8a3d-4402-919c-afa4fe2144c9   1Gi        RWO            longhorn       <unset>                 5m
+data-weaviate-sample-2   Bound    pvc-a846947c-212f-4aea-92a7-c8f88ae7f463   1Gi        RWO            longhorn       <unset>                 5m
+```
+
+Each PVC has `1Gi` of storage.
+
+## Expand Volume of the Weaviate Cluster
+
+Here, we are going to expand the volume of the cluster from `1Gi` to `3Gi`.
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wv-volume-expansion-offline
+  namespace: demo
+spec:
+  type: VolumeExpansion
+  databaseRef:
+    name: weaviate-sample
+  volumeExpansion:
+    node: 3Gi
+    mode: Offline
+```
+
+- `spec.type` specifies that this is a `VolumeExpansion` operation.
+- `spec.volumeExpansion.node` specifies the desired size of the volume after expansion.
+- `spec.volumeExpansion.mode` specifies the expansion mode, either `Online` or `Offline`.
+
+Let's create the `WeaviateOpsRequest` CR:
+
+```bash
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/weaviate/volume-expansion/ops-request.yaml
+weaviateopsrequest.ops.kubedb.com/wv-volume-expansion-offline created
+```
+
+The Ops Manager will expand the PVCs and reconcile the cluster.
+
+```bash
+$ kubectl get weaviateopsrequest -n demo wv-volume-expansion-offline
+NAME                          TYPE              STATUS       AGE
+wv-volume-expansion-offline   VolumeExpansion   Successful   2m
+```
+
+Let's check the `status.conditions` of the `WeaviateOpsRequest`:
+
+```bash
+$ kubectl get weaviateopsrequest -n demo wv-volume-expansion-offline -o yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: WeaviateOpsRequest
+metadata:
+  name: wv-volume-expansion-offline
+  namespace: demo
+spec:
+  apply: IfReady
+  databaseRef:
+    name: weaviate-sample
+  maxRetries: 1
+  type: VolumeExpansion
+  volumeExpansion:
+    mode: Offline
+    node: 3Gi
+status:
+  conditions:
+  - message: Weaviate ops-request has started to expand volume of Weaviate nodes
+    reason: VolumeExpansion
+    status: "True"
+    type: VolumeExpansion
+  - message: get petset; ConditionStatus:True
+    status: "True"
+    type: GetPetset
+  - message: delete petset; ConditionStatus:True
+    status: "True"
+    type: DeletePetset
+  - message: successfully deleted the petSets with orphan propagation policy
+    reason: OrphanPetSetPods
+    status: "True"
+    type: OrphanPetSetPods
+  - message: get pvc; ConditionStatus:True
+    status: "True"
+    type: GetPvc
+  - message: patch pvc; ConditionStatus:True
+    status: "True"
+    type: PatchPvc
+  - message: compare storage; ConditionStatus:True
+    status: "True"
+    type: CompareStorage
+  - message: successfully updated node PVC sizes
+    reason: UpdateNodePVCs
+    status: "True"
+    type: UpdateNodePVCs
+  - message: successfully reconciled the Weaviate resources
+    reason: UpdatePetSets
+    status: "True"
+    type: UpdatePetSets
+  - message: PetSet is recreated
+    reason: ReadyPetSets
+    status: "True"
+    type: ReadyPetSets
+  - message: Successfully completed volumeExpansion for Weaviate
+    reason: Successful
+    status: "True"
+    type: Successful
+  observedGeneration: 1
+  phase: Successful
+```
+
+Now, let's verify that the PVCs have been expanded to `3Gi`:
+
+```bash
+$ kubectl get pvc -n demo
+NAME                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
+data-weaviate-sample-0   Bound    pvc-b8b6d9e6-634f-4ead-b1fd-1bfe549976e4   3Gi        RWO            longhorn       <unset>                 14m
+data-weaviate-sample-1   Bound    pvc-4e9329c0-8a3d-4402-919c-afa4fe2144c9   3Gi        RWO            longhorn       <unset>                 10m
+data-weaviate-sample-2   Bound    pvc-a846947c-212f-4aea-92a7-c8f88ae7f463   3Gi        RWO            longhorn       <unset>                 10m
+
+$ kubectl get weaviate -n demo weaviate-sample -o jsonpath='{.spec.storage.resources.requests.storage}'
+3Gi
+```
+
+The volume has been expanded successfully.
+
+## Next Steps
+
+- Detail concepts of [Weaviate object](/docs/guides/weaviate/concepts/weaviate.md).
+- Automatically scale the storage with the [Storage Autoscaler](/docs/guides/weaviate/autoscaler/storage/storage-autoscale.md).
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl delete weaviateopsrequest -n demo wv-volume-expansion-offline
+$ kubectl delete weaviate -n demo weaviate-sample
+$ kubectl delete ns demo
+```


### PR DESCRIPTION
## Overview

Adds user-facing documentation for **KubeDB managed Weaviate**, mirroring the existing Qdrant guide layout and Postgres documentation style. All command output embedded in these pages was collected from a live KubeDB Weaviate cluster.

## Contents

**Guide pages** (`docs/guides/weaviate/`):
- **Quickstart** — provisioning walkthrough, generated resources, AppBinding, deletion policy, live REST API interaction
- **Concepts** — `Weaviate` and `WeaviateVersion` CRDs
- **Custom Configuration** — secret-backed and inline `conf.yaml`
- **TLS** — overview + configure-tls (cert-manager, mTLS)
- **Ops Requests** — restart, reconfigure, reconfigure-tls (add/rotate/update-issuer/remove), rotate-auth, vertical scaling, horizontal scaling, volume expansion, storage migration
- **Autoscaler** — compute and storage

Each ops/autoscaler topic follows the Qdrant `overview.md` + worked-example split.

**Example manifests** (`docs/examples/weaviate/`) for every guide.

## Notes
- The storage-autoscaler worked example documents the full setup and `describe` output; its live auto-trigger depends on the `volume_used_percentage` custom metric being served in the cluster. The underlying `VolumeExpansion` mechanism it uses is demonstrated live in the Volume Expansion guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a full Weaviate documentation set, including quickstart, configuration, TLS, reconfiguration, restart, authentication rotation, scaling, autoscaling, storage migration, and volume expansion guides.
  * Added many ready-to-use example manifests for common cluster setups and operations.
  * Expanded navigation and overview pages to help users find Weaviate-related workflows more easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->