### PR TITLE
Add HanaDB user documentation

### DIFF
--- a/docs/examples/hanadb/clustering/system-replication.yaml
+++ b/docs/examples/hanadb/clustering/system-replication.yaml
@@ -1,0 +1,33 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-cluster
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 2
+  storageType: Durable
+  topology:
+    mode: SystemReplication
+    systemReplication:
+      replicationMode: fullsync
+      operationMode: logreplay_readaccess
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: local-path
+  deletionPolicy: WipeOut

--- a/docs/examples/hanadb/configuration/hanadb-configuration.yaml
+++ b/docs/examples/hanadb/configuration/hanadb-configuration.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hanadb-configuration
+  namespace: demo
+stringData:
+  global.ini: |
+    [memorymanager]
+    global_allocation_limit = 8589934592

--- a/docs/examples/hanadb/configuration/standalone-cus-conf.yaml
+++ b/docs/examples/hanadb/configuration/standalone-cus-conf.yaml
@@ -1,0 +1,19 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-custom-config
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 1
+  configuration:
+    secretName: hanadb-configuration
+  storageType: Durable
+  storage:
+    storageClassName: local-path
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+  deletionPolicy: WipeOut

--- a/docs/examples/hanadb/monitoring/builtin-prometheus.yaml
+++ b/docs/examples/hanadb/monitoring/builtin-prometheus.yaml
@@ -1,0 +1,22 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-builtin-prometheus
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 1
+  storageType: Durable
+  storage:
+    storageClassName: local-path
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+  deletionPolicy: WipeOut
+  monitor:
+    agent: prometheus.io/builtin
+    prometheus:
+      exporter:
+        port: 9668

--- a/docs/examples/hanadb/monitoring/prometheus-operator.yaml
+++ b/docs/examples/hanadb/monitoring/prometheus-operator.yaml
@@ -1,0 +1,26 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-prometheus-operator
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 1
+  storageType: Durable
+  storage:
+    storageClassName: local-path
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+  deletionPolicy: WipeOut
+  monitor:
+    agent: prometheus.io/operator
+    prometheus:
+      exporter:
+        port: 9668
+      serviceMonitor:
+        labels:
+          release: prometheus
+        interval: 10s

--- a/docs/examples/hanadb/quickstart/standalone.yaml
+++ b/docs/examples/hanadb/quickstart/standalone.yaml
@@ -1,0 +1,17 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-quickstart
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 1
+  storageType: Durable
+  storage:
+    storageClassName: local-path
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+  deletionPolicy: Delete

--- a/docs/examples/hanadb/reconfigure/reconfigure.yaml
+++ b/docs/examples/hanadb/reconfigure/reconfigure.yaml
@@ -1,0 +1,17 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-reconfigure
+  namespace: demo
+spec:
+  type: Reconfigure
+  databaseRef:
+    name: hanadb-standalone
+  configuration:
+    applyConfig:
+      global.ini: |
+        [memorymanager]
+        global_allocation_limit = 9663676416
+    restart: "true"
+  timeout: 30m
+  apply: IfReady

--- a/docs/examples/hanadb/reconfigure/standalone-ops.yaml
+++ b/docs/examples/hanadb/reconfigure/standalone-ops.yaml
@@ -1,0 +1,28 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-standalone
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 1
+  storageType: Durable
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: local-path
+  deletionPolicy: WipeOut

--- a/docs/examples/hanadb/restart/restart.yaml
+++ b/docs/examples/hanadb/restart/restart.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-restart
+  namespace: demo
+spec:
+  type: Restart
+  databaseRef:
+    name: hanadb-cluster
+  timeout: 30m
+  apply: Always

--- a/docs/examples/hanadb/restart/system-replication-ops.yaml
+++ b/docs/examples/hanadb/restart/system-replication-ops.yaml
@@ -1,0 +1,33 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-cluster
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 2
+  storageType: Durable
+  topology:
+    mode: SystemReplication
+    systemReplication:
+      replicationMode: fullsync
+      operationMode: logreplay_readaccess
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: local-path
+  deletionPolicy: WipeOut

--- a/docs/examples/hanadb/rotate-authentication/rotate-auth-generated.yaml
+++ b/docs/examples/hanadb/rotate-authentication/rotate-auth-generated.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-rotate-auth-generated
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: hanadb-standalone
+  timeout: 30m
+  apply: IfReady

--- a/docs/examples/hanadb/rotate-authentication/rotate-auth-user.yaml
+++ b/docs/examples/hanadb/rotate-authentication/rotate-auth-user.yaml
@@ -1,0 +1,15 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-rotate-auth-user
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: hanadb-standalone
+  authentication:
+    secretRef:
+      kind: Secret
+      name: hanadb-new-auth
+  timeout: 30m
+  apply: IfReady

--- a/docs/examples/hanadb/rotate-authentication/standalone-ops.yaml
+++ b/docs/examples/hanadb/rotate-authentication/standalone-ops.yaml
@@ -1,0 +1,28 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-standalone
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 1
+  storageType: Durable
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: local-path
+  deletionPolicy: WipeOut

--- a/docs/examples/hanadb/scaling/standalone-ops.yaml
+++ b/docs/examples/hanadb/scaling/standalone-ops.yaml
@@ -1,0 +1,28 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-standalone
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 1
+  storageType: Durable
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: local-path
+  deletionPolicy: WipeOut

--- a/docs/examples/hanadb/scaling/system-replication-ops.yaml
+++ b/docs/examples/hanadb/scaling/system-replication-ops.yaml
@@ -1,0 +1,33 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-cluster
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 2
+  storageType: Durable
+  topology:
+    mode: SystemReplication
+    systemReplication:
+      replicationMode: fullsync
+      operationMode: logreplay_readaccess
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: local-path
+  deletionPolicy: WipeOut

--- a/docs/examples/hanadb/scaling/system-replication-vertical-scaling.yaml
+++ b/docs/examples/hanadb/scaling/system-replication-vertical-scaling.yaml
@@ -1,0 +1,20 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-vscale
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: hanadb-cluster
+  verticalScaling:
+    hanadb:
+      resources:
+        requests:
+          cpu: "2100m"
+          memory: "8448Mi"
+        limits:
+          cpu: "4"
+          memory: "14Gi"
+  timeout: 30m
+  apply: IfReady

--- a/docs/examples/hanadb/storage-migration/longhorn-single-migrated.yaml
+++ b/docs/examples/hanadb/storage-migration/longhorn-single-migrated.yaml
@@ -1,0 +1,18 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-single-migrated
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "30"
+  fromBackup: ""
+  fsType: ext4
+  dataLocality: disabled
+  unmapMarkSnapChainRemoved: ignored
+  disableRevisionCounter: "true"
+  dataEngine: v1
+  backupTargetName: default

--- a/docs/examples/hanadb/storage-migration/longhorn-single.yaml
+++ b/docs/examples/hanadb/storage-migration/longhorn-single.yaml
@@ -1,0 +1,18 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-single
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "30"
+  fromBackup: ""
+  fsType: ext4
+  dataLocality: disabled
+  unmapMarkSnapChainRemoved: ignored
+  disableRevisionCounter: "true"
+  dataEngine: v1
+  backupTargetName: default

--- a/docs/examples/hanadb/storage-migration/storage-migration-base.yaml
+++ b/docs/examples/hanadb/storage-migration/storage-migration-base.yaml
@@ -1,0 +1,55 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-cluster
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 2
+  storageType: Durable
+  topology:
+    mode: SystemReplication
+    systemReplication:
+      replicationMode: fullsync
+      operationMode: logreplay_readaccess
+  podTemplate:
+    spec:
+      initContainers:
+      - name: fix-volume-permissions
+        image: docker.io/saplabs/hanaexpress:2.00.082.00.20250528.1
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -ec
+        - chown -R 12000:79 /hana/mounts && chmod -R u+rwX,g+rwX /hana/mounts
+        securityContext:
+          runAsUser: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - CHOWN
+            - DAC_OVERRIDE
+            - FOWNER
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - name: data
+          mountPath: /hana/mounts
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: longhorn-single
+  deletionPolicy: WipeOut

--- a/docs/examples/hanadb/storage-migration/storage-migration.yaml
+++ b/docs/examples/hanadb/storage-migration/storage-migration.yaml
@@ -1,0 +1,13 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-storage-migration
+  namespace: demo
+spec:
+  type: StorageMigration
+  databaseRef:
+    name: hanadb-cluster
+  migration:
+    storageClassName: longhorn-single-migrated
+  timeout: 30m
+  apply: IfReady

--- a/docs/examples/hanadb/tls/hdb-ca-issuer.yaml
+++ b/docs/examples/hanadb/tls/hdb-ca-issuer.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: hdb-ca-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: hdb-ca

--- a/docs/examples/hanadb/tls/reconfigure-add-tls.yaml
+++ b/docs/examples/hanadb/tls/reconfigure-add-tls.yaml
@@ -1,0 +1,16 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-add-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: hanadb-cluster
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: hdb-ca-issuer
+  timeout: 30m
+  apply: IfReady

--- a/docs/examples/hanadb/tls/reconfigure-rotate-tls.yaml
+++ b/docs/examples/hanadb/tls/reconfigure-rotate-tls.yaml
@@ -1,0 +1,13 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-rotate-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: hanadb-cluster
+  tls:
+    rotateCertificates: true
+  timeout: 30m
+  apply: IfReady

--- a/docs/examples/hanadb/tls/system-replication-reconfigure-tls-base.yaml
+++ b/docs/examples/hanadb/tls/system-replication-reconfigure-tls-base.yaml
@@ -1,0 +1,33 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-cluster
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 2
+  storageType: Durable
+  topology:
+    mode: SystemReplication
+    systemReplication:
+      replicationMode: fullsync
+      operationMode: logreplay_readaccess
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: local-path
+  deletionPolicy: WipeOut

--- a/docs/examples/hanadb/tls/system-replication-tls.yaml
+++ b/docs/examples/hanadb/tls/system-replication-tls.yaml
@@ -1,0 +1,38 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-cluster
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 2
+  storageType: Durable
+  topology:
+    mode: SystemReplication
+    systemReplication:
+      replicationMode: fullsync
+      operationMode: logreplay_readaccess
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: hdb-ca-issuer
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: local-path
+  deletionPolicy: WipeOut

--- a/docs/examples/hanadb/volume-expansion/system-replication-ops.yaml
+++ b/docs/examples/hanadb/volume-expansion/system-replication-ops.yaml
@@ -1,0 +1,33 @@
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-cluster
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 2
+  storageType: Durable
+  topology:
+    mode: SystemReplication
+    systemReplication:
+      replicationMode: fullsync
+      operationMode: logreplay_readaccess
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: longhorn-single
+  deletionPolicy: WipeOut

--- a/docs/examples/hanadb/volume-expansion/volume-expansion.yaml
+++ b/docs/examples/hanadb/volume-expansion/volume-expansion.yaml
@@ -1,0 +1,14 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-volume-expansion
+  namespace: demo
+spec:
+  type: VolumeExpansion
+  databaseRef:
+    name: hanadb-cluster
+  volumeExpansion:
+    mode: Online
+    hanadb: 65Gi
+  timeout: 30m
+  apply: IfReady

--- a/docs/guides/hanadb/README.md
+++ b/docs/guides/hanadb/README.md
@@ -1,0 +1,79 @@
+---
+title: HanaDB
+menu:
+  docs_{{ .version }}:
+    identifier: hanadb-readme
+    name: HanaDB
+    parent: guides-hanadb
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+url: /docs/{{ .version }}/guides/hanadb/
+aliases:
+  - /docs/{{ .version }}/guides/hanadb/README/
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+## Overview
+
+KubeDB operates [SAP HANA](https://www.sap.com/products/technology-platform/hana.html) databases on
+Kubernetes through the `HanaDB` Custom Resource Definition (CRD). A single `HanaDB` object describes a
+standalone HANA instance or a multi-node HANA **System Replication** cluster, and the KubeDB operator
+provisions the PetSet, Services, authentication Secret, and AppBinding required to run it. Day-2
+operations such as restart, reconfigure, TLS management, scaling, volume expansion, storage migration,
+and credential rotation are driven declaratively through the `HanaDBOpsRequest` CRD.
+
+The guides in this section use [SAP HANA, express edition](https://www.sap.com/products/technology-platform/hana/express-trial.html)
+(`hanaexpress`) images.
+
+## Supported HanaDB Features
+
+| Features                                              | Availability |
+|-------------------------------------------------------|:------------:|
+| Standalone instance                                   |   &#10003;   |
+| System Replication cluster (multi-node)               |   &#10003;   |
+| Synchronous / async replication modes                 |   &#10003;   |
+| Read-enabled secondary (`logreplay_readaccess`)       |   &#10003;   |
+| Persistent Volume                                     |   &#10003;   |
+| Custom Configuration (`global.ini`)                   |   &#10003;   |
+| Custom docker image                                   |   &#10003;   |
+| Authentication (auto-generated credentials)           |   &#10003;   |
+| TLS/SSL (cert-manager)                                |   &#10003;   |
+| Builtin Prometheus Monitoring                         |   &#10003;   |
+| Prometheus Operator Monitoring                        |   &#10003;   |
+| Restart (`HanaDBOpsRequest`)                          |   &#10003;   |
+| Reconfigure (`HanaDBOpsRequest`)                      |   &#10003;   |
+| Reconfigure TLS (`HanaDBOpsRequest`)                  |   &#10003;   |
+| Vertical Scaling (`HanaDBOpsRequest`)                 |   &#10003;   |
+| Volume Expansion (`HanaDBOpsRequest`)                 |   &#10003;   |
+| Horizontal Scaling (`HanaDBOpsRequest`)               |   &#10003;   |
+| Storage Migration (`HanaDBOpsRequest`)                |   &#10003;   |
+| Rotate Authentication (`HanaDBOpsRequest`)            |   &#10003;   |
+
+## User Guide
+
+- [HanaDB Quickstart](/docs/guides/hanadb/quickstart/quickstart.md) — deploy a standalone HanaDB and connect to it.
+- [HanaDB System Replication](/docs/guides/hanadb/clustering/system-replication.md) — run a multi-node HANA System Replication cluster.
+- [Custom Configuration](/docs/guides/hanadb/configuration/using-config-file.md) — supply a custom `global.ini`.
+- [Monitoring with builtin Prometheus](/docs/guides/hanadb/monitoring/using-builtin-prometheus.md).
+- [Monitoring with Prometheus Operator](/docs/guides/hanadb/monitoring/using-prometheus-operator.md).
+- [TLS/SSL Encryption](/docs/guides/hanadb/tls/overview.md).
+- Day-2 operations: [Restart](/docs/guides/hanadb/restart/restart.md), [Reconfigure](/docs/guides/hanadb/reconfigure/reconfigure.md), [Vertical Scaling](/docs/guides/hanadb/scaling/vertical-scaling/vertical-scaling.md), [Volume Expansion](/docs/guides/hanadb/volume-expansion/volume-expansion.md), [Storage Migration](/docs/guides/hanadb/storage-migration/storage-migration.md), [Rotate Authentication](/docs/guides/hanadb/rotate-authentication/rotate-authentication.md).
+
+## Concepts
+
+- [HanaDB CRD](/docs/guides/hanadb/concepts/hanadb.md)
+- [HanaDBVersion CRD](/docs/guides/hanadb/concepts/catalog.md)
+- [HanaDBOpsRequest CRD](/docs/guides/hanadb/concepts/opsrequest.md)
+- [AppBinding](/docs/guides/hanadb/concepts/appbinding.md)
+
+> ## ⚠️ Legal Notice
+>
+> SAP® and SAP HANA® are registered trademarks of SAP SE. KubeDB is not affiliated with, endorsed by,
+> or sponsored by SAP SE.
+>
+> KubeDB provides only orchestration and management tooling for Kubernetes. It does not distribute,
+> bundle, ship, or include any SAP HANA software or binaries. Users must provide their own SAP HANA
+> container images and hold valid SAP licenses, and are solely responsible for compliance with SAP's
+> licensing terms.

--- a/docs/guides/hanadb/_index.md
+++ b/docs/guides/hanadb/_index.md
@@ -1,0 +1,10 @@
+---
+title: HanaDB
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb
+    name: HanaDB
+    parent: guides
+    weight: 12
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/clustering/_index.md
+++ b/docs/guides/hanadb/clustering/_index.md
@@ -1,0 +1,10 @@
+---
+title: Clustering
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-clustering
+    name: Clustering
+    parent: guides-hanadb
+    weight: 25
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/clustering/system-replication.md
+++ b/docs/guides/hanadb/clustering/system-replication.md
@@ -1,0 +1,182 @@
+---
+title: HanaDB System Replication
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-clustering-system-replication
+    name: System Replication
+    parent: guides-hanadb-clustering
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# HanaDB System Replication
+
+KubeDB can run SAP HANA in a multi-node **System Replication** cluster: a primary node serves
+read/write traffic and one or more secondary nodes replicate from it. This guide deploys a System
+Replication cluster and inspects its replication state.
+
+> Note: The YAML files used in this tutorial are stored in [docs/examples/hanadb/clustering](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/hanadb/clustering) folder in the GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Before You Begin
+
+- Install the KubeDB Provisioner and Ops-manager operators following the steps [here](/docs/setup/README.md).
+- A System Replication cluster runs multiple full HANA instances and can take **30–60 minutes** to
+  become `Ready`. Make sure your cluster has enough capacity.
+- Create a namespace:
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Create a System Replication Cluster
+
+Set `spec.topology.mode: SystemReplication`. The `systemReplication` block controls the HANA
+replication and operation modes:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-cluster
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 2
+  storageType: Durable
+  topology:
+    mode: SystemReplication
+    systemReplication:
+      replicationMode: fullsync
+      operationMode: logreplay_readaccess
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: local-path
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/clustering/system-replication.yaml
+hanadb.kubedb.com/hanadb-cluster created
+```
+
+Here,
+
+- `spec.replicas` is the total number of HANA nodes. It must be `>= 2`.
+- `spec.topology.systemReplication.replicationMode` is one of `sync`, `syncmem`, `async`, or `fullsync`.
+- `spec.topology.systemReplication.operationMode` is one of `logreplay`, `delta_datashipping`, or
+  `logreplay_readaccess`. With `logreplay_readaccess`, the secondary accepts read-only queries and
+  KubeDB creates a dedicated `secondary-hanadb-cluster` Service.
+- When `spec.replicas` is even, KubeDB also creates a small **arbiter** pod that acts as a raft
+  tie-breaker so the cluster can always elect a primary.
+
+## Verify the Cluster
+
+Wait until `hanadb-cluster` is `Ready`:
+
+```bash
+$ kubectl get hanadb.kubedb.com -n demo hanadb-cluster
+NAME             VERSION   STATUS   AGE
+hanadb-cluster   2.0.82    Ready    12m
+```
+
+KubeDB labels each pod with its role (`kubedb.com/role`). Note the `hanadb-cluster-arbiter-0` pod —
+because `spec.replicas` is even (2), KubeDB added an arbiter as the raft tie-breaker:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=hanadb-cluster -L kubedb.com/role
+NAME                       READY   STATUS    RESTARTS   AGE     ROLE
+hanadb-cluster-0           2/2     Running   0          12m     primary
+hanadb-cluster-1           2/2     Running   0          12m     secondary
+hanadb-cluster-arbiter-0   1/1     Running   0          5m33s   arbiter
+```
+
+The Services route traffic to the primary and (read-only) secondary:
+
+```bash
+$ kubectl get svc -n demo -l app.kubernetes.io/instance=hanadb-cluster
+NAME                       TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)               AGE
+hanadb-cluster             ClusterIP   10.43.65.245    <none>        39017/TCP             12m
+hanadb-cluster-pods        ClusterIP   None            <none>        39001/TCP,39017/TCP   12m
+hanadb-cluster-secondary   ClusterIP   10.43.219.128   <none>        39017/TCP             12m
+```
+
+Here `hanadb-cluster` always points at the primary, `hanadb-cluster-secondary` at the read-only
+secondary (created because `operationMode` is `logreplay_readaccess`), and `hanadb-cluster-pods` is the
+governing headless Service.
+
+## Inspect System Replication State
+
+Identify the primary pod (role `primary`) and inspect HANA's System Replication status:
+
+```bash
+$ kubectl exec -n demo hanadb-cluster-0 -c hanadb -- /bin/sh -lc \
+  'source /usr/sap/HXE/HDB90/HDBSettings.sh; hdbnsutil -sr_state'
+System Replication State
+~~~~~~~~~~~~~~~~~~~~~~~~
+online: true
+mode: primary
+operation mode: primary
+site id: 1
+site name: SITE_hanadb-cluster-0
+is source system: true
+is secondary/consumer system: false
+has secondaries/consumers attached: true
+is a takeover active: false
+Site Mappings:
+~~~~~~~~~~~~~~
+SITE_hanadb-cluster-0 (primary/primary)
+    |---SITE_hanadb-cluster-1 (sync/logreplay_readaccess)
+done.
+```
+
+The HANA SystemReplication status confirms the secondary is connected and `ACTIVE`. (HANA maps the
+`fullsync` replication mode to `SYNC` plus the full-sync option, so the runtime mode reads `SYNC`.)
+
+```bash
+$ HANA_PASSWORD="$(kubectl get secret hanadb-cluster-auth -n demo -o jsonpath='{.data.password}' | base64 -d)"
+$ kubectl exec -n demo hanadb-cluster-0 -c hanadb -- /bin/sh -lc \
+  "source /usr/sap/HXE/HDB90/HDBSettings.sh; hdbsql -i 90 -d SYSTEMDB -u SYSTEM -p '$HANA_PASSWORD' \
+  \"SELECT SITE_NAME, SECONDARY_SITE_NAME, REPLICATION_MODE, REPLICATION_STATUS FROM SYS.M_SERVICE_REPLICATION\""
+SITE_NAME,SECONDARY_SITE_NAME,REPLICATION_MODE,REPLICATION_STATUS
+"SITE_hanadb-cluster-0","SITE_hanadb-cluster-1","SYNC","ACTIVE"
+1 row selected
+```
+
+## Day-2 Operations
+
+Once the cluster is running you can:
+
+- [Restart](/docs/guides/hanadb/restart/restart.md) it (primary restarted last),
+- [Vertically scale](/docs/guides/hanadb/scaling/vertical-scaling/vertical-scaling.md) the nodes,
+- Enable [TLS](/docs/guides/hanadb/tls/overview.md), and
+- [Migrate storage](/docs/guides/hanadb/storage-migration/storage-migration.md).
+
+## Cleaning Up
+
+```bash
+$ kubectl delete hanadb.kubedb.com -n demo hanadb-cluster
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- Detailed concepts of the [HanaDB object](/docs/guides/hanadb/concepts/hanadb.md).
+- Review the [HanaDBOpsRequest CRD](/docs/guides/hanadb/concepts/opsrequest.md).

--- a/docs/guides/hanadb/concepts/_index.md
+++ b/docs/guides/hanadb/concepts/_index.md
@@ -1,0 +1,10 @@
+---
+title: Concepts
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-concepts
+    name: Concepts
+    parent: guides-hanadb
+    weight: 20
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/concepts/appbinding.md
+++ b/docs/guides/hanadb/concepts/appbinding.md
@@ -1,0 +1,85 @@
+---
+title: AppBinding CRD
+menu:
+  docs_{{ .version }}:
+    identifier: hanadb-concepts-appbinding
+    name: AppBinding
+    parent: guides-hanadb-concepts
+    weight: 25
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# AppBinding
+
+## What is AppBinding
+
+An `AppBinding` is a Kubernetes `Custom Resource Definition` (CRD) that points to an application or
+database. It lets other KubeDB components (and tools such as KubeStash) discover how to connect to a
+database without hard-coding connection details. When KubeDB provisions a `HanaDB`, it automatically
+creates an `AppBinding` with the same name in the same namespace.
+
+## HanaDB AppBinding
+
+Below is the `AppBinding` created by KubeDB for the `hanadb-quickstart` database from the
+[Quickstart](/docs/guides/hanadb/quickstart/quickstart.md):
+
+```yaml
+apiVersion: appcatalog.appscode.com/v1alpha1
+kind: AppBinding
+metadata:
+  name: hanadb-quickstart
+  namespace: demo
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: hanadb-quickstart
+    app.kubernetes.io/managed-by: kubedb.com
+    app.kubernetes.io/name: hanadbs.kubedb.com
+spec:
+  type: kubedb.com/hanadb
+  version: 2.0.82
+  appRef:
+    apiGroup: kubedb.com
+    kind: HanaDB
+    name: hanadb-quickstart
+    namespace: demo
+  clientConfig:
+    service:
+      name: hanadb-quickstart
+      path: /
+      port: 39017
+      scheme: tcp
+  secret:
+    name: hanadb-quickstart-auth
+```
+
+### spec.type
+
+`spec.type` identifies the kind of application. For HanaDB it is `kubedb.com/hanadb`.
+
+### spec.clientConfig
+
+`spec.clientConfig` describes how to reach the database. For HanaDB it points at the primary `Service`
+on the SQL port `39017` (`scheme: tcp`).
+
+### spec.secret
+
+`spec.secret.name` references the authentication `Secret` (`<name>-auth`) that holds the `SYSTEM`
+username and password. Consumers read the credentials from this secret.
+
+### spec.appRef
+
+`spec.appRef` is a back-reference to the owning `HanaDB` object.
+
+## Retrieve the AppBinding
+
+```bash
+kubectl get appbinding -n demo hanadb-quickstart -o yaml
+```
+
+## Next Steps
+
+- Learn about the [HanaDB CRD](/docs/guides/hanadb/concepts/hanadb.md).
+- Read about [HanaDBOpsRequest](/docs/guides/hanadb/concepts/opsrequest.md).

--- a/docs/guides/hanadb/concepts/catalog.md
+++ b/docs/guides/hanadb/concepts/catalog.md
@@ -1,0 +1,94 @@
+---
+title: HanaDBVersion CRD
+menu:
+  docs_{{ .version }}:
+    identifier: hanadb-concepts-catalog
+    name: HanaDBVersion
+    parent: guides-hanadb-concepts
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# HanaDBVersion
+
+## What is HanaDBVersion
+
+`HanaDBVersion` is a Kubernetes `Custom Resource Definition` (CRD). It is a cluster-scoped catalog object
+that holds the container images KubeDB uses for a particular SAP HANA release. When you set
+`spec.version` on a `HanaDB` object, KubeDB looks up the matching `HanaDBVersion` to pick the database,
+coordinator, and exporter images.
+
+A separate catalog object per version lets cluster administrators control exactly which images are used,
+deprecate old versions, and constrain version upgrades.
+
+## HanaDBVersion Spec
+
+```yaml
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: HanaDBVersion
+metadata:
+  name: 2.0.82
+spec:
+  version: 2.0.82
+  db:
+    image: docker.io/saplabs/hanaexpress:2.00.082.00.20250528.1
+  coordinator:
+    image: ghcr.io/kubedb/hanadb-coordinator:v0.5.0
+  exporter:
+    image: ghcr.io/kubedb/hanadb-exporter:1.0.0
+  securityContext:
+    runAsUser: 12000
+    runAsGroup: 79
+  updateConstraints:
+    allowlist:
+    - '>= 2.0.82, <= 2.0.88'
+```
+
+### spec.version
+
+`spec.version` is the SAP HANA database version string. It is the value users set in `HanaDB.spec.version`.
+
+### spec.db.image
+
+`spec.db.image` is the SAP HANA, express edition container image. This is a **required** field. KubeDB
+does not ship HANA images; the catalog points at images you are licensed to use.
+
+### spec.coordinator.image
+
+`spec.coordinator.image` is the image for the `hanadb-coordinator` raft sidecar that runs alongside each
+node of a `SystemReplication` cluster. It elects the primary and maintains the `kubedb.com/role` labels.
+
+### spec.exporter.image
+
+`spec.exporter.image` is the [hanadb_exporter](https://github.com/kubedb/hanadb-exporter) image used for
+Prometheus metrics. This is a **required** field.
+
+### spec.securityContext
+
+`spec.securityContext.runAsUser` and `spec.securityContext.runAsGroup` are the UID/GID the database
+container runs as (the HANA `hxeadm` user, `12000:79`). KubeDB uses these to default the pod security
+context and the data volume `fsGroup`.
+
+### spec.deprecated
+
+`spec.deprecated` is an optional boolean. When `true`, the operator rejects new `HanaDB` objects that
+reference this version and surfaces a warning. Existing databases keep running.
+
+### spec.updateConstraints
+
+`spec.updateConstraints.allowlist` / `denylist` constrain which versions a database on this version may
+be upgraded to.
+
+## List available versions
+
+```bash
+kubectl get hanadbversions
+```
+
+## Next Steps
+
+- Learn about the [HanaDB CRD](/docs/guides/hanadb/concepts/hanadb.md).
+- Deploy your first database with the [Quickstart](/docs/guides/hanadb/quickstart/quickstart.md).

--- a/docs/guides/hanadb/concepts/hanadb.md
+++ b/docs/guides/hanadb/concepts/hanadb.md
@@ -1,0 +1,211 @@
+---
+title: HanaDB CRD
+menu:
+  docs_{{ .version }}:
+    identifier: hanadb-concepts-hanadb
+    name: HanaDB
+    parent: guides-hanadb-concepts
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# HanaDB
+
+## What is HanaDB
+
+`HanaDB` is a Kubernetes `Custom Resource Definition` (CRD). It provides a declarative configuration for
+[SAP HANA](https://www.sap.com/products/technology-platform/hana.html) in a Kubernetes native way. You
+only need to describe the desired database configuration in a `HanaDB` object, and the KubeDB operator
+will create Kubernetes objects in the desired state for you.
+
+## HanaDB Spec
+
+As with all other Kubernetes objects, a `HanaDB` needs `apiVersion`, `kind`, and `metadata` fields. It
+also needs a `.spec` section. Below is an example of a `HanaDB` object describing a System Replication
+cluster.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-cluster
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 2
+  storageType: Durable
+  topology:
+    mode: SystemReplication
+    systemReplication:
+      replicationMode: fullsync
+      operationMode: logreplay_readaccess
+  authSecret:
+    name: hanadb-cluster-auth
+  configuration:
+    secretName: hanadb-configuration
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: hdb-ca-issuer
+  monitor:
+    agent: prometheus.io/operator
+    prometheus:
+      exporter:
+        port: 9668
+      serviceMonitor:
+        labels:
+          release: prometheus
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    storageClassName: local-path
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+  deletionPolicy: WipeOut
+```
+
+### spec.version
+
+`spec.version` is a required field specifying the name of the [HanaDBVersion](/docs/guides/hanadb/concepts/catalog.md)
+CRD where the docker images are specified. To list the available `HanaDBVersion` objects:
+
+```bash
+kubectl get hanadbversions
+```
+
+### spec.replicas
+
+`spec.replicas` is an optional field that specifies the number of database instances (pods). It
+defaults to `1`.
+
+- For a **Standalone** database (no `spec.topology`), keep `replicas: 1`.
+- For a **SystemReplication** cluster, `spec.replicas` is the total number of HANA nodes and must be
+  `>= 2`. When `spec.replicas` is even, KubeDB automatically adds an **arbiter** pod (a lightweight raft
+  tie-breaker that does not run the HANA database) so the cluster can elect a primary.
+
+### spec.topology
+
+`spec.topology` selects the deployment mode. When `spec.topology` is omitted, the database runs as a
+single **Standalone** instance.
+
+- `spec.topology.mode` — one of `Standalone` or `SystemReplication`.
+- `spec.topology.systemReplication.replicationMode` — HANA System Replication mode. One of `sync`,
+  `syncmem`, `async`, or `fullsync`. Defaults to `sync`.
+- `spec.topology.systemReplication.operationMode` — HANA operation mode. One of `logreplay`,
+  `delta_datashipping`, or `logreplay_readaccess`. Defaults to `logreplay`. Use `logreplay_readaccess`
+  to allow read-only queries on the secondary; in that case KubeDB also creates a dedicated
+  `secondary-<name>` Service.
+
+### spec.storageType
+
+`spec.storageType` is an optional field that can be `Durable` (default) or `Ephemeral`.
+
+- `Durable` — the database uses a `PersistentVolumeClaim` created from `spec.storage`.
+- `Ephemeral` — the database uses an `emptyDir` volume; data is lost when the pod restarts. HANA is
+  disk-heavy, so `Ephemeral` is only suitable for throwaway testing.
+
+### spec.storage
+
+When `spec.storageType` is `Durable`, `spec.storage` defines the PVC for the HANA data volume
+(`/hana/mounts`):
+
+- `spec.storage.storageClassName` — the name of the `StorageClass` to use.
+- `spec.storage.accessModes` — usually `["ReadWriteOnce"]`.
+- `spec.storage.resources.requests.storage` — requested volume size. HANA is disk-heavy; use a
+  realistic size (the guides use `64Gi`).
+
+### spec.authSecret
+
+`spec.authSecret` is an optional field referencing the `Secret` that holds the HANA `SYSTEM` user
+credentials. If omitted, KubeDB creates a secret named `<name>-auth` with an auto-generated password.
+The secret has type `kubernetes.io/basic-auth` with the following keys:
+
+- `username` — always `SYSTEM`.
+- `password` — the SYSTEM database password.
+- `password.json` — `{"master_password":"<password>"}`, the format consumed by the HANA container.
+
+> The HANA username must remain `SYSTEM`. See [Rotate Authentication](/docs/guides/hanadb/rotate-authentication/rotate-authentication.md)
+> for changing the password safely.
+
+### spec.configuration
+
+`spec.configuration` lets you supply a custom HANA `global.ini`:
+
+- `spec.configuration.secretName` — name of a `Secret` whose `global.ini` key holds the configuration.
+- `spec.configuration.applyConfig` — an inline `map[string]string` keyed by `global.ini`.
+
+See [Custom Configuration](/docs/guides/hanadb/configuration/using-config-file.md). At runtime, custom
+configuration is merged into HANA's `global.ini`.
+
+### spec.tls
+
+`spec.tls` configures TLS using [cert-manager](https://cert-manager.io/). When set, `spec.tls.issuerRef`
+is required and must reference a cert-manager `Issuer` or `ClusterIssuer`. KubeDB provisions three
+certificates with the aliases `server`, `client`, and `metrics-exporter`. See [TLS/SSL Encryption](/docs/guides/hanadb/tls/overview.md).
+
+### spec.monitor
+
+`spec.monitor` enables Prometheus metrics through the bundled `hanadb_exporter`. Set
+`spec.monitor.agent` to `prometheus.io/builtin` or `prometheus.io/operator`. See
+[Monitoring](/docs/guides/hanadb/monitoring/using-builtin-prometheus.md).
+
+### spec.podTemplate
+
+`spec.podTemplate` customizes the pods that run the database. The most common use is setting resources
+on the named containers. A HanaDB pod can run these containers:
+
+- `hanadb` — the SAP HANA database (always present).
+- `hanadb-coordinator` — the raft coordinator sidecar (present only for `SystemReplication` clusters; it
+  elects the primary and labels pods).
+- `exporter` — the Prometheus exporter (present only when `spec.monitor` is set).
+
+### spec.deletionPolicy
+
+`spec.deletionPolicy` controls what happens to the data and auxiliary objects when the `HanaDB` object
+is deleted:
+
+| Value           | PetSet / Pods | PVC      | Auth & config secrets |
+|-----------------|:-------------:|:--------:|:---------------------:|
+| `DoNotTerminate`| blocks delete | —        | —                     |
+| `Halt`          | deleted       | kept     | kept                  |
+| `Delete`        | deleted       | deleted  | kept                  |
+| `WipeOut`       | deleted       | deleted  | deleted               |
+
+`Delete` is the default. For more details, see [this blog post](https://appscode.com/blog/post/deletion-policy/).
+
+### spec.healthChecker
+
+`spec.healthChecker` tunes how KubeDB probes the database (defaults: `periodSeconds: 20`,
+`timeoutSeconds: 10`, `failureThreshold: 3`). Setting `spec.healthChecker.disableWriteCheck: true`
+keeps the periodic write probe from creating its bookkeeping tenant database/table.
+
+## HanaDB Status
+
+`spec.status.phase` reflects the overall state of the database and is one of:
+
+`Provisioning`, `DataRestoring`, `Ready`, `Critical`, `NotReady`, `Halted`, or `Unknown`.
+
+KubeDB derives the phase from the `status.conditions` array (for example `ProvisioningStarted`,
+`ReplicaReady`, `AcceptingConnection`, `Ready`, and `Provisioned`).
+
+## Next Steps
+
+- Deploy a [Standalone HanaDB](/docs/guides/hanadb/quickstart/quickstart.md).
+- Deploy a [System Replication cluster](/docs/guides/hanadb/clustering/system-replication.md).
+- Learn about [HanaDBVersion](/docs/guides/hanadb/concepts/catalog.md) and [HanaDBOpsRequest](/docs/guides/hanadb/concepts/opsrequest.md).

--- a/docs/guides/hanadb/concepts/opsrequest.md
+++ b/docs/guides/hanadb/concepts/opsrequest.md
@@ -1,0 +1,102 @@
+---
+title: HanaDBOpsRequest CRD
+menu:
+  docs_{{ .version }}:
+    identifier: hanadb-concepts-opsrequest
+    name: HanaDBOpsRequest
+    parent: guides-hanadb-concepts
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# HanaDBOpsRequest
+
+## What is HanaDBOpsRequest
+
+`HanaDBOpsRequest` is a Kubernetes `Custom Resource Definition` (CRD). It provides a declarative way to
+run **day-2 operations** — such as restart, reconfiguration, scaling, volume expansion, storage
+migration, TLS management, and credential rotation — against an existing `HanaDB` database. The KubeDB
+Ops-manager operator watches `HanaDBOpsRequest` objects and orchestrates the change while keeping the
+database available.
+
+## Supported operation types
+
+Every operation type below is implemented by the KubeDB Ops-manager operator for HanaDB:
+
+| `spec.type`          | What it does                                                             | Guide |
+|----------------------|-------------------------------------------------------------------------|-------|
+| `Restart`            | Rolling restart of the database pods.                                   | [Restart](/docs/guides/hanadb/restart/restart.md) |
+| `Reconfigure`        | Apply / change / remove custom `global.ini` configuration.              | [Reconfigure](/docs/guides/hanadb/reconfigure/reconfigure.md) |
+| `ReconfigureTLS`     | Add, rotate, or remove TLS certificates.                                | [Reconfigure TLS](/docs/guides/hanadb/tls/overview.md) |
+| `VerticalScaling`    | Change CPU/memory of the database (and sidecar) containers.             | [Vertical Scaling](/docs/guides/hanadb/scaling/vertical-scaling/vertical-scaling.md) |
+| `VolumeExpansion`    | Grow the data PVCs (requires an expandable StorageClass).               | [Volume Expansion](/docs/guides/hanadb/volume-expansion/volume-expansion.md) |
+| `HorizontalScaling`  | Add/remove nodes of a System Replication cluster.                       | — |
+| `StorageMigration`   | Move the data volumes to a different StorageClass.                      | [Storage Migration](/docs/guides/hanadb/storage-migration/storage-migration.md) |
+| `RotateAuth`         | Rotate the `SYSTEM` password (auto-generated or user-provided).         | [Rotate Authentication](/docs/guides/hanadb/rotate-authentication/rotate-authentication.md) |
+
+## HanaDBOpsRequest Spec
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-restart
+  namespace: demo
+spec:
+  type: Restart
+  databaseRef:
+    name: hanadb-cluster
+  timeout: 30m
+  apply: IfReady
+```
+
+### spec.databaseRef
+
+`spec.databaseRef.name` is **required** and references the target `HanaDB` object in the same namespace.
+
+### spec.type
+
+`spec.type` is **required** and is one of the supported operation types listed above.
+
+### spec.timeout
+
+`spec.timeout` bounds how long the operation may run before it is marked failed (for example `30m`). It
+is **required** for `StorageMigration` and recommended for every storage-heavy or restart-heavy
+operation.
+
+### spec.apply
+
+`spec.apply` controls when the operation starts:
+
+- `IfReady` (default) — wait until the database is `Ready` before applying.
+- `Always` — apply even if the database is not `Ready` (used by `Restart` to recover an unhealthy
+  database).
+
+### Operation-specific fields
+
+Each type reads its own sub-spec:
+
+- `spec.restart` — empty marker for `Restart`.
+- `spec.configuration` — `{ configSecret, applyConfig, removeCustomConfig, restart }` for `Reconfigure`.
+  `applyConfig` keys must be `global.ini`; the values are **merged** with the existing inline
+  configuration. `restart` is `auto` (default), `true`, or `false`.
+- `spec.tls` — `{ issuerRef, certificates, rotateCertificates, remove }` for `ReconfigureTLS`.
+- `spec.verticalScaling` — `{ hanadb, coordinator, exporter }` resources for `VerticalScaling`.
+- `spec.volumeExpansion` — `{ hanadb, mode }` where `mode` is `Online` or `Offline`, for `VolumeExpansion`.
+- `spec.horizontalScaling` — `{ replicas }` for `HorizontalScaling` (System Replication only, `>= 2`).
+- `spec.migration` — `{ storageClassName, oldPVReclaimPolicy }` for `StorageMigration`.
+- `spec.authentication` — `{ secretRef }` for `RotateAuth` (omit to auto-generate a new password).
+
+## HanaDBOpsRequest Status
+
+`status.phase` of a `HanaDBOpsRequest` is one of `Pending`, `Progressing`, `Successful`, `Failed`,
+`Skipped`, `WaitingForApproval`, `Approved`, or `Denied`. The `status.conditions` array records each
+step of the operation (for example `UpdatePetSets`, `RestartPods`, `Successful`).
+
+## Next Steps
+
+- Run a [Restart](/docs/guides/hanadb/restart/restart.md) or [Reconfigure](/docs/guides/hanadb/reconfigure/reconfigure.md).
+- Review the [HanaDB CRD](/docs/guides/hanadb/concepts/hanadb.md).

--- a/docs/guides/hanadb/configuration/_index.md
+++ b/docs/guides/hanadb/configuration/_index.md
@@ -1,0 +1,10 @@
+---
+title: Custom Configuration
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-configuration
+    name: Custom Configuration
+    parent: guides-hanadb
+    weight: 30
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/configuration/using-config-file.md
+++ b/docs/guides/hanadb/configuration/using-config-file.md
@@ -1,0 +1,133 @@
+---
+title: HanaDB Custom Configuration
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-configuration-using-config-file
+    name: Custom Configuration
+    parent: guides-hanadb-configuration
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Run HanaDB with Custom Configuration
+
+KubeDB lets you supply a custom SAP HANA `global.ini` to tune the database. This guide shows how to set
+custom configuration at creation time using a `Secret`. To change configuration on a running database,
+see [Reconfigure](/docs/guides/hanadb/reconfigure/reconfigure.md).
+
+> Note: The YAML files used in this tutorial are stored in [docs/examples/hanadb/configuration](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/hanadb/configuration) folder in the GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Before You Begin
+
+- Install the KubeDB Provisioner and Ops-manager operators following the steps [here](/docs/setup/README.md).
+- Create a namespace:
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Overview
+
+SAP HANA reads its configuration from `global.ini`. KubeDB supports overriding `global.ini` settings.
+The custom values are **merged** into HANA's `global.ini` — you only specify the sections and keys you
+want to change. In this guide we lower the HANA memory budget by setting
+`[memorymanager] global_allocation_limit` (in bytes).
+
+## Create a Configuration Secret
+
+Put the custom `global.ini` in a `Secret`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hanadb-configuration
+  namespace: demo
+stringData:
+  global.ini: |
+    [memorymanager]
+    global_allocation_limit = 8589934592
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/configuration/hanadb-configuration.yaml
+secret/hanadb-configuration created
+```
+
+The key inside the secret **must** be `global.ini`. Here `global_allocation_limit = 8589934592` caps the
+HANA global allocation at 8 GiB.
+
+## Create a HanaDB Using the Configuration Secret
+
+Reference the secret with `spec.configuration.secretName`:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-custom-config
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 1
+  configuration:
+    secretName: hanadb-configuration
+  storageType: Durable
+  storage:
+    storageClassName: local-path
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/configuration/standalone-cus-conf.yaml
+hanadb.kubedb.com/hanadb-custom-config created
+```
+
+Wait for the database to become `Ready`:
+
+```bash
+$ kubectl get hanadb.kubedb.com -n demo hanadb-custom-config
+NAME                   VERSION   STATUS   AGE
+hanadb-custom-config   2.0.82    Ready    24m
+```
+
+## Verify the Configuration
+
+Read the password and query `M_INIFILE_CONTENTS` to confirm HANA picked up the custom value:
+
+```bash
+$ HANA_PASSWORD="$(kubectl get secret hanadb-custom-config-auth -n demo -o jsonpath='{.data.password}' | base64 -d)"
+
+$ kubectl exec -n demo hanadb-custom-config-0 -c hanadb -- /bin/sh -lc \
+  "source /usr/sap/HXE/HDB90/HDBSettings.sh; hdbsql -i 90 -d SYSTEMDB -u SYSTEM -p '$HANA_PASSWORD' \
+  \"SELECT LAYER_NAME, VALUE FROM M_INIFILE_CONTENTS WHERE FILE_NAME='global.ini' AND SECTION='memorymanager' AND KEY='global_allocation_limit'\""
+LAYER_NAME,VALUE
+"SYSTEM","8589934592"
+"DEFAULT","0"
+2 rows selected
+```
+
+The `SYSTEM` layer shows the custom value `8589934592` (8 GiB) merged into `global.ini` from the
+configuration secret, overriding the `DEFAULT` layer.
+
+## Cleaning Up
+
+```bash
+$ kubectl delete hanadb.kubedb.com -n demo hanadb-custom-config
+$ kubectl delete secret -n demo hanadb-configuration
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- Change configuration on a running database with [Reconfigure](/docs/guides/hanadb/reconfigure/reconfigure.md).
+- Review the [HanaDB CRD](/docs/guides/hanadb/concepts/hanadb.md).

--- a/docs/guides/hanadb/monitoring/_index.md
+++ b/docs/guides/hanadb/monitoring/_index.md
@@ -1,0 +1,10 @@
+---
+title: Monitoring
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-monitoring
+    name: Monitoring
+    parent: guides-hanadb
+    weight: 35
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/monitoring/overview.md
+++ b/docs/guides/hanadb/monitoring/overview.md
@@ -1,0 +1,56 @@
+---
+title: HanaDB Monitoring Overview
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-monitoring-overview
+    name: Overview
+    parent: guides-hanadb-monitoring
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Monitoring HanaDB
+
+KubeDB exposes Prometheus metrics for HanaDB through a bundled
+[hanadb_exporter](https://github.com/kubedb/hanadb-exporter) sidecar. You enable it through the
+`spec.monitor` field of the `HanaDB` object.
+
+## How it works
+
+When `spec.monitor` is set, KubeDB adds an `exporter` container to the database pods and a `<db>-stats`
+Service that exposes the metrics endpoint (default port `9668`, path `/metrics`). Two agents are
+supported:
+
+- `prometheus.io/builtin` — annotates the stats Service so a Prometheus server that scrapes by
+  annotation discovers the target. See [Using Builtin Prometheus](/docs/guides/hanadb/monitoring/using-builtin-prometheus.md).
+- `prometheus.io/operator` — creates a `ServiceMonitor` for the
+  [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator). See
+  [Using Prometheus Operator](/docs/guides/hanadb/monitoring/using-prometheus-operator.md).
+
+## The spec.monitor field
+
+```yaml
+spec:
+  monitor:
+    agent: prometheus.io/operator   # or prometheus.io/builtin
+    prometheus:
+      exporter:
+        port: 9668
+      serviceMonitor:
+        labels:
+          release: prometheus
+        interval: 10s
+```
+
+- `spec.monitor.agent` selects the monitoring agent.
+- `spec.monitor.prometheus.exporter.port` is the exporter port (`9668`).
+- `spec.monitor.prometheus.serviceMonitor.labels` must match the `serviceMonitorSelector` of your
+  Prometheus Operator instance (commonly `release: prometheus`).
+
+## Next Steps
+
+- [Using Builtin Prometheus](/docs/guides/hanadb/monitoring/using-builtin-prometheus.md).
+- [Using Prometheus Operator](/docs/guides/hanadb/monitoring/using-prometheus-operator.md).

--- a/docs/guides/hanadb/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/hanadb/monitoring/using-builtin-prometheus.md
@@ -1,0 +1,115 @@
+---
+title: HanaDB Builtin Prometheus
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-monitoring-builtin
+    name: Builtin Prometheus
+    parent: guides-hanadb-monitoring
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Monitoring HanaDB with Builtin Prometheus
+
+This guide deploys a HanaDB with the builtin Prometheus agent so a Prometheus server that scrapes by pod
+annotation can collect its metrics.
+
+> Note: The YAML files used in this tutorial are stored in [docs/examples/hanadb/monitoring](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/hanadb/monitoring) folder in the GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Before You Begin
+
+- Install the KubeDB Provisioner and Ops-manager operators following the steps [here](/docs/setup/README.md).
+- Create a namespace:
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Deploy a HanaDB with Builtin Monitoring
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-builtin-prometheus
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 1
+  storageType: Durable
+  storage:
+    storageClassName: local-path
+    accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        storage: 64Gi
+  deletionPolicy: WipeOut
+  monitor:
+    agent: prometheus.io/builtin
+    prometheus:
+      exporter:
+        port: 9668
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/monitoring/builtin-prometheus.yaml
+hanadb.kubedb.com/hanadb-builtin-prometheus created
+```
+
+Wait until the database is `Ready`.
+
+## Verify the Metrics Endpoint
+
+KubeDB adds an `exporter` container and a `<db>-stats` Service:
+
+```bash
+$ kubectl get pod -n demo hanadb-builtin-prometheus-0 -o jsonpath='{range .spec.containers[*]}{.name}{"\n"}{end}'
+hanadb
+exporter
+
+$ kubectl get svc -n demo -l app.kubernetes.io/instance=hanadb-builtin-prometheus
+NAME                              TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)               AGE
+hanadb-builtin-prometheus         ClusterIP   10.43.27.56     <none>        39017/TCP             17m
+hanadb-builtin-prometheus-pods    ClusterIP   None            <none>        39001/TCP,39017/TCP   17m
+hanadb-builtin-prometheus-stats   ClusterIP   10.43.169.153   <none>        9668/TCP              17m
+```
+
+The stats Service carries the `prometheus.io/scrape`, `prometheus.io/port`, and `prometheus.io/path`
+annotations a builtin Prometheus uses to discover the target:
+
+```bash
+$ kubectl get svc -n demo hanadb-builtin-prometheus-stats -o jsonpath='{.metadata.annotations}' | jq
+{
+  "monitoring.appscode.com/agent": "prometheus.io/builtin",
+  "prometheus.io/path": "/metrics",
+  "prometheus.io/port": "9668",
+  "prometheus.io/scheme": "http",
+  "prometheus.io/scrape": "true"
+}
+```
+
+Scrape the metrics to confirm the exporter is serving (the `exporter` container is distroless, so curl
+the stats Service from a throwaway pod):
+
+```bash
+$ kubectl run hdb-metrics-check -n demo --rm -i --restart=Never --image=curlimages/curl:8.10.1 -- \
+  curl -s http://hanadb-builtin-prometheus-stats.demo.svc:9668/metrics | grep -E '^hanadb_' | head
+hanadb_column_tables_used_memory_mb{database_name="SYSTEMDB",host="hanadb-builtin-prometheus-0",insnr="90",sid="HXE"} 6.0
+hanadb_schema_used_memory_mb{database_name="SYSTEMDB",host="hanadb-builtin-prometheus-0",insnr="90",schema_name="_SYS_REPO",sid="HXE"} 1.0
+hanadb_schema_used_memory_mb{database_name="SYSTEMDB",host="hanadb-builtin-prometheus-0",insnr="90",schema_name="_SYS_DI",sid="HXE"} 1.0
+```
+
+## Cleaning Up
+
+```bash
+$ kubectl delete hanadb.kubedb.com -n demo hanadb-builtin-prometheus
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- [Monitor with the Prometheus Operator](/docs/guides/hanadb/monitoring/using-prometheus-operator.md).

--- a/docs/guides/hanadb/monitoring/using-prometheus-operator.md
+++ b/docs/guides/hanadb/monitoring/using-prometheus-operator.md
@@ -1,0 +1,104 @@
+---
+title: HanaDB Prometheus Operator
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-monitoring-operator
+    name: Prometheus Operator
+    parent: guides-hanadb-monitoring
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Monitoring HanaDB with Prometheus Operator
+
+This guide deploys a HanaDB with the `prometheus.io/operator` agent so the
+[Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) discovers it through a
+`ServiceMonitor`.
+
+> Note: The YAML files used in this tutorial are stored in [docs/examples/hanadb/monitoring](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/hanadb/monitoring) folder in the GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Before You Begin
+
+- Install the KubeDB Provisioner and Ops-manager operators following the steps [here](/docs/setup/README.md).
+- Install the [Prometheus Operator](https://github.com/prometheus-operator/kube-prometheus-stack) and
+  note the label its `Prometheus` uses to select `ServiceMonitor`s (often `release: prometheus`):
+
+```bash
+$ kubectl get prometheus -n monitoring -o jsonpath='{.items[0].spec.serviceMonitorSelector}'; echo
+{}
+```
+
+> An empty `serviceMonitorSelector` (`{}`) means this Prometheus selects **all** `ServiceMonitor`s in the
+> namespaces it watches. If your Prometheus uses a non-empty selector, set
+> `spec.monitor.prometheus.serviceMonitor.labels` to match it (the `release: prometheus` label below is a
+> common convention for the kube-prometheus-stack chart).
+
+## Deploy a HanaDB with Prometheus Operator Monitoring
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-prometheus-operator
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 1
+  storageType: Durable
+  storage:
+    storageClassName: local-path
+    accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        storage: 64Gi
+  deletionPolicy: WipeOut
+  monitor:
+    agent: prometheus.io/operator
+    prometheus:
+      exporter:
+        port: 9668
+      serviceMonitor:
+        labels:
+          release: prometheus
+        interval: 10s
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/monitoring/prometheus-operator.yaml
+hanadb.kubedb.com/hanadb-prometheus-operator created
+```
+
+Wait until the database is `Ready`.
+
+## Verify the ServiceMonitor
+
+KubeDB creates a `ServiceMonitor` carrying the `release: prometheus` label so the operator's Prometheus
+selects it:
+
+```bash
+$ kubectl get servicemonitor -n demo -l app.kubernetes.io/instance=hanadb-prometheus-operator
+NAME                               AGE
+hanadb-prometheus-operator-stats   17m
+
+$ kubectl get servicemonitor -n demo hanadb-prometheus-operator-stats \
+  -o jsonpath='port={.spec.endpoints[0].port} interval={.spec.endpoints[0].interval}{"\n"}selector={.spec.selector.matchLabels}{"\n"}'
+port=metrics interval=10s
+selector={"app.kubernetes.io/instance":"hanadb-prometheus-operator","app.kubernetes.io/managed-by":"kubedb.com","app.kubernetes.io/name":"hanadbs.kubedb.com","kubedb.com/role":"stats"}
+```
+
+Once Prometheus reloads, the HanaDB target appears in its **Status → Targets** page.
+
+## Cleaning Up
+
+```bash
+$ kubectl delete hanadb.kubedb.com -n demo hanadb-prometheus-operator
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- [Monitor with builtin Prometheus](/docs/guides/hanadb/monitoring/using-builtin-prometheus.md).
+- Review the [HanaDB CRD](/docs/guides/hanadb/concepts/hanadb.md).

--- a/docs/guides/hanadb/quickstart/_index.md
+++ b/docs/guides/hanadb/quickstart/_index.md
@@ -1,0 +1,10 @@
+---
+title: Quickstart
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-quickstart
+    name: Quickstart
+    parent: guides-hanadb
+    weight: 15
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/quickstart/quickstart.md
+++ b/docs/guides/hanadb/quickstart/quickstart.md
@@ -1,0 +1,269 @@
+---
+title: HanaDB Quickstart
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-quickstart-guide
+    name: Quickstart
+    parent: guides-hanadb-quickstart
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# HanaDB QuickStart
+
+This tutorial shows you how to run a standalone [SAP HANA](https://www.sap.com/products/technology-platform/hana.html)
+database using KubeDB.
+
+> Note: The YAML files used in this tutorial are stored in [docs/examples/hanadb/quickstart](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/hanadb/quickstart) folder in the GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Before You Begin
+
+- You need a Kubernetes cluster and the `kubectl` command-line tool configured to communicate with it.
+- Install the KubeDB **Provisioner** and **Ops-manager** operators in your cluster following the steps
+  [here](/docs/setup/README.md), with the HanaDB feature and catalog enabled.
+- SAP HANA is resource and disk heavy. A standalone instance can take **20–30 minutes** to become
+  `Ready`. Make sure your cluster has enough CPU, memory, and storage.
+
+To keep things isolated, this tutorial uses a separate namespace called `demo`:
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Check Available StorageClass
+
+```bash
+$ kubectl get storageclass
+NAME                   PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+local-path (default)   rancher.io/local-path   Delete          WaitForFirstConsumer   false                  19d
+```
+
+## Find Available HanaDBVersion
+
+KubeDB maintains a `HanaDBVersion` CRD with all supported SAP HANA versions and their images:
+
+```bash
+$ kubectl get hanadbversions
+NAME     VERSION   DB_IMAGE                                               DEPRECATED   AGE
+2.0.76   2.0.76    docker.io/saplabs/hanaexpress:2.00.076.00.20240701.1                31h
+2.0.82   2.0.82    docker.io/saplabs/hanaexpress:2.00.082.00.20250528.1                6d13h
+2.0.88   2.0.88    docker.io/saplabs/hanaexpress:2.00.088.00.20251110.1                31h
+```
+
+## Create a HanaDB Database
+
+KubeDB implements a `HanaDB` CRD to define the specification of a HANA database. Below is a minimal
+standalone `HanaDB` object:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-quickstart
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 1
+  storageType: Durable
+  storage:
+    storageClassName: local-path
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 64Gi
+  deletionPolicy: Delete
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/quickstart/standalone.yaml
+hanadb.kubedb.com/hanadb-quickstart created
+```
+
+Here,
+
+- `spec.version` is the name of the `HanaDBVersion` CRD, which specifies the container images.
+- `spec.replicas` is the number of database pods. For a standalone database this is `1`.
+- `spec.storageType` is `Durable` (uses a PVC) or `Ephemeral` (uses an `emptyDir`).
+- `spec.storage` defines the PVC for the HANA data volume.
+- `spec.deletionPolicy` controls what happens to data when the `HanaDB` object is deleted.
+
+When a `HanaDB` object is created, the KubeDB operator creates a `PetSet`, a primary `Service`, a
+governing (headless) `Service`, an authentication `Secret`, and an `AppBinding` with the matching name.
+
+> Because `hanadb` is also a short name registered by the KubeDB GitOps API, prefer the fully qualified
+> resource `hanadb.kubedb.com` (or short name `hdb`) in `kubectl` commands.
+
+## Wait for the Database to be Ready
+
+```bash
+$ kubectl get hanadb.kubedb.com -n demo hanadb-quickstart -w
+NAME                VERSION   STATUS         AGE
+hanadb-quickstart   2.0.82    Provisioning   2m
+hanadb-quickstart   2.0.82    Provisioning   18m
+hanadb-quickstart   2.0.82    Ready          19m
+```
+
+When `status.phase` becomes `Ready`, the database is ready for traffic. Let's look at the details with
+`kubectl describe`:
+
+```bash
+$ kubectl describe hanadb.kubedb.com -n demo hanadb-quickstart
+Name:         hanadb-quickstart
+Namespace:    demo
+API Version:  kubedb.com/v1alpha2
+Kind:         HanaDB
+Metadata:
+  Finalizers:
+    kubedb.com
+Spec:
+  Auth Secret:
+    Name:           hanadb-quickstart-auth
+  Deletion Policy:  Delete
+  Health Checker:
+    Failure Threshold:  3
+    Period Seconds:     20
+    Timeout Seconds:    10
+  Pod Template:
+    Spec:
+      Containers:
+        Name:  hanadb
+        Resources:
+          Limits:
+            Cpu:     4
+            Memory:  10Gi
+          Requests:
+            Cpu:     2
+            Memory:  8Gi
+        Security Context:
+          Run As Group:     79
+          Run As Non Root:  true
+          Run As User:      12000
+      Security Context:
+        Fs Group:  12000
+  Replicas:        1
+  Storage:
+    Access Modes:
+      ReadWriteOnce
+    Resources:
+      Requests:
+        Storage:         64Gi
+    Storage Class Name:  local-path
+  Storage Type:          Durable
+  Version:               2.0.82
+Status:
+  Conditions:
+    Reason:  DatabaseProvisioningStartedSuccessfully
+    Status:  True
+    Type:    ProvisioningStarted
+    Reason:  AllReplicasReady
+    Status:  True
+    Type:    ReplicaReady
+    Reason:  AcceptingConnection
+    Status:  True
+    Type:    AcceptingConnection
+    Reason:  AllReplicasReady
+    Status:  True
+    Type:    Ready
+    Reason:  DatabaseSuccessfullyProvisioned
+    Status:  True
+    Type:    Provisioned
+  Phase:     Ready
+```
+
+Note that KubeDB filled in sensible defaults — for example the default resources on the `hanadb`
+container and the `12000:79` security context derived from the `HanaDBVersion`.
+
+## Check Resources Created by KubeDB
+
+```bash
+$ kubectl get hanadb.kubedb.com,pods,pvc,svc -n demo -l app.kubernetes.io/instance=hanadb-quickstart
+NAME                              VERSION   STATUS   AGE
+hanadb.kubedb.com/hanadb-quickstart   2.0.82    Ready    19m
+
+NAME                      READY   STATUS    RESTARTS   AGE
+pod/hanadb-quickstart-0   1/1     Running   0          6m30s
+
+NAME                                             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+persistentvolumeclaim/data-hanadb-quickstart-0   Bound    pvc-83118378-1265-4843-b653-a89568615269   64Gi       RWO            local-path     6m31s
+
+NAME                             TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)               AGE
+service/hanadb-quickstart        ClusterIP   10.43.188.77   <none>        39017/TCP             6m33s
+service/hanadb-quickstart-pods   ClusterIP   None           <none>        39001/TCP,39017/TCP   6m33s
+```
+
+- `hanadb-quickstart` (port `39017`) is the primary SQL `Service`.
+- `hanadb-quickstart-pods` is the governing headless `Service` (nameserver port `39001`, SQL port `39017`).
+
+## Connect to the HanaDB Database
+
+KubeDB stores the `SYSTEM` user credentials in the `hanadb-quickstart-auth` Secret:
+
+```bash
+$ kubectl get secret -n demo hanadb-quickstart-auth -o jsonpath='{.type}'
+kubernetes.io/basic-auth
+
+$ kubectl get secret -n demo hanadb-quickstart-auth -o go-template='{{range $k,$v := .data}}{{$k}}{{"\n"}}{{end}}'
+password
+password.json
+username
+```
+
+Read the password into a shell variable (avoid pasting real passwords into shared terminals):
+
+```bash
+$ HANA_PASSWORD="$(kubectl get secret hanadb-quickstart-auth -n demo -o jsonpath='{.data.password}' | base64 -d)"
+```
+
+Run a query with `hdbsql` from inside the database pod. Source the HANA environment first:
+
+```bash
+$ kubectl exec -n demo hanadb-quickstart-0 -c hanadb -- /bin/sh -lc \
+  "source /usr/sap/HXE/HDB90/HDBSettings.sh; hdbsql -i 90 -d SYSTEMDB -u SYSTEM -p '$HANA_PASSWORD' 'SELECT 1 AS HELLO FROM DUMMY'"
+HELLO
+1
+1 row selected (overall time 3143 usec; server time 158 usec)
+```
+
+List the databases inside the HANA instance:
+
+```bash
+$ kubectl exec -n demo hanadb-quickstart-0 -c hanadb -- /bin/sh -lc \
+  "source /usr/sap/HXE/HDB90/HDBSettings.sh; hdbsql -i 90 -d SYSTEMDB -u SYSTEM -p '$HANA_PASSWORD' \"SELECT DATABASE_NAME, ACTIVE_STATUS FROM SYS.M_DATABASES\""
+DATABASE_NAME,ACTIVE_STATUS
+"SYSTEMDB","YES"
+"HXE","YES"
+"KUBEDB_HEALTH_CHECK","YES"
+3 rows selected
+```
+
+Here, `SYSTEMDB` is the HANA system database, `HXE` is the tenant database, and `KUBEDB_HEALTH_CHECK`
+is the tenant database KubeDB uses for its periodic write probe.
+
+## Cleaning Up
+
+To clean up the Kubernetes resources created by this tutorial, run:
+
+```bash
+$ kubectl patch -n demo hanadb.kubedb.com/hanadb-quickstart -p '{"spec":{"deletionPolicy":"WipeOut"}}' --type="merge"
+$ kubectl delete hanadb.kubedb.com -n demo hanadb-quickstart
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- Deploy a [System Replication cluster](/docs/guides/hanadb/clustering/system-replication.md).
+- Apply [custom configuration](/docs/guides/hanadb/configuration/using-config-file.md).
+- Set up [monitoring](/docs/guides/hanadb/monitoring/using-builtin-prometheus.md) and [TLS](/docs/guides/hanadb/tls/overview.md).
+- Detailed concepts of the [HanaDB object](/docs/guides/hanadb/concepts/hanadb.md).
+
+> ## ⚠️ Legal Notice
+>
+> SAP® and SAP HANA® are registered trademarks of SAP SE. KubeDB is not affiliated with, endorsed by,
+> or sponsored by SAP SE. KubeDB provides only orchestration and management tooling and does not
+> distribute any SAP HANA software or binaries. Users must provide their own SAP HANA container images
+> and hold valid SAP licenses.

--- a/docs/guides/hanadb/reconfigure/_index.md
+++ b/docs/guides/hanadb/reconfigure/_index.md
@@ -1,0 +1,10 @@
+---
+title: Reconfigure
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-reconfigure
+    name: Reconfigure
+    parent: guides-hanadb
+    weight: 55
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/reconfigure/reconfigure.md
+++ b/docs/guides/hanadb/reconfigure/reconfigure.md
@@ -1,0 +1,189 @@
+---
+title: Reconfigure HanaDB
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-reconfigure-reconfigure
+    name: Reconfigure
+    parent: guides-hanadb-reconfigure
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Reconfigure HanaDB
+
+This guide shows how to change the custom `global.ini` configuration of a running HanaDB using a
+`HanaDBOpsRequest` of type `Reconfigure`.
+
+> Note: The YAML files used in this tutorial are stored in [docs/examples/hanadb/reconfigure](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/hanadb/reconfigure) folder in the GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Before You Begin
+
+- Install the KubeDB Provisioner and Ops-manager operators following the steps [here](/docs/setup/README.md).
+- Create a namespace:
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Deploy a HanaDB
+
+Deploy a standalone HanaDB to reconfigure:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-standalone
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 1
+  storageType: Durable
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: local-path
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/reconfigure/standalone-ops.yaml
+hanadb.kubedb.com/hanadb-standalone created
+```
+
+Wait until `hanadb-standalone` is `Ready`.
+
+## Check Current Configuration
+
+Read the current value of `[memorymanager] global_allocation_limit`:
+
+```bash
+$ HANA_PASSWORD="$(kubectl get secret hanadb-standalone-auth -n demo -o jsonpath='{.data.password}' | base64 -d)"
+
+$ kubectl exec -n demo hanadb-standalone-0 -c hanadb -- /bin/sh -lc \
+  "source /usr/sap/HXE/HDB90/HDBSettings.sh; hdbsql -i 90 -d SYSTEMDB -u SYSTEM -p '$HANA_PASSWORD' \
+  \"SELECT LAYER_NAME, VALUE FROM M_INIFILE_CONTENTS WHERE FILE_NAME='global.ini' AND SECTION='memorymanager' AND KEY='global_allocation_limit'\""
+LAYER_NAME,VALUE
+"DEFAULT","0"
+1 row selected
+```
+
+The database starts with no custom override (only the `DEFAULT` layer, value `0` = HANA decides).
+
+## Create a Reconfigure HanaDBOpsRequest
+
+Change `global_allocation_limit` to 9 GiB (`9663676416` bytes) and force a restart so the value takes
+effect:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-reconfigure
+  namespace: demo
+spec:
+  type: Reconfigure
+  databaseRef:
+    name: hanadb-standalone
+  configuration:
+    applyConfig:
+      global.ini: |
+        [memorymanager]
+        global_allocation_limit = 9663676416
+    restart: "true"
+  timeout: 30m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/reconfigure/reconfigure.yaml
+hanadbopsrequest.ops.kubedb.com/hdbops-reconfigure created
+```
+
+Here,
+
+- `spec.configuration.applyConfig` carries the `global.ini` fragment. The fragment is **merged** with the
+  database's existing inline configuration (only the keys you list are changed).
+- `spec.configuration.restart: "true"` forces a pod restart so the new `global.ini` is applied. Use
+  `"auto"` (the default) to let KubeDB decide, or `"false"` to skip the restart.
+
+## Verify the Reconfiguration
+
+Wait for the ops request to reach `Successful`:
+
+```bash
+$ kubectl get hdbops -n demo hdbops-reconfigure
+NAME                 TYPE          STATUS       AGE
+hdbops-reconfigure   Reconfigure   Successful   111s
+```
+
+```bash
+$ kubectl describe hdbops -n demo hdbops-reconfigure
+...
+Status:
+  Conditions:
+    Reason:  Reconfigure
+    Status:  True
+    Type:    Reconfigure
+    Reason:  DatabasePauseSucceeded
+    Status:  True
+    Type:    DatabasePauseSucceeded
+    Reason:  UpdatePetSets
+    Status:  True
+    Type:    UpdatePetSets
+    Reason:  RestartPods
+    Status:  True
+    Type:    RestartPods
+    Reason:  Successful
+    Status:  True
+    Type:    Successful
+  Phase:     Successful
+```
+
+Confirm the new value is live (it shows up under the `SYSTEM` layer once the pod has restarted with the
+updated configuration):
+
+```bash
+$ kubectl exec -n demo hanadb-standalone-0 -c hanadb -- /bin/sh -lc \
+  "source /usr/sap/HXE/HDB90/HDBSettings.sh; hdbsql -i 90 -d SYSTEMDB -u SYSTEM -p '$HANA_PASSWORD' \
+  \"SELECT LAYER_NAME, VALUE FROM M_INIFILE_CONTENTS WHERE FILE_NAME='global.ini' AND SECTION='memorymanager' AND KEY='global_allocation_limit'\""
+LAYER_NAME,VALUE
+"DEFAULT","0"
+"SYSTEM","9663676416"
+2 rows selected
+```
+
+The `SYSTEM` layer now carries the new value `9663676416` (9 GiB).
+
+To **remove** all custom configuration, set `spec.configuration.removeCustomConfig: true` in the
+`HanaDBOpsRequest` instead of `applyConfig`.
+
+## Cleaning Up
+
+```bash
+$ kubectl delete hdbops -n demo hdbops-reconfigure
+$ kubectl delete hanadb.kubedb.com -n demo hanadb-standalone
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- Set initial configuration at creation time with [Custom Configuration](/docs/guides/hanadb/configuration/using-config-file.md).
+- [Vertically scale](/docs/guides/hanadb/scaling/vertical-scaling/vertical-scaling.md) a HanaDB.

--- a/docs/guides/hanadb/restart/_index.md
+++ b/docs/guides/hanadb/restart/_index.md
@@ -1,0 +1,10 @@
+---
+title: Restart
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-restart
+    name: Restart
+    parent: guides-hanadb
+    weight: 50
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/restart/restart.md
+++ b/docs/guides/hanadb/restart/restart.md
@@ -1,0 +1,168 @@
+---
+title: Restart HanaDB
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-restart-restart
+    name: Restart
+    parent: guides-hanadb-restart
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Restart HanaDB
+
+This guide shows how to restart a HanaDB database using a `HanaDBOpsRequest` of type `Restart`. KubeDB
+performs a **rolling restart**, one pod at a time. For a System Replication cluster the **primary is
+restarted last** to minimize avoidable failovers.
+
+> Note: The YAML files used in this tutorial are stored in [docs/examples/hanadb/restart](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/hanadb/restart) folder in the GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Before You Begin
+
+- Install the KubeDB Provisioner and Ops-manager operators following the steps [here](/docs/setup/README.md).
+- Create a namespace:
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## Deploy a HanaDB System Replication Cluster
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-cluster
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 2
+  storageType: Durable
+  topology:
+    mode: SystemReplication
+    systemReplication:
+      replicationMode: fullsync
+      operationMode: logreplay_readaccess
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: local-path
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/restart/system-replication-ops.yaml
+hanadb.kubedb.com/hanadb-cluster created
+```
+
+Wait until `hanadb-cluster` is `Ready`. Note the current pod ages and which pod is primary:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=hanadb-cluster -L kubedb.com/role
+NAME                       READY   STATUS    RESTARTS   AGE    ROLE
+hanadb-cluster-0           2/2     Running   0          14m    primary
+hanadb-cluster-1           2/2     Running   0          14m    secondary
+hanadb-cluster-arbiter-0   1/1     Running   0          8m     arbiter
+```
+
+## Create a Restart HanaDBOpsRequest
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-restart
+  namespace: demo
+spec:
+  type: Restart
+  databaseRef:
+    name: hanadb-cluster
+  timeout: 30m
+  apply: Always
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/restart/restart.yaml
+hanadbopsrequest.ops.kubedb.com/hdbops-restart created
+```
+
+Here `spec.apply: Always` lets the restart proceed even if the database is not `Ready`, which is useful
+for recovering an unhealthy database.
+
+## Verify the Restart
+
+```bash
+$ kubectl get hdbops -n demo hdbops-restart
+NAME             TYPE      STATUS       AGE
+hdbops-restart   Restart   Successful   7m32s
+```
+
+```bash
+$ kubectl describe hdbops -n demo hdbops-restart
+...
+Status:
+  Conditions:
+    Message:  HanaDBOpsRequest has started to restart HanaDB nodes
+    Reason:   Restart
+    Status:   True
+    Type:     Restart
+    Message:  Successfully paused database
+    Reason:   DatabasePauseSucceeded
+    Status:   True
+    Type:     DatabasePauseSucceeded
+    Message:  Successfully restarted HanaDB nodes
+    Reason:   RestartNodes
+    Status:   True
+    Type:     RestartNodes
+    Message:  Successfully completed restart for HanaDB.
+    Reason:   Successful
+    Status:   True
+    Type:     Successful
+  Phase:      Successful
+```
+
+The operator evicts the secondary (`hanadb-cluster-1`) first and the primary (`hanadb-cluster-0`) last.
+The pods now show a fresh age and the database is back to `Ready`. Note that restarting the old primary
+triggers a normal HANA SystemReplication takeover, so the `primary`/`secondary` roles may swap:
+
+```bash
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=hanadb-cluster -L kubedb.com/role
+NAME                       READY   STATUS    RESTARTS   AGE     ROLE
+hanadb-cluster-0           2/2     Running   0          4m30s   secondary
+hanadb-cluster-1           2/2     Running   0          7m16s   primary
+hanadb-cluster-arbiter-0   1/1     Running   0          15m     arbiter
+
+$ kubectl get hanadb.kubedb.com -n demo hanadb-cluster
+NAME             VERSION   STATUS   AGE
+hanadb-cluster   2.0.82    Ready    22m
+```
+
+## Cleaning Up
+
+```bash
+$ kubectl delete hdbops -n demo hdbops-restart
+$ kubectl delete hanadb.kubedb.com -n demo hanadb-cluster
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- [Vertically scale](/docs/guides/hanadb/scaling/vertical-scaling/vertical-scaling.md) a HanaDB.
+- Review the [HanaDBOpsRequest CRD](/docs/guides/hanadb/concepts/opsrequest.md).

--- a/docs/guides/hanadb/rotate-authentication/_index.md
+++ b/docs/guides/hanadb/rotate-authentication/_index.md
@@ -1,0 +1,10 @@
+---
+title: Rotate Authentication
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-rotate-authentication
+    name: Rotate Authentication
+    parent: guides-hanadb
+    weight: 75
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/rotate-authentication/rotate-authentication.md
+++ b/docs/guides/hanadb/rotate-authentication/rotate-authentication.md
@@ -1,0 +1,200 @@
+---
+title: Rotate Authentication HanaDB
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-rotate-authentication-guide
+    name: Rotate Authentication
+    parent: guides-hanadb-rotate-authentication
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Rotate Authentication of HanaDB
+
+This guide shows how to rotate the `SYSTEM` password of a HanaDB using a `HanaDBOpsRequest` of type
+`RotateAuth`. You can let KubeDB generate a new password, or supply your own through a `Secret`.
+
+> Note: The YAML files used in this tutorial are stored in [docs/examples/hanadb/rotate-authentication](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/hanadb/rotate-authentication) folder in the GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Before You Begin
+
+- Install the KubeDB Provisioner and Ops-manager operators following the steps [here](/docs/setup/README.md).
+- Create a namespace `demo` and deploy a standalone `hanadb-standalone` (see
+  [Reconfigure](/docs/guides/hanadb/reconfigure/reconfigure.md#deploy-a-hanadb)).
+
+## Password requirements
+
+The HANA username always remains `SYSTEM`. A user-provided password must be HANA-compatible:
+
+- ASCII letters and digits only,
+- at least 8 characters,
+- starts with a letter, and
+- contains an uppercase letter, a lowercase letter, and a digit.
+
+KubeDB-generated passwords already satisfy these rules.
+
+## Check the Current Credentials
+
+```bash
+$ kubectl get secret hanadb-standalone-auth -n demo -o go-template='{{range $k,$v := .data}}{{$k}}{{"\n"}}{{end}}'
+password
+password.json
+username
+
+$ kubectl get secret hanadb-standalone-auth -n demo -o jsonpath='{.data.username}' | base64 -d; echo
+SYSTEM
+```
+
+## Option A — Rotate with a KubeDB-generated password
+
+Apply a `RotateAuth` ops request with no `authentication` block:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-rotate-auth-generated
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: hanadb-standalone
+  timeout: 30m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/rotate-authentication/rotate-auth-generated.yaml
+hanadbopsrequest.ops.kubedb.com/hdbops-rotate-auth-generated created
+```
+
+Wait for the ops request to succeed:
+
+```bash
+$ kubectl get hdbops -n demo hdbops-rotate-auth-generated
+NAME                           TYPE         STATUS       AGE
+hdbops-rotate-auth-generated   RotateAuth   Successful   4m22s
+```
+
+```bash
+$ kubectl describe hdbops -n demo hdbops-rotate-auth-generated
+...
+Status:
+  Conditions:
+    Message:  HanaDBOpsRequest has started to rotate auth for HanaDB nodes
+    Reason:   RotateAuth
+    Status:   True
+    Type:     RotateAuth
+    Message:  Successfully generated new credentials
+    Reason:   UpdateCredential
+    Status:   True
+    Type:     UpdateCredential
+    Message:  Successfully reconciled HanaDB with new auth credentials
+    Reason:   UpdatePetSets
+    Status:   True
+    Type:     UpdatePetSets
+    Message:  Successfully restarted HanaDB nodes
+    Reason:   RestartNodes
+    Status:   True
+    Type:     RestartNodes
+    Message:  Successfully completed RotateAuth for HanaDB.
+    Reason:   Successful
+    Status:   True
+    Type:     Successful
+  Phase:      Successful
+```
+
+KubeDB updates the `hanadb-standalone-auth` secret with the new password (keeping the previous one under
+`.prev` keys) and verifies connectivity with the new credentials:
+
+```bash
+$ kubectl get secret hanadb-standalone-auth -n demo -o go-template='{{range $k,$v := .data}}{{$k}}{{"\n"}}{{end}}'
+password
+password.json
+password.prev
+username
+username.prev
+
+$ NEW_PASSWORD="$(kubectl get secret hanadb-standalone-auth -n demo -o jsonpath='{.data.password}' | base64 -d)"
+$ kubectl exec -n demo hanadb-standalone-0 -c hanadb -- /bin/sh -lc \
+  "source /usr/sap/HXE/HDB90/HDBSettings.sh; hdbsql -i 90 -d SYSTEMDB -u SYSTEM -p '$NEW_PASSWORD' 'SELECT 1 AS OK FROM DUMMY'"
+OK
+1
+1 row selected
+```
+
+## Option B — Rotate with a user-provided password
+
+First create a `Secret` with the new credentials (username `SYSTEM`):
+
+```bash
+$ kubectl create secret generic hanadb-new-auth -n demo \
+  --from-literal=username=SYSTEM \
+  --from-literal=password='NewHanaPass1'
+secret/hanadb-new-auth created
+```
+
+Then reference it from the ops request:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-rotate-auth-user
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: hanadb-standalone
+  authentication:
+    secretRef:
+      kind: Secret
+      name: hanadb-new-auth
+  timeout: 30m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/rotate-authentication/rotate-auth-user.yaml
+hanadbopsrequest.ops.kubedb.com/hdbops-rotate-auth-user created
+```
+
+```bash
+$ kubectl get hdbops -n demo hdbops-rotate-auth-user
+NAME                      TYPE         STATUS       AGE
+hdbops-rotate-auth-user   RotateAuth   Successful   2m33s
+```
+
+After the request succeeds, KubeDB pins `spec.authSecret` to your secret (`externallyManaged: true`):
+
+```bash
+$ kubectl get hanadb.kubedb.com hanadb-standalone -n demo -o jsonpath='{.spec.authSecret}'
+{"activeFrom":"...","externallyManaged":true,"name":"hanadb-new-auth"}
+```
+
+You can now connect with the password you supplied:
+
+```bash
+$ kubectl exec -n demo hanadb-standalone-0 -c hanadb -- /bin/sh -lc \
+  "source /usr/sap/HXE/HDB90/HDBSettings.sh; hdbsql -i 90 -d SYSTEMDB -u SYSTEM -p 'NewHanaPass1' 'SELECT 1 AS OK FROM DUMMY'"
+OK
+1
+1 row selected
+```
+
+## Cleaning Up
+
+```bash
+$ kubectl delete hdbops -n demo hdbops-rotate-auth-generated hdbops-rotate-auth-user
+$ kubectl delete secret -n demo hanadb-new-auth
+$ kubectl delete hanadb.kubedb.com -n demo hanadb-standalone
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- Review the [HanaDB CRD](/docs/guides/hanadb/concepts/hanadb.md).
+- Encrypt connections with [TLS/SSL](/docs/guides/hanadb/tls/overview.md).

--- a/docs/guides/hanadb/scaling/_index.md
+++ b/docs/guides/hanadb/scaling/_index.md
@@ -1,0 +1,10 @@
+---
+title: Scaling
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-scaling
+    name: Scaling
+    parent: guides-hanadb
+    weight: 60
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/scaling/vertical-scaling/_index.md
+++ b/docs/guides/hanadb/scaling/vertical-scaling/_index.md
@@ -1,0 +1,10 @@
+---
+title: Vertical Scaling
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-scaling-vertical
+    name: Vertical Scaling
+    parent: guides-hanadb-scaling
+    weight: 20
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/hanadb/scaling/vertical-scaling/vertical-scaling.md
@@ -1,0 +1,143 @@
+---
+title: Vertical Scaling HanaDB
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-scaling-vertical-scaling
+    name: Vertical Scaling
+    parent: guides-hanadb-scaling-vertical
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Vertical Scale HanaDB
+
+This guide shows how to change the CPU and memory of a HanaDB database using a `HanaDBOpsRequest` of type
+`VerticalScaling`. KubeDB updates the PetSet resources and performs a rolling restart (primary last for a
+cluster).
+
+> Note: The YAML files used in this tutorial are stored in [docs/examples/hanadb/scaling](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/hanadb/scaling) folder in the GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Before You Begin
+
+- Install the KubeDB Provisioner and Ops-manager operators following the steps [here](/docs/setup/README.md).
+- Deploy a `hanadb-cluster` System Replication database (see [Restart](/docs/guides/hanadb/restart/restart.md#deploy-a-hanadb-system-replication-cluster)) in namespace `demo`.
+
+## Check Resources Before Scaling
+
+```bash
+$ kubectl get pod -n demo hanadb-cluster-0 -o json | jq '.spec.containers[] | select(.name=="hanadb") | .resources'
+{
+  "limits": {
+    "cpu": "4",
+    "memory": "14Gi"
+  },
+  "requests": {
+    "cpu": "1500m",
+    "memory": "8Gi"
+  }
+}
+```
+
+## Create a VerticalScaling HanaDBOpsRequest
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-vscale
+  namespace: demo
+spec:
+  type: VerticalScaling
+  databaseRef:
+    name: hanadb-cluster
+  verticalScaling:
+    hanadb:
+      resources:
+        requests:
+          cpu: "2100m"
+          memory: "8448Mi"
+        limits:
+          cpu: "4"
+          memory: "14Gi"
+  timeout: 30m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/scaling/system-replication-vertical-scaling.yaml
+hanadbopsrequest.ops.kubedb.com/hdbops-vscale created
+```
+
+Here,
+
+- `spec.verticalScaling.hanadb.resources` are the desired resources for the `hanadb` container. You can
+  also scale the `coordinator` and `exporter` containers via `spec.verticalScaling.coordinator` and
+  `spec.verticalScaling.exporter`.
+
+## Verify the Scaling
+
+```bash
+$ kubectl get hdbops -n demo hdbops-vscale
+NAME            TYPE              STATUS       AGE
+hdbops-vscale   VerticalScaling   Successful   4m22s
+```
+
+```bash
+$ kubectl describe hdbops -n demo hdbops-vscale
+...
+Status:
+  Conditions:
+    Message:  HanaDB ops-request has started to vertically scaling the HanaDB nodes
+    Reason:   VerticalScaling
+    Status:   True
+    Type:     VerticalScaling
+    Message:  Successfully updated PetSets Resources
+    Reason:   UpdatePetSets
+    Status:   True
+    Type:     UpdatePetSets
+    Message:  Successfully Restarted Pods With Resources
+    Reason:   RestartPods
+    Status:   True
+    Type:     RestartPods
+    Message:  Successfully completed the vertical scaling for HanaDB
+    Reason:   Successful
+    Status:   True
+    Type:     Successful
+  Phase:      Successful
+```
+
+Confirm the new resources are in effect on the PetSet and pods:
+
+```bash
+$ kubectl get petset -n demo hanadb-cluster \
+  -o jsonpath='{range .spec.template.spec.containers[?(@.name=="hanadb")]}{.name}{": "}{.resources}{"\n"}{end}'
+hanadb: {"limits":{"cpu":"4","memory":"14Gi"},"requests":{"cpu":"2100m","memory":"8448Mi"}}
+
+$ kubectl get pod -n demo hanadb-cluster-0 -o json | jq '.spec.containers[] | select(.name=="hanadb") | .resources'
+{
+  "limits": {
+    "cpu": "4",
+    "memory": "14Gi"
+  },
+  "requests": {
+    "cpu": "2100m",
+    "memory": "8448Mi"
+  }
+}
+```
+
+## Cleaning Up
+
+```bash
+$ kubectl delete hdbops -n demo hdbops-vscale
+$ kubectl delete hanadb.kubedb.com -n demo hanadb-cluster
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- [Expand the volume](/docs/guides/hanadb/volume-expansion/volume-expansion.md) of a HanaDB.
+- Review the [HanaDBOpsRequest CRD](/docs/guides/hanadb/concepts/opsrequest.md).

--- a/docs/guides/hanadb/storage-migration/_index.md
+++ b/docs/guides/hanadb/storage-migration/_index.md
@@ -1,0 +1,10 @@
+---
+title: Storage Migration
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-storage-migration
+    name: Storage Migration
+    parent: guides-hanadb
+    weight: 70
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/storage-migration/storage-migration.md
+++ b/docs/guides/hanadb/storage-migration/storage-migration.md
@@ -1,0 +1,153 @@
+---
+title: Storage Migration HanaDB
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-storage-migration-storage-migration
+    name: Storage Migration
+    parent: guides-hanadb-storage-migration
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Storage Migration of HanaDB
+
+This guide shows how to move a HanaDB's data volumes to a different `StorageClass` using a
+`HanaDBOpsRequest` of type `StorageMigration`. KubeDB provisions new PVCs on the target StorageClass,
+copies the data with a migrator Job, swaps the volumes in, and recreates each pod (primary last for a
+cluster).
+
+> Note: The YAML files used in this tutorial are stored in [docs/examples/hanadb/storage-migration](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/hanadb/storage-migration) folder in the GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Before You Begin
+
+- Install the KubeDB Provisioner and Ops-manager operators following the steps [here](/docs/setup/README.md).
+- You need a **source** and a **target** `StorageClass`. This guide migrates between two
+  [Longhorn](https://longhorn.io/) StorageClasses, `longhorn-single` and `longhorn-single-migrated`:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-single-migrated
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "30"
+  fsType: ext4
+  dataLocality: disabled
+  dataEngine: v1
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/storage-migration/longhorn-single.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/storage-migration/longhorn-single-migrated.yaml
+```
+
+## Deploy a HanaDB on the Source StorageClass
+
+The base manifest places the data on `longhorn-single` and adds an init container that fixes the volume
+permissions (HANA runs as `12000:79`):
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/storage-migration/storage-migration-base.yaml
+hanadb.kubedb.com/hanadb-cluster created
+```
+
+Wait until `hanadb-cluster` is `Ready`, then note the source StorageClass of the PVCs:
+
+```bash
+$ kubectl get pvc -n demo -l app.kubernetes.io/instance=hanadb-cluster \
+  -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,SIZE:.status.capacity.storage
+NAME                            SC                SIZE
+data-hanadb-cluster-0           longhorn-single   64Gi
+data-hanadb-cluster-1           longhorn-single   64Gi
+data-hanadb-cluster-arbiter-0   longhorn-single   2Gi
+```
+
+## Create a StorageMigration HanaDBOpsRequest
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-storage-migration
+  namespace: demo
+spec:
+  type: StorageMigration
+  databaseRef:
+    name: hanadb-cluster
+  migration:
+    storageClassName: longhorn-single-migrated
+  timeout: 30m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/storage-migration/storage-migration.yaml
+hanadbopsrequest.ops.kubedb.com/hdbops-storage-migration created
+```
+
+Here,
+
+- `spec.migration.storageClassName` is the **target** StorageClass.
+- `spec.timeout` is **required** for `StorageMigration`; migrations copy all data and can take a while.
+
+## Verify the Migration
+
+```bash
+$ kubectl get hdbops -n demo hdbops-storage-migration
+NAME                       TYPE               STATUS       AGE
+hdbops-storage-migration   StorageMigration   Successful   14m
+```
+
+```bash
+$ kubectl describe hdbops -n demo hdbops-storage-migration
+...
+Status:
+  Conditions:
+    Message:  Successfully migrated StorageClass for HanaDB
+    Reason:   StorageMigration
+    Status:   True
+    Type:     StorageMigration
+    Message:  Successfully Migrated HanaDB StorageClass
+    Reason:   Successful
+    Status:   True
+    Type:     Successful
+  Phase:      Successful
+```
+
+KubeDB migrates the data PVCs one node at a time (the primary last); the small arbiter volume is left on
+its original StorageClass. Confirm the data PVCs are now bound to the target StorageClass and the database
+is `Ready`:
+
+```bash
+$ kubectl get pvc -n demo -l app.kubernetes.io/instance=hanadb-cluster \
+  -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,SIZE:.status.capacity.storage
+NAME                            SC                         SIZE
+data-hanadb-cluster-0           longhorn-single-migrated   64Gi
+data-hanadb-cluster-1           longhorn-single-migrated   64Gi
+data-hanadb-cluster-arbiter-0   longhorn-single            2Gi
+
+$ kubectl get hanadb.kubedb.com -n demo hanadb-cluster
+NAME             VERSION   STATUS   AGE
+hanadb-cluster   2.0.82    Ready    26m
+```
+
+## Cleaning Up
+
+```bash
+$ kubectl delete hdbops -n demo hdbops-storage-migration
+$ kubectl delete hanadb.kubedb.com -n demo hanadb-cluster
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- [Expand the volume](/docs/guides/hanadb/volume-expansion/volume-expansion.md) of a HanaDB.
+- Review the [HanaDBOpsRequest CRD](/docs/guides/hanadb/concepts/opsrequest.md).

--- a/docs/guides/hanadb/tls/_index.md
+++ b/docs/guides/hanadb/tls/_index.md
@@ -1,0 +1,10 @@
+---
+title: TLS/SSL Encryption
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-tls
+    name: TLS/SSL Encryption
+    parent: guides-hanadb
+    weight: 45
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/tls/overview.md
+++ b/docs/guides/hanadb/tls/overview.md
@@ -1,0 +1,273 @@
+---
+title: HanaDB TLS/SSL Encryption
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-tls-overview
+    name: TLS Overview
+    parent: guides-hanadb-tls
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# HanaDB TLS/SSL Encryption
+
+KubeDB supports providing TLS/SSL encryption for HanaDB using [cert-manager](https://cert-manager.io/).
+This guide shows how to deploy a HanaDB with TLS enabled, and how to add, rotate, and remove TLS on a
+running database with a `HanaDBOpsRequest`.
+
+> Note: The YAML files used in this tutorial are stored in [docs/examples/hanadb/tls](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/hanadb/tls) folder in the GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Before You Begin
+
+- Install [cert-manager](https://cert-manager.io/docs/installation/) in your cluster (it provisions the
+  certificates).
+- Install the KubeDB Provisioner and Ops-manager operators following the steps [here](/docs/setup/README.md).
+- Create a namespace:
+
+```bash
+$ kubectl create ns demo
+namespace/demo created
+```
+
+## How TLS works in HanaDB
+
+When `spec.tls` is set on a `HanaDB`, KubeDB asks cert-manager to issue three certificates, identified by
+their **alias**:
+
+| Alias              | Secret name                  | Used for                                          |
+|--------------------|------------------------------|---------------------------------------------------|
+| `server`           | `<db>-server-cert`           | The HANA SQL server certificate (mounted into the pod at `/etc/hanadb-tls/server`). |
+| `client`           | `<db>-client-cert`           | Client authentication used by KubeDB.             |
+| `metrics-exporter` | `<db>-metrics-exporter-cert` | The Prometheus exporter's client connection.      |
+
+`spec.tls.issuerRef` is required and must reference a cert-manager `Issuer` or `ClusterIssuer`.
+
+## Create an Issuer
+
+These guides use a self-signed CA `Issuer`. First create a CA key pair and a `Secret`, then an `Issuer`
+that signs with it.
+
+```bash
+# generate a CA
+$ openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout ca.key -out ca.crt -subj "/CN=ca/O=kubedb"
+# store it as a Secret
+$ kubectl create secret tls hdb-ca --cert=ca.crt --key=ca.key -n demo
+```
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: hdb-ca-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: hdb-ca
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/tls/hdb-ca-issuer.yaml
+issuer.cert-manager.io/hdb-ca-issuer created
+```
+
+## Option A — Deploy a HanaDB with TLS enabled
+
+Set `spec.tls.issuerRef` directly on the `HanaDB`:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-cluster
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 2
+  storageType: Durable
+  topology:
+    mode: SystemReplication
+    systemReplication:
+      replicationMode: fullsync
+      operationMode: logreplay_readaccess
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: hdb-ca-issuer
+  storage:
+    accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: local-path
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/tls/system-replication-tls.yaml
+hanadb.kubedb.com/hanadb-cluster created
+```
+
+## Option B — Add TLS to a running HanaDB (ReconfigureTLS)
+
+If the database already exists without TLS, add TLS with a `HanaDBOpsRequest` of type `ReconfigureTLS`:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-add-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: hanadb-cluster
+  tls:
+    issuerRef:
+      apiGroup: cert-manager.io
+      kind: Issuer
+      name: hdb-ca-issuer
+  timeout: 30m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/tls/reconfigure-add-tls.yaml
+hanadbopsrequest.ops.kubedb.com/hdbops-add-tls created
+```
+
+> `ReconfigureTLS` performs a **rolling restart** of the HANA pods to load the new certificates. Request
+> success alone is not enough — verify the database returns to `Ready` and that TLS connections work.
+
+Wait for the ops request to succeed:
+
+```bash
+$ kubectl get hdbops -n demo hdbops-add-tls
+NAME             TYPE             STATUS       AGE
+hdbops-add-tls   ReconfigureTLS   Successful   7m
+```
+
+```bash
+$ kubectl describe hdbops -n demo hdbops-add-tls
+...
+Status:
+  Conditions:
+    Message:  HanaDBOpsRequest has started to reconfigure TLS
+    Reason:   ReconfigureTLS
+    Type:     ReconfigureTLS
+    Message:  Successfully reconciled HanaDB with TLS configuration
+    Reason:   UpdatePetSets
+    Type:     UpdatePetSets
+    Message:  Successfully restarted HanaDB nodes
+    Reason:   RestartNodes
+    Type:     RestartNodes
+    Message:  Successfully resumed database
+    Reason:   DatabaseResumeSucceeded
+    Type:     DatabaseResumeSucceeded
+    Message:  HanaDB is ready after reconfigureTLS
+    Reason:   DatabaseReady
+    Type:     DatabaseReady
+    Message:  Successfully completed reconfigureTLS for HanaDB.
+    Reason:   Successful
+    Type:     Successful
+  Phase:      Successful
+```
+
+## Verify TLS
+
+Confirm the certificates and secrets exist, and that the server cert is mounted:
+
+```bash
+$ kubectl get issuer,certificate -n demo
+NAME                                  READY   AGE
+issuer.cert-manager.io/hdb-ca-issuer   True    10m
+
+NAME                                                               READY   SECRET                                 AGE
+certificate.cert-manager.io/hanadb-cluster-client-cert             True    hanadb-cluster-client-cert             3m
+certificate.cert-manager.io/hanadb-cluster-metrics-exporter-cert   True    hanadb-cluster-metrics-exporter-cert   3m
+certificate.cert-manager.io/hanadb-cluster-server-cert             True    hanadb-cluster-server-cert             3m
+
+$ kubectl exec -n demo hanadb-cluster-1 -c hanadb -- /bin/sh -lc 'ls -l /etc/hanadb-tls/server'
+total 0
+lrwxrwxrwx 1 root root ... ca.crt -> ..data/ca.crt
+lrwxrwxrwx 1 root root ... tls.crt -> ..data/tls.crt
+lrwxrwxrwx 1 root root ... tls.key -> ..data/tls.key
+```
+
+Verify the TLS handshake against the SQL port (`39017`) using `openssl s_client`:
+
+```bash
+$ kubectl run hdb-tls-check -n demo --rm -i --restart=Never --image=alpine:3.20 -- \
+  sh -lc "apk add --no-cache openssl >/dev/null && echo | openssl s_client -connect hanadb-cluster.demo.svc:39017 -servername hanadb-cluster.demo.svc"
+...
+New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
+...
+```
+
+The handshake completes over TLS 1.3, confirming the SQL port now requires TLS. (SAP HANA serves the
+SQL endpoint from its own internal PKI keystore, so the certificate subject shown by `openssl` is HANA's
+`ClientPKI` rather than the cert-manager leaf; the cert-manager material is supplied to the pod at
+`/etc/hanadb-tls/server`.)
+
+## Rotate Certificates
+
+To force cert-manager to re-issue the certificates (for example before expiry), apply a `ReconfigureTLS`
+request with `tls.rotateCertificates: true`:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-rotate-tls
+  namespace: demo
+spec:
+  type: ReconfigureTLS
+  databaseRef:
+    name: hanadb-cluster
+  tls:
+    rotateCertificates: true
+  timeout: 30m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/tls/reconfigure-rotate-tls.yaml
+hanadbopsrequest.ops.kubedb.com/hdbops-rotate-tls created
+```
+
+KubeDB re-issues all three certificates from the same issuer and performs a rolling restart so the pods
+pick up the new material. Track the request and confirm the database returns to `Ready`:
+
+```bash
+$ kubectl get hdbops -n demo hdbops-rotate-tls
+$ kubectl get hanadb.kubedb.com -n demo hanadb-cluster
+```
+
+> After a certificate rotation on a System Replication cluster, verify that a `primary` role is
+> re-elected (`kubectl get pods -n demo -l app.kubernetes.io/instance=hanadb-cluster -L kubedb.com/role`)
+> and that the raft coordinator can connect to HANA over the new certificate. If the coordinator logs
+> show `x509: certificate signed by unknown authority`, the rotated CA is not yet trusted by the
+> sidecar — inspect `kubectl logs <pod> -c hanadb-coordinator` before retrying.
+
+## Remove TLS
+
+To disable TLS, apply a `ReconfigureTLS` request with `tls.remove: true`. For a System Replication
+cluster, KubeDB keeps HANA's `sslclientpki` disabled after removal (per SAP guidance); for a standalone
+database it restores HANA's built-in ClientPKI. Either way the pods are restarted.
+
+## Cleaning Up
+
+```bash
+$ kubectl delete hdbops -n demo hdbops-add-tls hdbops-rotate-tls
+$ kubectl delete hanadb.kubedb.com -n demo hanadb-cluster
+$ kubectl delete issuer -n demo hdb-ca-issuer
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- Set up [monitoring](/docs/guides/hanadb/monitoring/using-builtin-prometheus.md).
+- Review the [HanaDBOpsRequest CRD](/docs/guides/hanadb/concepts/opsrequest.md).

--- a/docs/guides/hanadb/volume-expansion/_index.md
+++ b/docs/guides/hanadb/volume-expansion/_index.md
@@ -1,0 +1,10 @@
+---
+title: Volume Expansion
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-volume-expansion
+    name: Volume Expansion
+    parent: guides-hanadb
+    weight: 65
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/hanadb/volume-expansion/volume-expansion.md
+++ b/docs/guides/hanadb/volume-expansion/volume-expansion.md
@@ -1,0 +1,179 @@
+---
+title: Volume Expansion HanaDB
+menu:
+  docs_{{ .version }}:
+    identifier: guides-hanadb-volume-expansion-volume-expansion
+    name: Volume Expansion
+    parent: guides-hanadb-volume-expansion
+    weight: 15
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Volume Expansion of HanaDB
+
+This guide shows how to grow the data volumes of a HanaDB using a `HanaDBOpsRequest` of type
+`VolumeExpansion`.
+
+> Note: The YAML files used in this tutorial are stored in [docs/examples/hanadb/volume-expansion](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/hanadb/volume-expansion) folder in the GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+
+## Before You Begin
+
+- Install the KubeDB Provisioner and Ops-manager operators following the steps [here](/docs/setup/README.md).
+- **Volume expansion requires a `StorageClass` that supports expansion** (`allowVolumeExpansion: true`).
+  Verify this before you start:
+
+```bash
+$ kubectl get storageclass
+NAME                       PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+local-path (default)       rancher.io/local-path   Delete          WaitForFirstConsumer   false                  19d
+longhorn-single            driver.longhorn.io      Delete          Immediate              true                   1h
+```
+
+> The `local-path` provisioner used in the other guides does **not** support volume expansion
+> (`ALLOWVOLUMEEXPANSION` is `false`). For this guide, deploy the database on an expansion-capable
+> StorageClass such as [Longhorn](https://longhorn.io/) (`longhorn-single` above).
+
+## Deploy a HanaDB on an Expandable StorageClass
+
+This guide uses a System Replication cluster on `longhorn-single`; the same `VolumeExpansion`
+`HanaDBOpsRequest` works for a standalone database as well.
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: HanaDB
+metadata:
+  name: hanadb-cluster
+  namespace: demo
+spec:
+  version: "2.0.82"
+  replicas: 2
+  storageType: Durable
+  topology:
+    mode: SystemReplication
+    systemReplication:
+      replicationMode: fullsync
+      operationMode: logreplay_readaccess
+  podTemplate:
+    spec:
+      containers:
+      - name: hanadb
+        resources:
+          requests:
+            cpu: "1500m"
+            memory: "8Gi"
+          limits:
+            cpu: "4"
+            memory: "14Gi"
+  storage:
+    accessModes: ["ReadWriteOnce"]
+    resources:
+      requests:
+        storage: 64Gi
+    storageClassName: longhorn-single
+  deletionPolicy: WipeOut
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/volume-expansion/system-replication-ops.yaml
+hanadb.kubedb.com/hanadb-cluster created
+```
+
+Wait until `hanadb-cluster` is `Ready`, then check the current PVC sizes:
+
+```bash
+$ kubectl get pvc -n demo -l app.kubernetes.io/instance=hanadb-cluster \
+  -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,SIZE:.status.capacity.storage
+NAME                            SC                SIZE
+data-hanadb-cluster-0           longhorn-single   64Gi
+data-hanadb-cluster-1           longhorn-single   64Gi
+data-hanadb-cluster-arbiter-0   longhorn-single   2Gi
+```
+
+## Create a VolumeExpansion HanaDBOpsRequest
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: HanaDBOpsRequest
+metadata:
+  name: hdbops-volume-expansion
+  namespace: demo
+spec:
+  type: VolumeExpansion
+  databaseRef:
+    name: hanadb-cluster
+  volumeExpansion:
+    mode: Online
+    hanadb: 65Gi
+  timeout: 30m
+  apply: IfReady
+```
+
+```bash
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/hanadb/volume-expansion/volume-expansion.yaml
+hanadbopsrequest.ops.kubedb.com/hdbops-volume-expansion created
+```
+
+Here,
+
+- `spec.volumeExpansion.hanadb` is the new size of each HANA data volume.
+- `spec.volumeExpansion.mode` is `Online` (expand in place) or `Offline` (recreate pods). `Online`
+  requires the StorageClass/CSI driver to support online expansion.
+
+## Verify the Expansion
+
+```bash
+$ kubectl get hdbops -n demo hdbops-volume-expansion
+NAME                      TYPE              STATUS       AGE
+hdbops-volume-expansion   VolumeExpansion   Successful   2m36s
+```
+
+```bash
+$ kubectl describe hdbops -n demo hdbops-volume-expansion
+...
+Status:
+  Conditions:
+    Message:  HanaDBOpsRequest has started to expand volume of HanaDB nodes.
+    Reason:   VolumeExpansion
+    Status:   True
+    Type:     VolumeExpansion
+    Message:  Successfully paused database
+    Reason:   DatabasePauseSucceeded
+    Status:   True
+    Type:     DatabasePauseSucceeded
+    Message:  PetSet is recreated
+    Reason:   ReadyPetSets
+    Status:   True
+    Type:     ReadyPetSets
+    Message:  Successfully completed volume expansion for HanaDB.
+    Reason:   Successful
+    Status:   True
+    Type:     Successful
+  Phase:      Successful
+```
+
+Confirm the data PVCs grew to the requested size (the small arbiter volume is unchanged):
+
+```bash
+$ kubectl get pvc -n demo -l app.kubernetes.io/instance=hanadb-cluster \
+  -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,SIZE:.status.capacity.storage
+NAME                            SC                SIZE
+data-hanadb-cluster-0           longhorn-single   65Gi
+data-hanadb-cluster-1           longhorn-single   65Gi
+data-hanadb-cluster-arbiter-0   longhorn-single   2Gi
+```
+
+## Cleaning Up
+
+```bash
+$ kubectl delete hdbops -n demo hdbops-volume-expansion
+$ kubectl delete hanadb.kubedb.com -n demo hanadb-cluster
+$ kubectl delete ns demo
+```
+
+## Next Steps
+
+- Move data to a different StorageClass with [Storage Migration](/docs/guides/hanadb/storage-migration/storage-migration.md).
+- Review the [HanaDBOpsRequest CRD](/docs/guides/hanadb/concepts/opsrequest.md).


### PR DESCRIPTION
## What

Adds user-facing documentation and runnable examples for KubeDB-managed **SAP HanaDB**, under `docs/guides/hanadb/` and `docs/examples/hanadb/`.

All command output embedded in the guides was collected from a **live cluster** running the HanaDB operator (standalone + System Replication topologies), not invented.

## Guides

- **Overview** + concepts: `HanaDB`, `HanaDBVersion`, `HanaDBOpsRequest`, `AppBinding`
- **Quickstart** (standalone) and **System Replication** clustering (primary / read-only secondary / arbiter, `hdbnsutil -sr_state`)
- **Custom configuration** via a `global.ini` secret
- **Monitoring** with builtin Prometheus and the Prometheus Operator
- **TLS/SSL** with cert-manager — enable at creation (`spec.tls`) and via `ReconfigureTLS`
- Day-2 ops: **Restart**, **Reconfigure**, **Vertical Scaling**, **Volume Expansion**, **Storage Migration**
- **Rotate Authentication** (operator-generated and user-provided credentials)

## Coverage notes

- Every documented `HanaDBOpsRequest` type is present in the API and implemented by the ops controller.
- Restart / Reconfigure / Vertical Scaling / Rotate Auth validated live on standalone and/or System Replication databases.
- TLS *enable* (`ReconfigureTLS`) validated live. The certificate-**rotation** path is documented with a troubleshooting note: in testing, after a rotation the raft coordinator could fail to verify the new certificate (`x509: certificate signed by unknown authority`), stalling primary re-election — the guide tells users how to detect this.
- Volume Expansion and Storage Migration validated live on Longhorn (`allowVolumeExpansion: true`); the guides call out the expandable-StorageClass requirement since `local-path` cannot expand.

## Validation

- All example YAMLs pass `kubectl apply --dry-run=server`.
- Hugo menu identifiers are unique; internal guide links resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full HanaDB documentation section with guides for quickstart, clustering, configuration, monitoring, TLS, reconfiguration, restart, authentication rotation, scaling, storage migration, and volume expansion.
  * Added many ready-to-use example manifests for standalone and system-replication deployments, plus operational requests for day-2 tasks.
  * Included examples for custom configuration, Prometheus monitoring, TLS setup, storage migration, and online volume expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->