### PR TITLE
Add Cassandra DC-DR (cross data center disaster recovery) guide

### DIFF
--- a/docs/guides/cassandra/README.md
+++ b/docs/guides/cassandra/README.md
@@ -59,3 +59,7 @@ ref : https://cacoo.com/diagrams/4PxSEzhFdNJRIbIb/0281B
 
 - [Quickstart Cassandra](/docs/guides/cassandra/quickstart/guide/quickstart.md) with KubeDB Operator.
 - Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).
+
+## Cross-DC Disaster Recovery (DC-DR)
+
+Do you want to run your Cassandra database across multiple data centers and recover from a full data center failure with a single, automatically re-routing write endpoint? KubeDB runs one masterless Cassandra ring across the data centers, makes each data center a full Cassandra datacenter replicated by `NetworkTopologyStrategy`, keeps availability with per-DC `LOCAL_QUORUM` consistency (not a fence), and lets the `dr-controlplane` Lease route the single write endpoint to a surviving data center. Follow [here](/docs/guides/cassandra/dr/overview/index.md).

--- a/docs/guides/cassandra/dr/_index.md
+++ b/docs/guides/cassandra/dr/_index.md
@@ -1,0 +1,10 @@
+---
+title: Disaster Recovery
+menu:
+  docs_{{ .version }}:
+    identifier: cas-dr-cassandra
+    name: DR
+    parent: cas-cassandra-guides
+    weight: 55
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/cassandra/dr/guide/index.md
+++ b/docs/guides/cassandra/dr/guide/index.md
@@ -1,0 +1,387 @@
+---
+title: DC-DR User Guide
+menu:
+  docs_{{ .version }}:
+    identifier: cas-dr-guide-cassandra
+    name: User Guide
+    parent: cas-dr-cassandra
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+# Running Cassandra in DC-DR Mode: User Guide
+
+This guide covers every aspect of operating a distributed Cassandra in cross data center
+disaster recovery (DC-DR) mode: the components, the naming contract, deployment,
+connecting through the single write endpoint, reading and writing locally, consistency
+levels, monitoring, hint and repair backlog as the lag proxy, switchover and failback,
+scaling, and day-2 operations.
+
+Read the [DC-DR Overview](/docs/guides/cassandra/dr/overview/index.md) first for the
+architecture, and the [DC-DR Runbook](/docs/guides/cassandra/dr/runbook/index.md) for
+scenario-by-scenario procedures.
+
+> **New to KubeDB?** Please start [here](/docs/README.md).
+
+## Components and where they run
+
+| Component | Runs in | Responsibility |
+| --- | --- | --- |
+| **`dr-controlplane`** + 3-site etcd quorum | across the data centers (an OCM control plane) | Publishes one `coordination.k8s.io` **Lease** per failover scope. The Lease holder is the DC the single write endpoint resolves to. The Lease is routing, policy, and observability, **not** a failover or fence mechanism. |
+| **`dr-controlplane` agent** | each spoke (DC) | Contends for the primary-DC Lease for its DC and projects the Lease decision into the local spoke as the `primary-dc` marker. |
+| **KubeDB Cassandra operator (hub)** | the OCM hub | Expands the `Cassandra` CR into one Cassandra datacenter per Member DC, wires `NetworkTopologyStrategy`, cross-DC seeds, and the snitch, routes the single write endpoint by following the Lease, drives planned switchover, and writes `status.disasterRecovery`. |
+| **Cassandra ring** | every Member DC (a full Cassandra datacenter) | The masterless Dynamo-style ring. Gossip carries membership across DCs; `NetworkTopologyStrategy` replicates continuously. There is no leader and no cross-DC election. |
+| **KubeSlice** | each spoke | Provides the cross-DC pod network so the one ring spans clusters: gossip and the storage port (7000/7001) reach across DCs and CQL (9042) is reachable for the endpoint. |
+
+## The DC-name contract
+
+One string identifies a data center everywhere. **Keep these identical:**
+
+- the OCM spoke cluster name
+- the agent `--dc-name`
+- the primary-DC Lease `holderIdentity`
+- the marker `data.activeDC`
+- the Cassandra `dc=` in each pod's `cassandra-rackdc.properties`
+- the pod label `open-cluster-management.io/cluster-name`
+- the `PlacementPolicy` `distributionRule.clusterName`
+
+## Deploying
+
+### PlacementPolicy
+
+Map the global replica indices to data centers and tag each DC with its role:
+
+```yaml
+apiVersion: apps.k8s.appscode.com/v1
+kind: PlacementPolicy
+metadata:
+  name: cas-dcdr
+spec:
+  clusterSpreadConstraint:
+    slice:
+      projectNamespace: kubeslice-demo
+      sliceName: demo-slice
+    failoverPolicy:
+      trigger:
+        scope: Global       # one cluster-wide failover scope (or Group + a group name)
+      mode: ThreeDC         # ThreeDC: 3 Member DCs, no arbiter; TwoDC: 2 Member DCs + an engine-free Arbiter DC
+    distributionRules:
+    - clusterName: dc-a
+      role: Member
+      replicaIndices: [0, 1, 2]
+    - clusterName: dc-b
+      role: Member
+      replicaIndices: [3, 4, 5]
+    - clusterName: dc-c
+      role: Member
+      replicaIndices: [6, 7, 8]
+```
+
+- Each **Member** rule maps to one Cassandra datacenter; its `replicaIndices` are the
+  nodes (racks) of that datacenter, replicated with `NetworkTopologyStrategy`.
+- `mode: ThreeDC` expects an odd number of Member DCs and **no** separate Arbiter DC (the
+  preferred layout, and Cassandra's own recommended geo shape). `mode: TwoDC` expects two
+  Member DCs plus an engine-free Arbiter DC that runs only the `dr-controlplane` etcd
+  member (no Cassandra) so the coordination quorum keeps an odd site count.
+- Roles are `Member` and `Arbiter` only. An `Arbiter` rule carries an empty
+  `replicaIndices` and no Cassandra is scheduled onto it.
+
+### Cassandra
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Cassandra
+metadata:
+  name: cas-dcdr
+  namespace: demo
+spec:
+  version: "5.0.3"
+  distributed: true
+  topology:
+    rack:
+    - name: rack-a
+      replicas: 3
+      storage:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi
+  storageType: Durable
+  podTemplate:
+    spec:
+      podPlacementPolicy:
+        name: cas-dcdr
+  deletionPolicy: WipeOut
+```
+
+### What the operator creates
+
+- **One logical ring** whose members are spread across the Member DCs, each Member DC a
+  full Cassandra datacenter with its own racks. Every pod is configured with
+  `GossipingPropertyFileSnitch` and a per-pod `cassandra-rackdc.properties`
+  (`dc=<clusterName>`, `rack=<rack>`), and the seed list includes a few seeds per remote
+  DC so gossip forms one ring across the DCs.
+- **`NetworkTopologyStrategy` replication** with a replication factor per DC. User
+  keyspaces must use `NetworkTopologyStrategy`; a keyspace on `SimpleStrategy` is **not**
+  DC-DR safe (it ignores datacenters). See "Keyspaces and replication" below.
+- A single **write endpoint** (Service plus `AppBinding`) that the orchestrator points at
+  the active DC by following the Lease. Reads and writes at `LOCAL_QUORUM` can also go to
+  any DC directly.
+
+All data-bearing pods carry the offshoot selectors plus the
+`open-cluster-management.io/cluster-name` label, so the single write endpoint and the
+single `AppBinding` keep working as the active DC moves.
+
+> The snitch (`GossipingPropertyFileSnitch`) and the per-pod `dc=`/`rack=` values are the
+> topology contract. Do not change a pod's `dc=` after it has joined the ring; that is a
+> datacenter move, not a config edit.
+
+## Keyspaces and replication
+
+Create every user keyspace with `NetworkTopologyStrategy` and a replication factor per
+Member DC. For the three-DC layout above:
+
+```sql
+CREATE KEYSPACE app
+  WITH replication = {
+    'class': 'NetworkTopologyStrategy',
+    'dc-a': 3,
+    'dc-b': 3,
+    'dc-c': 3
+  };
+```
+
+- `NetworkTopologyStrategy` places replicas per datacenter, which is what makes the ring
+  DC-DR safe: each DC holds a full copy and can serve `LOCAL_QUORUM` on its own.
+- A keyspace using `SimpleStrategy` is not datacenter-aware and is **not** DC-DR safe.
+  Convert it with `ALTER KEYSPACE ... WITH replication = {'class':
+  'NetworkTopologyStrategy', ...}` and then run `nodetool repair` so the new replicas are
+  populated.
+- The system keyspaces `system_auth`, `system_distributed`, and `system_traces` should
+  also use `NetworkTopologyStrategy` across the DCs so authentication and system state
+  survive a DC loss.
+
+## Connecting
+
+A DC-DR Cassandra exposes a single write endpoint, the same shape as any KubeDB
+Cassandra:
+
+- the **write endpoint** `<db>` resolves to the active DC's nodes (CQL port 9042); the
+  Lease-driven routing keeps a stable single-writer posture;
+- one **`AppBinding`** `<db>` for applications and KubeDB integrations.
+
+Because Cassandra is masterless, every DC can accept reads and writes, but the single
+endpoint gives a stable single-writer posture: applications keep using `<db>` and, after a
+failover, reconnect and land on the new active DC. If your driver is datacenter-aware, you
+can also point it at a local DC with a `DCAwareRoundRobinPolicy` and `LOCAL_QUORUM` for
+lowest latency.
+
+### Writes and consistency (the correctness knob)
+
+There is no fence and no quorum that decides who may commit. Correctness comes from the
+**consistency level** you choose per statement or per keyspace:
+
+```sql
+-- Local-quorum write against the write endpoint <db>:9042 (the default, DC-loss tolerant):
+CONSISTENCY LOCAL_QUORUM;
+INSERT INTO app.orders (id, item, qty) VALUES (uuid(), 'widget', 1);
+```
+
+- **`LOCAL_QUORUM`** acks when a quorum of replicas in the local DC has the write; it
+  keeps working when another DC is down and replicates asynchronously to the other DCs.
+  This is the documented default.
+- **`EACH_QUORUM`** acks only when a quorum in **every** DC has the write; it is the
+  strongest cross-DC durability but fails while any DC is down. Reserve it for keyspaces
+  or statements that cannot tolerate the `LOCAL_QUORUM` loss window.
+- The bounded loss on an unplanned active-DC loss is only writes that acked at
+  `LOCAL_QUORUM` in the lost DC but had not yet replicated to survivors (bounded by hint
+  and replication backlog when the DC died, recoverable by repair if the DC returns).
+
+### Read locally
+
+Any DC serves `LOCAL_QUORUM` reads. Point read traffic at an in-DC coordinator for low
+latency; reads are eventually consistent across DCs, bounded by hint and repair backlog.
+Use `LOCAL_QUORUM` reads plus `LOCAL_QUORUM` writes on a keyspace with RF >= 3 per DC for
+read-your-writes within a DC.
+
+## Monitoring and observability
+
+### status.disasterRecovery
+
+The single CR carries the whole cross-DC view:
+
+```bash
+$ kubectl get cassandra -n demo cas-dcdr -o jsonpath='{.status.disasterRecovery}' | jq
+```
+
+| Field | Meaning |
+| --- | --- |
+| `activeDC` | The DC the single write endpoint currently resolves to (a routing choice, not a promoted primary). |
+| `phase` | `Steady`, `FailingOver`, `FailingBack`, or `Degraded`. |
+| `lastTransitionTime` | When `activeDC` last changed. |
+| `dataCenters[].clusterName` | The data center, by its OCM managed cluster name (also the Cassandra `dc=`). |
+| `dataCenters[].role` | `Member` or `Arbiter`. |
+| `dataCenters[].writable` | True only for the active (write-routed) DC (a routing marker, not an engine fence). |
+| `dataCenters[].upNormalNodes` | The DC's UN (up/normal) node count from `nodetool status`. |
+| `dataCenters[].totalNodes` | The DC's total node count. |
+| `dataCenters[].pendingHints` | Cross-DC hinted-handoff backlog for this DC (a lag proxy). |
+| `dataCenters[].repairBacklog` | Anti-entropy repair staleness for this DC (a lag proxy). |
+| `dataCenters[].healthy` | Whether the DC has its expected UN nodes. |
+
+### Useful checks
+
+```bash
+# Which DC the Lease intends as the write-routed active DC:
+$ kubectl --kubeconfig <coord> -n dc-failover get lease primary-dc \
+    -o jsonpath='{.spec.holderIdentity}'
+
+# Per-DC nodes and DCs:
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=cas-dcdr \
+    -L open-cluster-management.io/cluster-name
+
+# Ring and per-DC node status (UN = up/normal), from any node:
+$ kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
+
+# Cross-DC streaming, pending hints, and pending ranges (the lag signal):
+$ kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool netstats
+
+# Gossip view of every node across DCs:
+$ kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool gossipinfo
+```
+
+## Replication, lag, and RPO
+
+- Cross-DC replication is **native Cassandra `NetworkTopologyStrategy`** over the storage
+  port (7000, or 7001 with TLS), asynchronous, one copy per write per remote DC (the
+  local coordinator forwards to a remote coordinator that fans out to local replicas).
+  There is exactly one ring, so there is no extra replication link to manage.
+- The lag signals are the **hinted-handoff backlog** (`nodetool netstats`, hints stored
+  for a temporarily down node) and **repair staleness** (how long since the last
+  cross-DC `nodetool repair`). These are surfaced into `status.disasterRecovery` as
+  `pendingHints` and `repairBacklog`.
+- A **planned switchover is a routing move**, so it loses no committed data on its own;
+  for the strictest handoff, drain hints and run a cross-DC repair first so the target is
+  fully converged. An **unplanned failover** may lose only writes that acked at
+  `LOCAL_QUORUM` in the lost DC but had not yet replicated (bounded by the hint and
+  replication backlog when the DC died). Keyspaces written at `EACH_QUORUM` lose zero on
+  the writes that acked, at the cost of not acking while any DC is down.
+
+## Arbiter and DC-count guidance
+
+- **Prefer an odd number of Member DCs.** Three full Cassandra datacenters, each with its
+  own replication factor, is the preferred layout and needs **no arbiter**. It is also
+  Cassandra's own recommended geo shape.
+- **An Arbiter DC appears only for an even data-DC count** (two Member DCs). It is
+  **engine-free**: it runs only the `dr-controlplane` etcd member so the coordination
+  quorum keeps an odd site count. No Cassandra runs in the Arbiter DC, because
+  Cassandra's data plane needs no cross-DC voter (its correctness is per-DC quorum on each
+  query).
+- This is different from ClickHouse and MongoDB, whose arbiter DC holds a data-less engine
+  voter. Cassandra's arbiter holds none.
+
+## Planned switchover (routing move)
+
+Move the active (write-routed) DC on purpose by annotating the Cassandra:
+
+```bash
+$ kubectl annotate cassandra -n demo cas-dcdr dr.kubedb.com/switchover-to=dc-b
+```
+
+The hub then:
+
+1. checks the target is a known, healthy DC within the hint and repair backlog budget;
+2. sets `phase: FailingOver`;
+3. moves the Lease and the single write endpoint to `dc-b`.
+
+Watch `status.disasterRecovery` for `phase` returning to `Steady` with the new
+`activeDC`. There is no promotion step and no engine catch-up gate, because every DC is
+already a full writable datacenter. For a strict zero-loss handoff, drain hints and run a
+cross-DC `nodetool repair` toward the target before switching so it is fully converged.
+
+## Failback
+
+Failback is native and clean. A returned DC rejoins the ring by gossip, receives hinted
+handoff within the hint window, and a full cross-DC `nodetool repair` (anti-entropy)
+reconciles the rest. There is **no rewind**: Cassandra is AP and reconciles by
+last-write-wins on cell timestamps, so there is nothing to roll back (unlike the Postgres
+`pg_rewind` path).
+
+After the returned DC is caught up (its `pendingHints` drained and a cross-DC repair
+complete), steer the active DC back with a planned switchover:
+
+```bash
+$ kubectl annotate cassandra -n demo cas-dcdr dr.kubedb.com/switchover-to=dc-a
+```
+
+> Tune `max_hint_window_in_ms` for the outage you want hinted handoff to cover. Beyond
+> the hint window, hints are dropped and only `nodetool repair` reconciles the gap, so run
+> a full cross-DC repair as part of any failback that outlasted the hint window.
+
+## Scaling and day-2 operations
+
+The standard `CassandraOpsRequest` operations (`VerticalScaling`, `HorizontalScaling`,
+`VolumeExpansion`, `UpdateVersion`, `Reconfigure`, `ReconfigureTLS`, `Restart`,
+`RotateAuth`, `StorageMigration`) apply to a DC-DR cluster. They act on the distributed
+per-DC datacenters across the DCs and are issued exactly as for a single-cluster
+Cassandra. There is no failover ops type: there is nothing to fail over in a masterless
+ring, and the planned switchover is the `dr.kubedb.com/switchover-to` annotation, not an
+ops request.
+
+`HorizontalScaling` gains a per-DC form so you can scale each DC's node count
+independently:
+
+```yaml
+apiVersion: ops.kubedb.com/v1alpha1
+kind: CassandraOpsRequest
+metadata:
+  name: cas-dcdr-hscale
+  namespace: demo
+spec:
+  type: HorizontalScaling
+  databaseRef:
+    name: cas-dcdr
+  horizontalScaling:
+    dataCenters:
+    - clusterName: dc-a
+      replicas: 4
+    - clusterName: dc-b
+      replicas: 3
+```
+
+> After changing a DC's node count, run `nodetool cleanup` on the DC (removes data no
+> longer owned after token ranges move) and a `nodetool repair` if you also changed a
+> keyspace's replication factor.
+
+> **Note:** the distributed Cassandra substrate and the DC-DR layer are net-new for
+> Cassandra (KubeDB models Cassandra as a single logical DC today). Treat the field names
+> and flows in this guide as the intended user experience; confirm availability in your
+> release before relying on them in production.
+
+## Deletion and cleanup
+
+```bash
+$ kubectl delete cassandra -n demo cas-dcdr
+```
+
+Per `deletionPolicy`, the operator removes the per-DC datacenters and the cluster-scoped
+per-DC `PlacementPolicies` it generated (these carry no owner reference, so the operator
+deletes them explicitly). The user-provided base `PlacementPolicy` is left for you to
+delete.
+
+## Limitations
+
+- **Adding or removing a whole data center** is a topology change (a datacenter and
+  replication-factor change), performed by editing the `PlacementPolicy` topology and the
+  keyspaces' `NetworkTopologyStrategy`, then running `nodetool repair`, not by a scaling
+  request.
+- Cross-DC replication is asynchronous; an unplanned failover has a non-zero RPO bounded
+  by the hint and replication backlog (only recent `LOCAL_QUORUM` writes not yet
+  replicated). Use `EACH_QUORUM` for keyspaces that cannot tolerate that window, and a
+  planned switchover with a preceding repair for a strict handoff.
+- User keyspaces must use `NetworkTopologyStrategy`; a `SimpleStrategy` keyspace is not
+  datacenter-aware and is not DC-DR safe.
+- There is no strong split-brain fence: a partitioned DC keeps serving `LOCAL_QUORUM`
+  (Cassandra is AP). Divergent writes across a partition are reconciled by
+  last-write-wins on cell timestamps during hinted handoff and repair on heal, not
+  prevented.

--- a/docs/guides/cassandra/dr/guide/index.md
+++ b/docs/guides/cassandra/dr/guide/index.md
@@ -98,6 +98,8 @@ metadata:
 spec:
   version: "5.0.3"
   distributed: true
+  podPlacementPolicy:
+    name: cas-dcdr
   topology:
     rack:
     - name: rack-a
@@ -108,10 +110,6 @@ spec:
           requests:
             storage: 1Gi
   storageType: Durable
-  podTemplate:
-    spec:
-      podPlacementPolicy:
-        name: cas-dcdr
   deletionPolicy: WipeOut
 ```
 

--- a/docs/guides/cassandra/dr/guide/index.md
+++ b/docs/guides/cassandra/dr/guide/index.md
@@ -221,13 +221,14 @@ $ kubectl get cassandra -n demo cas-dcdr -o jsonpath='{.status.disasterRecovery}
 | `phase` | `Steady`, `FailingOver`, `FailingBack`, or `Degraded`. |
 | `lastTransitionTime` | When `activeDC` last changed. |
 | `dataCenters[].clusterName` | The data center, by its OCM managed cluster name (also the Cassandra `dc=`). |
-| `dataCenters[].role` | `Member` or `Arbiter`. |
+| `dataCenters[].role` | `Member` (a full Cassandra datacenter) or `Arbiter` (engine-free, etcd vote only). |
+| `dataCenters[].replicationFactor` | The DC's `NetworkTopologyStrategy` replication factor for the managed keyspaces. |
 | `dataCenters[].writable` | True only for the active (write-routed) DC (a routing marker, not an engine fence). |
-| `dataCenters[].upNormalNodes` | The DC's UN (up/normal) node count from `nodetool status`. |
+| `dataCenters[].upNodes` | The DC's UN (up/normal) node count from `nodetool status`. |
 | `dataCenters[].totalNodes` | The DC's total node count. |
-| `dataCenters[].pendingHints` | Cross-DC hinted-handoff backlog for this DC (a lag proxy). |
-| `dataCenters[].repairBacklog` | Anti-entropy repair staleness for this DC (a lag proxy). |
-| `dataCenters[].healthy` | Whether the DC has its expected UN nodes. |
+| `dataCenters[].hintBacklogBytes` | Cross-DC hinted-handoff backlog for this DC (a lag proxy). |
+| `dataCenters[].pendingRanges` | Streaming/pending ranges (`nodetool netstats`) for this DC, non-zero while it catches up after a rejoin or repair (a lag proxy). |
+| `dataCenters[].healthy` | Whether this DC's health Lease is fresh. |
 
 ### Useful checks
 
@@ -257,9 +258,9 @@ $ kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool gossipinfo
   local coordinator forwards to a remote coordinator that fans out to local replicas).
   There is exactly one ring, so there is no extra replication link to manage.
 - The lag signals are the **hinted-handoff backlog** (`nodetool netstats`, hints stored
-  for a temporarily down node) and **repair staleness** (how long since the last
-  cross-DC `nodetool repair`). These are surfaced into `status.disasterRecovery` as
-  `pendingHints` and `repairBacklog`.
+  for a temporarily down node) and the **pending/streaming ranges** (`nodetool netstats`,
+  non-zero while a DC catches up after a rejoin or repair). These are surfaced into
+  `status.disasterRecovery` as `hintBacklogBytes` and `pendingRanges`.
 - A **planned switchover is a routing move**, so it loses no committed data on its own;
   for the strictest handoff, drain hints and run a cross-DC repair first so the target is
   fully converged. An **unplanned failover** may lose only writes that acked at
@@ -307,7 +308,7 @@ reconciles the rest. There is **no rewind**: Cassandra is AP and reconciles by
 last-write-wins on cell timestamps, so there is nothing to roll back (unlike the Postgres
 `pg_rewind` path).
 
-After the returned DC is caught up (its `pendingHints` drained and a cross-DC repair
+After the returned DC is caught up (its `hintBacklogBytes` drained and a cross-DC repair
 complete), steer the active DC back with a planned switchover:
 
 ```bash
@@ -344,9 +345,9 @@ spec:
   horizontalScaling:
     dataCenters:
     - clusterName: dc-a
-      replicas: 4
+      node: 4
     - clusterName: dc-b
-      replicas: 3
+      node: 3
 ```
 
 > After changing a DC's node count, run `nodetool cleanup` on the DC (removes data no

--- a/docs/guides/cassandra/dr/overview/index.md
+++ b/docs/guides/cassandra/dr/overview/index.md
@@ -1,0 +1,338 @@
+---
+title: DC-DR Overview
+menu:
+  docs_{{ .version }}:
+    identifier: cas-dr-overview-cassandra
+    name: Overview
+    parent: cas-dr-cassandra
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+# Cross Data Center Disaster Recovery (DC-DR) for Cassandra
+
+KubeDB can run a single distributed `Cassandra` across multiple data centers (DCs) so
+the database survives the loss of an entire data center. Cassandra is masterless: one
+Dynamo-style ring spans the data centers, gossip carries membership, and every DC is a
+full Cassandra datacenter that accepts reads and writes locally. So DR is not about
+promoting a new primary and it is not about a fence that decides who may commit. It is
+about two things: the per-query **consistency level** (`LOCAL_QUORUM`), which makes each
+DC ack writes locally and tolerate the loss of another DC, and a single Lease-routed
+write endpoint, which records and steers where a stable single-writer client sends
+writes. When a data center is lost, the surviving DCs keep accepting writes at
+`LOCAL_QUORUM` on their own, and the write endpoint follows to a surviving DC.
+
+This page is the conceptual overview and a quick start. See also:
+
+- [DC-DR User Guide](/docs/guides/cassandra/dr/guide/index.md) for every aspect of
+  running in DC-DR mode (components, status, connecting, monitoring, consistency,
+  switchover, failback, day-2 ops).
+- [DC-DR Runbook](/docs/guides/cassandra/dr/runbook/index.md) for what to do in each
+  operational scenario.
+
+> **New to KubeDB?** Please start [here](/docs/README.md).
+
+## Why Cassandra DC-DR is different
+
+Most KubeDB engines (Postgres, MariaDB, MSSQL) keep their consensus quorum **inside** a
+single DC, because a raft or cluster manager flaps or stalls when its quorum spans data
+centers. Those engines run one independent group per DC and build a separate cross-DC
+replication link, and DR means promoting a standby.
+
+**Cassandra is the geo-native exception, further along the same axis as ClickHouse and
+MongoDB.** Cassandra is fully masterless: there is no primary, no cross-DC election, and
+multi-datacenter replication is first class in the engine. So for Cassandra:
+
+- **One logical ring spans the DCs.** Each Member DC is a Cassandra datacenter, its
+  KubeDB racks becoming racks within it. Gossip carries membership across DCs over the
+  cross-DC overlay. Unlike Postgres raft or Galera wsrep, spreading membership across
+  DCs is exactly what Cassandra is designed for.
+- **Replication is native and continuous.** User keyspaces use `NetworkTopologyStrategy`
+  with a replication factor per DC (for example `{dc-a: 3, dc-b: 3, dc-c: 3}`). Every
+  write is sent once to each DC (the local coordinator forwards it to a remote
+  coordinator that fans out to the local replicas), so the WAN one-copy-then-fan-out
+  rule is native. There is **no second replication link to build**.
+- **There is no failover in the engine, because there is no leader.** Cassandra has no
+  primary and no cross-DC election, so nothing gets promoted and nothing gets fenced.
+  Availability is preserved by consistency level, not by a quorum that decides who may
+  commit. Writing in more than one DC at once (active-active) is legitimate for
+  Cassandra.
+- **Failback is native and clean.** A returned DC rejoins the ring by gossip, receives
+  hinted handoff within the hint window, and a full cross-DC `nodetool repair`
+  (anti-entropy) reconciles the rest. There is **no rewind**: Cassandra is AP and
+  reconciles by last-write-wins on cell timestamps, so there is nothing to roll back.
+  This is different from the Postgres `pg_rewind` path.
+
+## How it works
+
+DC-DR for Cassandra rests on five rules.
+
+- **One ring, each DC a Cassandra datacenter.** The operator expands the distributed
+  `Cassandra` CR into one Cassandra datacenter per Member DC, wiring
+  `GossipingPropertyFileSnitch` (per-pod `cassandra-rackdc.properties` with `dc=<DC>`
+  and `rack=<rack>`) and per-DC seeds so gossip and the storage port reach across DCs.
+  The ring is one; the datacenters within it are the DR boundary.
+- **Consistency, not a fence, is the correctness knob.** Use `LOCAL_QUORUM` for reads
+  and writes so each DC acks locally (low latency, DC-loss tolerant) while data still
+  replicates to the other DCs. A partitioned DC keeps serving `LOCAL_QUORUM` (Cassandra
+  is AP), so there is **no split-brain fence in the strong sense**. On rejoin, hinted
+  handoff plus anti-entropy `nodetool repair` reconcile. Use `EACH_QUORUM` only when a
+  write must be durable in every DC before it acks (higher latency, not DC-loss
+  tolerant).
+- **The Lease routes the single write endpoint; it does not promote or fence anything.**
+  A small control plane (`dr-controlplane`), backed by a three-site etcd quorum,
+  publishes one `coordination.k8s.io` **Lease** per failover scope. For Cassandra the
+  Lease is pure routing and observability: it records which DC the single user-facing
+  write endpoint resolves to and steers clients there, giving a stable single-writer
+  posture and one consistent cross-engine status. Because Cassandra is masterless, this
+  is a write-routing choice, not an engine-enforced primary and not a data-plane fence.
+  On an unplanned DC loss the orchestrator moves the Lease and the endpoint to a
+  surviving DC. The Lease is routing, policy, and observability, **not** a failover
+  mechanism (there is nothing to fail over, the ring keeps running).
+- **Reads and writes can stay local.** Any DC serves `LOCAL_QUORUM` reads and writes, so
+  traffic can stay in-DC for low latency while the ring replicates asynchronously to the
+  other DCs. The single write endpoint is a convenience for a stable single-writer
+  posture, not a requirement of the engine.
+- **One cross-DC copy per write per DC, then fan out intra-DC.** With
+  `NetworkTopologyStrategy`, a write is sent once across the WAN to each remote DC, whose
+  local coordinator fans it out to that DC's replicas over the local network. This is
+  native, so cross-DC write traffic is one copy per write per DC with no operator-side
+  cascade to build (unlike the ClickHouse per-shard fetch source or the Postgres
+  standby-DC cascade).
+
+> **Why prefer an odd number of data DCs?** With an odd number of Member DCs (for
+> example three), the `dr-controlplane` etcd quorum has its odd site count among the data
+> DCs themselves, and Cassandra's own recommended geo shape is three or more full
+> datacenters. No separate arbiter is needed. An arbiter DC appears only when the data-DC
+> count is even, and it is engine-free (see below).
+
+### Data center roles
+
+Each DC plays one role, set on the `PlacementPolicy` `distributionRule.role`:
+
+| Role | Holds Cassandra data | Holds a coordination vote | Purpose |
+| --- | --- | --- | --- |
+| **Member** | yes | yes | A full Cassandra datacenter with its racks and its own `NetworkTopologyStrategy` replication factor; a candidate for the single write endpoint. |
+| **Arbiter** | no | yes (etcd only) | The arbiter DC. Holds only the `dr-controlplane` etcd vote to give the coordination quorum an odd site count. **No Cassandra runs here.** Present only when the data-DC count is even. |
+
+> Unlike ClickHouse and MongoDB, whose arbiter DC holds a data-less engine voter (a
+> Keeper voter or a voting mongod), the Cassandra arbiter DC holds **no engine member at
+> all**. Cassandra's data plane needs no cross-DC voter because its correctness comes
+> from per-DC quorum on each query, not from a cross-DC vote. The arbiter DC exists only
+> to give the `dr-controlplane` failover service its odd etcd quorum.
+
+## Consistency is the tradeoff (the one real decision)
+
+Cassandra has no cross-DC quorum tax on membership: gossip is cheap and asynchronous.
+The one real decision is the **consistency level** on your reads and writes, because it
+sets the availability-versus-durability tradeoff directly.
+
+### A. LOCAL_QUORUM (the documented default, DC-loss tolerant)
+
+Each read and write reaches a quorum of replicas **within the local DC** and acks
+there; the write still replicates asynchronously to the other DCs. Latency is local, and
+losing an entire other DC does not block writes in the survivors. The bounded loss on a
+hard DC loss is only writes that were acked at `LOCAL_QUORUM` locally but not yet
+replicated to the survivors (reconciled by repair if the lost DC returns, otherwise
+lost). This is the path documented in detail here and is Cassandra's own recommended
+multi-DC default.
+
+### B. EACH_QUORUM (durable in every DC before ack, not DC-loss tolerant)
+
+A write must reach a quorum of replicas **in every DC** before it acks. This gives the
+strongest cross-DC durability (a write that acked survives the loss of any one DC), but
+it is **not** DC-loss tolerant: if a DC is down, writes at `EACH_QUORUM` fail. Use it
+per keyspace or per statement only for data that cannot tolerate the `LOCAL_QUORUM` loss
+window.
+
+### At a glance
+
+| Consistency | Ack scope | Write latency | Behavior on a DC loss |
+| --- | --- | --- | --- |
+| A. `LOCAL_QUORUM` (documented here) | quorum in the local DC | low (local) | writes continue in survivors; bounded loss of unreplicated recent writes |
+| B. `EACH_QUORUM` | quorum in every DC | higher (cross-DC on every write) | writes fail while any DC is down (zero loss on the writes that did ack) |
+
+The rest of these docs assume `LOCAL_QUORUM` normal operation with `EACH_QUORUM`
+reserved for the keyspaces that need it. Choose per keyspace: `LOCAL_QUORUM` for
+availability, `EACH_QUORUM` for the strictest cross-DC durability.
+
+## The single-CR, single-endpoint model
+
+The user creates **one** distributed `Cassandra` object (with `spec.distributed: true`
+and a `podPlacementPolicy` referencing a `PlacementPolicy` that carries
+`distributionRules` and a `failoverPolicy`) and gets **one** `AppBinding` and **one**
+write endpoint. The operator expands the CR into one Cassandra datacenter per Member DC
+(its racks placed within it), wires `NetworkTopologyStrategy`, cross-DC seeds, and the
+snitch, and routes the single write endpoint to the active DC by following the Lease.
+
+The single CR's `status.disasterRecovery` carries the whole cross-DC view: the active
+(write-routed) DC, each DC's UN (up/normal) node count from `nodetool status`, the
+cross-DC hint and repair backlog as the lag proxy, and the DR phase.
+
+## Prerequisites
+
+- A distributed Cassandra substrate: Open Cluster Management (OCM) hub and spoke
+  clusters, KubeSlice connecting the spokes so the ring reaches across DCs, and a storage
+  class on each data-bearing spoke. The Cassandra ports (CQL 9042, storage/gossip 7000
+  or TLS 7001, and JMX where enabled) must be reachable across the DCs.
+- The `dr-controlplane` service and its three-site etcd quorum installed across the data
+  centers, with a `dr-controlplane` agent running in each spoke (DC). When the data-DC
+  count is even, the third etcd member sits in the arbiter DC (which runs no Cassandra).
+- The KubeDB Cassandra operator started with the DC-DR flags (coordination kubeconfig
+  and the operator's local DC name).
+- One consistent **DC name** per data center, used everywhere: the OCM spoke cluster
+  name, the agent `--dc-name`, the Lease `holderIdentity`, the Cassandra `dc=` in
+  `cassandra-rackdc.properties`, the pod label
+  `open-cluster-management.io/cluster-name`, and the `PlacementPolicy`
+  `distributionRule.clusterName`. Keep them identical.
+
+## Deploy a DC-DR Cassandra
+
+### 1. PlacementPolicy
+
+Assign global replica indices to data centers and tag each DC with its role. Here three
+Member DCs (`dc-a`, `dc-b`, `dc-c`) each become a full Cassandra datacenter with
+replication factor 3, an odd layout that needs no arbiter:
+
+```yaml
+apiVersion: apps.k8s.appscode.com/v1
+kind: PlacementPolicy
+metadata:
+  name: cas-dcdr
+spec:
+  clusterSpreadConstraint:
+    slice:
+      projectNamespace: kubeslice-demo
+      sliceName: demo-slice
+    failoverPolicy:
+      trigger:
+        scope: Global
+      mode: ThreeDC
+    distributionRules:
+    - clusterName: dc-a
+      role: Member
+      replicaIndices: [0, 1, 2]     # Cassandra DC "dc-a" (racks within it), NTS RF 3
+    - clusterName: dc-b
+      role: Member
+      replicaIndices: [3, 4, 5]     # Cassandra DC "dc-b", NTS RF 3
+    - clusterName: dc-c
+      role: Member
+      replicaIndices: [6, 7, 8]     # Cassandra DC "dc-c", NTS RF 3 (odd layout, no arbiter)
+```
+
+- Each **Member** rule maps to one Cassandra datacenter; its `replicaIndices` become the
+  nodes (racks) of that datacenter.
+- `failoverPolicy.trigger.scope: Global` makes this one cluster-wide failover scope.
+- This odd (`ThreeDC`) layout needs **no arbiter DC**. Use an `Arbiter` rule with an
+  empty `replicaIndices` only when the data-DC count is even, and that arbiter runs no
+  Cassandra.
+
+### 2. Cassandra
+
+Reference the `PlacementPolicy` and opt the Cassandra into DC-DR expansion:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: Cassandra
+metadata:
+  name: cas-dcdr
+  namespace: demo
+spec:
+  version: "5.0.3"
+  distributed: true
+  topology:
+    rack:
+    - name: rack-a
+      replicas: 3
+      storage:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi
+  storageType: Durable
+  podTemplate:
+    spec:
+      podPlacementPolicy:
+        name: cas-dcdr
+  deletionPolicy: WipeOut
+```
+
+The operator expands this into one Cassandra datacenter per Member DC (`dc-a`, `dc-b`,
+`dc-c`), each a full ring member with `NetworkTopologyStrategy` replication, and routes
+the single write endpoint to the active DC by following the Lease.
+
+## Observe the DC-DR state
+
+The single `Cassandra` object's `status.disasterRecovery` carries the whole cross-DC
+view:
+
+```bash
+$ kubectl get cassandra -n demo cas-dcdr -o jsonpath='{.status.disasterRecovery}' | jq
+```
+
+```json
+{
+  "activeDC": "dc-a",
+  "phase": "Steady",
+  "lastTransitionTime": "2026-06-30T10:00:00Z",
+  "dataCenters": [
+    {
+      "clusterName": "dc-a", "role": "Member", "writable": true, "healthy": true,
+      "upNormalNodes": 3, "totalNodes": 3, "pendingHints": 0, "repairBacklog": 0
+    },
+    {
+      "clusterName": "dc-b", "role": "Member", "writable": false, "healthy": true,
+      "upNormalNodes": 3, "totalNodes": 3, "pendingHints": 12, "repairBacklog": 0
+    },
+    {
+      "clusterName": "dc-c", "role": "Member", "writable": false, "healthy": true,
+      "upNormalNodes": 3, "totalNodes": 3, "pendingHints": 8, "repairBacklog": 0
+    }
+  ]
+}
+```
+
+- `activeDC` is the DC the single write endpoint currently resolves to (a routing
+  choice, not a promoted primary, and not a claim that only this DC may write).
+- `phase` is `Steady`, `FailingOver`, `FailingBack`, or `Degraded`.
+- Each `dataCenters` entry reports the DC role, whether it is the write-routed DC, its
+  UN (up/normal) node count from `nodetool status`, its cross-DC hint backlog and repair
+  backlog (the lag proxy), and its health.
+
+## Unplanned failover
+
+When the active DC is lost, the surviving DCs **keep accepting reads and writes at
+`LOCAL_QUORUM` on their own**, because each DC acks locally and every DC is already
+writable. There is no promotion and no fence. The orchestrator observes the Lease move
+to a surviving DC and points the single write endpoint there.
+`status.disasterRecovery.phase` moves to `FailingOver` and back to `Steady`. Bounded loss
+is only writes that acked at `LOCAL_QUORUM` in the lost DC but had not yet replicated to
+the survivors (recoverable by repair if that DC returns, otherwise lost). Use
+`EACH_QUORUM` for keyspaces that cannot tolerate that window.
+
+## Planned switchover (routing move)
+
+To move the active (write-routed) DC on purpose, annotate the Cassandra with the target
+DC:
+
+```bash
+$ kubectl annotate cassandra -n demo cas-dcdr dr.kubedb.com/switchover-to=dc-b
+```
+
+The orchestrator checks the target DC is healthy and within the hint/repair backlog
+budget, then moves the Lease and the write endpoint to `dc-b`. Because Cassandra is
+active-active and every DC already holds the data, there is no promotion and no catch-up
+gate of the ClickHouse or Postgres kind; the move is a routing change. For the strictest
+zero-loss handoff, drain hints and run a cross-DC `nodetool repair` first so the target
+is fully converged.
+
+## Cleanup
+
+```bash
+$ kubectl delete cassandra -n demo cas-dcdr
+$ kubectl delete placementpolicy cas-dcdr
+```
+
+Deleting the `Cassandra` removes the per-DC datacenters and the generated per-DC
+`PlacementPolicies`. The user-provided base `PlacementPolicy` is left for you to delete.

--- a/docs/guides/cassandra/dr/overview/index.md
+++ b/docs/guides/cassandra/dr/overview/index.md
@@ -241,6 +241,8 @@ metadata:
 spec:
   version: "5.0.3"
   distributed: true
+  podPlacementPolicy:
+    name: cas-dcdr
   topology:
     rack:
     - name: rack-a
@@ -251,10 +253,6 @@ spec:
           requests:
             storage: 1Gi
   storageType: Durable
-  podTemplate:
-    spec:
-      podPlacementPolicy:
-        name: cas-dcdr
   deletionPolicy: WipeOut
 ```
 

--- a/docs/guides/cassandra/dr/overview/index.md
+++ b/docs/guides/cassandra/dr/overview/index.md
@@ -278,16 +278,16 @@ $ kubectl get cassandra -n demo cas-dcdr -o jsonpath='{.status.disasterRecovery}
   "lastTransitionTime": "2026-06-30T10:00:00Z",
   "dataCenters": [
     {
-      "clusterName": "dc-a", "role": "Member", "writable": true, "healthy": true,
-      "upNormalNodes": 3, "totalNodes": 3, "pendingHints": 0, "repairBacklog": 0
+      "clusterName": "dc-a", "role": "Member", "replicationFactor": 3, "writable": true, "healthy": true,
+      "upNodes": 3, "totalNodes": 3, "hintBacklogBytes": 0, "pendingRanges": 0
     },
     {
-      "clusterName": "dc-b", "role": "Member", "writable": false, "healthy": true,
-      "upNormalNodes": 3, "totalNodes": 3, "pendingHints": 12, "repairBacklog": 0
+      "clusterName": "dc-b", "role": "Member", "replicationFactor": 3, "writable": false, "healthy": true,
+      "upNodes": 3, "totalNodes": 3, "hintBacklogBytes": 12, "pendingRanges": 0
     },
     {
-      "clusterName": "dc-c", "role": "Member", "writable": false, "healthy": true,
-      "upNormalNodes": 3, "totalNodes": 3, "pendingHints": 8, "repairBacklog": 0
+      "clusterName": "dc-c", "role": "Member", "replicationFactor": 3, "writable": false, "healthy": true,
+      "upNodes": 3, "totalNodes": 3, "hintBacklogBytes": 8, "pendingRanges": 0
     }
   ]
 }

--- a/docs/guides/cassandra/dr/runbook/index.md
+++ b/docs/guides/cassandra/dr/runbook/index.md
@@ -100,7 +100,7 @@ the Lease resolves to.
 
 ```bash
 kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
-kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} writable:{.writable} hints:{.pendingHints}{"\n"}{end}'
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} writable:{.writable} hints:{.hintBacklogBytes}{"\n"}{end}'
 ```
 
 **Action:** heal the network. The DCs re-gossip and reconcile automatically via hinted
@@ -183,7 +183,7 @@ endpoint does not move.
 
 ```bash
 # Target health and backlog from status:
-kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} healthy={.healthy} hints={.pendingHints} repair={.repairBacklog}{"\n"}{end}'
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} healthy={.healthy} hints={.hintBacklogBytes} repair={.pendingRanges}{"\n"}{end}'
 # Ring and streaming from the target DC:
 kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
 kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool netstats
@@ -214,7 +214,7 @@ written at `EACH_QUORUM` will fail while that DC is down.
 **Verify the active DC is serving:**
 
 ```bash
-kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[?(@.writable==true)]}{.clusterName} up:{.upNormalNodes}/{.totalNodes}{end}'
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[?(@.writable==true)]}{.clusterName} up:{.upNodes}/{.totalNodes}{end}'
 kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
 ```
 
@@ -236,7 +236,7 @@ by last-write-wins on cell timestamps.
 
 ```bash
 kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
-kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} healthy={.healthy} hints={.pendingHints} repair={.repairBacklog}{"\n"}{end}'
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} healthy={.healthy} hints={.hintBacklogBytes} repair={.pendingRanges}{"\n"}{end}'
 ```
 
 **Action:** run a **full cross-DC `nodetool repair`** to reconcile everything beyond the
@@ -253,7 +253,7 @@ its hints are drained and the repair is complete.
 
 ## 9. Hint backlog growing (a DC falling behind)
 
-**Symptoms:** `pendingHints` for a DC keeps rising in `status.disasterRecovery`; that DC is
+**Symptoms:** `hintBacklogBytes` for a DC keeps rising in `status.disasterRecovery`; that DC is
 lagging.
 
 **Impact:** cross-DC replication is behind for that DC, so the RPO window on an unplanned
@@ -264,7 +264,7 @@ other DCs yet.
 
 ```bash
 kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool netstats
-kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} hints={.pendingHints} repair={.repairBacklog}{"\n"}{end}'
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} hints={.hintBacklogBytes} repair={.pendingRanges}{"\n"}{end}'
 ```
 
 **Action:** relieve the cross-DC bottleneck (WAN bandwidth, node load in the lagging DC).
@@ -282,7 +282,7 @@ handoff.
 
 ```bash
 # Is this DC the write-routed one, and is it healthy?
-kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} writable:{.writable} up:{.upNormalNodes}/{.totalNodes}{"\n"}{end}'
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} writable:{.writable} up:{.upNodes}/{.totalNodes}{"\n"}{end}'
 # What DC does the Lease route to?
 kubectl --kubeconfig <coord> -n dc-failover get lease primary-dc -o jsonpath='{.spec.holderIdentity}'
 # Ring health from a node:
@@ -341,7 +341,7 @@ repair, only cell values reconciled by timestamp).
 ```bash
 kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
 kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool netstats
-kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} hints={.pendingHints} repair={.repairBacklog}{"\n"}{end}'
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} hints={.hintBacklogBytes} repair={.pendingRanges}{"\n"}{end}'
 ```
 
 **Action:** let hinted handoff drain, then run a **full cross-DC `nodetool repair`** to

--- a/docs/guides/cassandra/dr/runbook/index.md
+++ b/docs/guides/cassandra/dr/runbook/index.md
@@ -1,0 +1,369 @@
+---
+title: DC-DR Runbook
+menu:
+  docs_{{ .version }}:
+    identifier: cas-dr-runbook-cassandra
+    name: Runbook
+    parent: cas-dr-cassandra
+    weight: 30
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+# Cassandra DC-DR Runbook
+
+Scenario-by-scenario procedures for operating a Cassandra cluster in cross data center
+disaster recovery (DC-DR) mode. Each scenario lists the **symptoms**, what KubeDB and
+Cassandra do **automatically**, how to **verify**, and the **action** to take.
+
+Read the [User Guide](/docs/guides/cassandra/dr/guide/index.md) for the concepts and
+commands referenced here. Throughout, `<coord>` is the coordination control plane
+kubeconfig, and `cas-dcdr`/`demo` are the example database and namespace. The example pod
+`cas-dcdr-rack-a-0` is the first node of rack `rack-a`.
+
+## Quick reference
+
+```bash
+# Active DC, phase, and per-DC view:
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{.status.disasterRecovery}' | jq
+
+# Lease holder (the DC the coordination plane routes writes to):
+kubectl --kubeconfig <coord> -n dc-failover get lease primary-dc -o jsonpath='{.spec.holderIdentity}'
+
+# Per-DC nodes and DCs:
+kubectl get pods -n demo -l app.kubernetes.io/instance=cas-dcdr -L open-cluster-management.io/cluster-name
+
+# Ring status per DC (UN = up/normal), from any node:
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
+
+# Cross-DC streaming, pending hints, pending ranges (the lag signal):
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool netstats
+```
+
+Golden rules:
+
+- **Consistency level, not a fence, is the correctness knob.** Cassandra is AP and
+  masterless. A partitioned DC keeps serving `LOCAL_QUORUM`; there is no cross-DC quorum
+  that stops it committing. Reconciliation happens after the fact via hinted handoff and
+  `nodetool repair`.
+- **There is no promotion and no failover in the engine.** Every DC is a full writable
+  Cassandra datacenter. DR is a routing change (the write endpoint follows the Lease to a
+  surviving DC), not an election.
+- **Exactly one DC is `writable: true`** in `status.disasterRecovery` at any instant (the
+  write-routed active DC), even though the engine lets every DC accept writes. This is a
+  routing marker, not an engine fence.
+- **The Lease is routing, not safety.** If the Lease is stale, Cassandra keeps running on
+  its own; what you lose is switchover and endpoint steering.
+- **Use `EACH_QUORUM`** only for keyspaces that must be durable in every DC before ack; it
+  fails while any DC is down.
+
+---
+
+## 1. Active DC lost (zone/cluster failure)
+
+**Symptoms:** the active DC's nodes are gone/unreachable; writes to the endpoint fail
+briefly until it re-points.
+
+**Automatic:** the surviving DCs **keep accepting reads and writes at `LOCAL_QUORUM` on
+their own**, because each DC acks locally and every DC is already a full writable
+datacenter. There is no promotion and no fence. The orchestrator observes the Lease move
+to a surviving DC and points the single write endpoint there. `phase` moves `FailingOver`
+to `Steady`.
+
+**Verify:**
+
+```bash
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{.status.disasterRecovery.activeDC}'   # the survivor
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status                                   # lost DC's nodes DN/absent
+```
+
+**Action:** none required for availability. Note the RPO: only writes that acked at
+`LOCAL_QUORUM` in the lost DC but had not yet replicated to survivors are at risk
+(recoverable by repair if the DC returns). Keyspaces written at `EACH_QUORUM` lose zero on
+writes that acked. When the failed DC returns, see scenario 8 (re-add a DC).
+
+---
+
+## 2. Network partition between data centers
+
+**Symptoms:** DCs are up but cannot reach each other.
+
+**Automatic:** **both sides keep serving `LOCAL_QUORUM` locally**, because Cassandra is AP
+and each DC acks within itself. There is **no strong split-brain fence**: unlike
+ClickHouse Keeper or Postgres raft, a minority DC is not stopped from committing. Both
+sides may take writes during the partition. On heal, hinted handoff (within the hint
+window) plus anti-entropy `nodetool repair` reconcile divergent writes by last-write-wins
+on cell timestamps. The write endpoint stays on (or the orchestrator moves it to) the DC
+the Lease resolves to.
+
+**Verify both sides are serving and check hint backlog:**
+
+```bash
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} writable:{.writable} hints:{.pendingHints}{"\n"}{end}'
+```
+
+**Action:** heal the network. The DCs re-gossip and reconcile automatically via hinted
+handoff, then run a full cross-DC `nodetool repair` to converge anything beyond the hint
+window. There is no rewind. If the divergence window matters for a keyspace, write it at
+`EACH_QUORUM` so it does not ack during a partition.
+
+---
+
+## 3. Planned switchover (maintenance on the active DC)
+
+**Action:**
+
+```bash
+kubectl annotate cassandra -n demo cas-dcdr dr.kubedb.com/switchover-to=dc-b
+```
+
+**Automatic:** the hub gates on the target's health and hint/repair backlog, then moves
+the Lease and the write endpoint to `dc-b`. Because every DC is already a full writable
+datacenter, this is a routing move: there is no promotion and no engine catch-up gate. For
+a strict zero-loss handoff, drain hints and run a cross-DC `nodetool repair` toward the
+target first so it is fully converged.
+
+**Verify:**
+
+```bash
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{.status.disasterRecovery.activeDC}'  # dc-b
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{.status.disasterRecovery.phase}'     # Steady
+```
+
+**If it does not complete:** see scenario 6 (switchover stuck).
+
+---
+
+## 4. Planned failback to the original DC
+
+After the original DC is healthy and caught up (failback is native: it rejoins by gossip,
+takes hinted handoff, and a cross-DC repair reconciles the rest, with no rewind), steer
+the active DC back:
+
+```bash
+kubectl annotate cassandra -n demo cas-dcdr dr.kubedb.com/switchover-to=dc-a
+```
+
+Same routing-move flow as scenario 3. There is no `pg_rewind` step and no rollback;
+Cassandra reconciles by last-write-wins on cell timestamps. Run a full cross-DC
+`nodetool repair` first if the outage outlasted the hint window.
+
+---
+
+## 5. Arbiter DC lost (even layout only)
+
+**Symptoms:** in an even (`TwoDC`) layout, the Arbiter DC is gone; its `dr-controlplane`
+etcd member is unreachable. (The Arbiter DC runs **no Cassandra**, so no data or ring node
+is affected.)
+
+**Impact:** none on the Cassandra ring; both data DCs keep serving. You lose the tie-break
+etcd vote, so the coordination plane may not be able to move the Lease until the Arbiter
+DC (or its etcd member) returns. In the preferred odd (`ThreeDC`) layout there is no
+Arbiter DC and this scenario does not apply.
+
+**Verify the ring is unaffected and check the coordination plane:**
+
+```bash
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status                                # both data DCs UN
+kubectl --kubeconfig <coord> -n dc-failover get lease primary-dc                         # may be stale
+```
+
+**Action:** restore the Arbiter DC's etcd member to regain the coordination quorum and
+Lease steering. The Cassandra ring needs nothing.
+
+---
+
+## 6. Planned switchover stuck (endpoint not moving)
+
+**Symptoms:** after annotating `switchover-to`, `phase` stays `FailingOver` and the
+endpoint does not move.
+
+**Diagnose:**
+
+```bash
+# Target health and backlog from status:
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} healthy={.healthy} hints={.pendingHints} repair={.repairBacklog}{"\n"}{end}'
+# Ring and streaming from the target DC:
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool netstats
+```
+
+**Causes & action:**
+
+- **Target over the backlog budget** the switchover gates on the target's hint and repair
+  backlog. Drain hints and run a cross-DC `nodetool repair` toward the target so it is
+  converged, then retry.
+- **Target unhealthy** ensure the target DC shows its expected UN nodes in `nodetool
+  status`.
+- **Coordination plane down** the Lease cannot move (see scenario 11); restore it.
+- **Abort** remove the annotation to cancel:
+  `kubectl annotate cassandra -n demo cas-dcdr dr.kubedb.com/switchover-to-`.
+
+---
+
+## 7. A standby DC is lost
+
+**Symptoms:** a non-active DC's nodes are gone; that DC shows `healthy: false` and DN/absent
+nodes in `nodetool status`.
+
+**Impact:** none on writes. The active DC keeps serving `LOCAL_QUORUM` on its own. You lose
+that DC's redundancy and its local read capacity until it returns, plus any keyspace
+written at `EACH_QUORUM` will fail while that DC is down.
+
+**Verify the active DC is serving:**
+
+```bash
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[?(@.writable==true)]}{.clusterName} up:{.upNormalNodes}/{.totalNodes}{end}'
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
+```
+
+**Action:** recover the DC's nodes; they rejoin the ring by gossip and catch up through
+hinted handoff. Run a cross-DC `nodetool repair` after they return if the outage outlasted
+the hint window.
+
+---
+
+## 8. Re-add / recover a previously lost data center
+
+After a DC returns from a failure:
+
+**Automatic:** its nodes rejoin the ring by gossip and take hinted handoff for writes that
+happened within the hint window. There is no rewind and no rollback; Cassandra reconciles
+by last-write-wins on cell timestamps.
+
+**Verify:**
+
+```bash
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} healthy={.healthy} hints={.pendingHints} repair={.repairBacklog}{"\n"}{end}'
+```
+
+**Action:** run a **full cross-DC `nodetool repair`** to reconcile everything beyond the
+hint window:
+
+```bash
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool repair --full
+```
+
+To make the returned DC the active DC again, perform a planned failback (scenario 4) once
+its hints are drained and the repair is complete.
+
+---
+
+## 9. Hint backlog growing (a DC falling behind)
+
+**Symptoms:** `pendingHints` for a DC keeps rising in `status.disasterRecovery`; that DC is
+lagging.
+
+**Impact:** cross-DC replication is behind for that DC, so the RPO window on an unplanned
+loss widens. `LOCAL_QUORUM` reads in the lagging DC may not see the newest writes from
+other DCs yet.
+
+**Verify:**
+
+```bash
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool netstats
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} hints={.pendingHints} repair={.repairBacklog}{"\n"}{end}'
+```
+
+**Action:** relieve the cross-DC bottleneck (WAN bandwidth, node load in the lagging DC).
+If hints are being dropped past `max_hint_window_in_ms`, run a cross-DC `nodetool repair`
+to reconcile. Tune `max_hint_window_in_ms` for the outages you expect to cover with hinted
+handoff.
+
+---
+
+## 10. A DC is unexpectedly rejecting writes
+
+**Symptoms:** a DC you expect to serve writes is rejecting them.
+
+**Diagnose:**
+
+```bash
+# Is this DC the write-routed one, and is it healthy?
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} writable:{.writable} up:{.upNormalNodes}/{.totalNodes}{"\n"}{end}'
+# What DC does the Lease route to?
+kubectl --kubeconfig <coord> -n dc-failover get lease primary-dc -o jsonpath='{.spec.holderIdentity}'
+# Ring health from a node:
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
+```
+
+**Causes & action:**
+
+- **Writing at `EACH_QUORUM` while another DC is down** `EACH_QUORUM` needs a quorum in
+  every DC, so it fails when any DC is down. This is by design. Use `LOCAL_QUORUM` for
+  DC-loss tolerance, or restore the down DC.
+- **Not enough local replicas for `LOCAL_QUORUM`** if too many nodes in the local DC are
+  down, `LOCAL_QUORUM` cannot be met. Recover the DC's nodes (`nodetool status` shows
+  DN).
+- **Not the write-routed DC** applications should use the endpoint `<db>`, which routes to
+  the active DC; writing directly to a standby DC is legitimate for Cassandra but changes
+  your single-writer posture.
+
+Cassandra will not block a write for lack of a cross-DC vote; a write failure here is a
+local-replica or consistency-level issue, not a fence.
+
+---
+
+## 11. Coordination plane (dr-controlplane / etcd) unavailable
+
+**Symptoms:** the Lease cannot be read/renewed across the spokes.
+
+**Automatic:** Cassandra keeps running on its own, so the ring stays writable in every DC
+and the endpoint stays where it last resolved; the Lease is routing, not the failover
+mechanism, so its loss does not stop writes. What you lose is **endpoint steering and
+planned switchover**: the orchestrator cannot move the active DC until the Lease quorum
+returns.
+
+**Verify:**
+
+```bash
+kubectl --kubeconfig <coord> -n dc-failover get lease primary-dc   # error / stale
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status          # ring still serving
+```
+
+**Action:** restore the `dr-controlplane` etcd quorum (in the even layout its third member
+is in the Arbiter DC). Once the Lease is renewable, endpoint steering and switchover
+resume.
+
+---
+
+## 12. Suspected data divergence after a partition
+
+Cassandra is AP: during a partition, both sides can accept `LOCAL_QUORUM` writes, so
+divergence is expected and reconciled after the fact, not prevented. This is not a bug and
+not the same as ClickHouse or Postgres split-brain (there is no committed-log fork to
+repair, only cell values reconciled by timestamp).
+
+**Diagnose:**
+
+```bash
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool netstats
+kubectl get cassandra -n demo cas-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} hints={.pendingHints} repair={.repairBacklog}{"\n"}{end}'
+```
+
+**Action:** let hinted handoff drain, then run a **full cross-DC `nodetool repair`** to
+reconcile all replicas; the newest cell wins by timestamp. For data that must never
+diverge across a partition, write it at `EACH_QUORUM` (it will not ack during a partition)
+and read it at a consistency level that spans DCs.
+
+```bash
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool repair --full
+```
+
+---
+
+## Escalation checklist
+
+When unsure, collect:
+
+```bash
+kubectl get cassandra -n demo cas-dcdr -o yaml
+kubectl --kubeconfig <coord> -n dc-failover get lease -o yaml
+kubectl get pods -n demo -l app.kubernetes.io/instance=cas-dcdr -L open-cluster-management.io/cluster-name -o wide
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool status
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool netstats
+kubectl exec -n demo cas-dcdr-rack-a-0 -- nodetool gossipinfo
+```


### PR DESCRIPTION
Adds the Cassandra cross data center disaster recovery (DC-DR) documentation, mirroring the ClickHouse DR docs but rewritten for Cassandra's masterless, geo-native model.

## Files added

- `docs/guides/cassandra/dr/_index.md` : the DR section menu entry (identifier `cas-dr-cassandra`, parent `cas-cassandra-guides`, weight 55).
- `docs/guides/cassandra/dr/overview/index.md` : concepts and architecture plus a quick start. One masterless ring across DCs, each Member DC a full Cassandra datacenter, `NetworkTopologyStrategy` continuous replication, the Lease routes and observes only (no promotion, no fence), `LOCAL_QUORUM` vs `EACH_QUORUM` as the correctness tradeoff, engine-free Arbiter DC only for an even data-DC count, 3-DC odd layout example.
- `docs/guides/cassandra/dr/guide/index.md` : full user guide (components, DC-name contract, deployment, keyspaces with `NetworkTopologyStrategy`, connecting through the single endpoint, consistency levels, `status.disasterRecovery` with per-DC UN node counts and hint/repair backlog as the lag proxy, switchover as a routing move, repair-based failback with no rewind, per-DC day-2 ops).
- `docs/guides/cassandra/dr/runbook/index.md` : scenario-by-scenario operational procedures (active DC loss, partition, switchover, failback, standby loss, hint backlog, unexpected write rejection, coordination plane loss, post-partition divergence).

Also wires a DC-DR link into `docs/guides/cassandra/README.md`, matching the ClickHouse README pattern.

## Cassandra-specific adaptation

These docs reflect Cassandra's actual semantics, not ClickHouse's: masterless leaderless ring with gossip membership, the Lease routes and observes only (active-active writes are legitimate), consistency level (`LOCAL_QUORUM`, `EACH_QUORUM`) is the correctness knob rather than a fence, a partitioned DC keeps serving `LOCAL_QUORUM` (AP), and failback reconciles via hinted handoff plus `nodetool repair` with no rewind (last-write-wins by timestamp). ClickHouse Keeper / ReplicatedMergeTree / shard language is replaced with Cassandra ring / gossip / NetworkTopologyStrategy / racks / nodetool language.

Front-matter follows existing cassandra docs conventions (`cas-` identifier prefix, `docs_{{ .version }}` menu, `cas-cassandra-guides` parent).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new Cassandra “Cross–data center disaster recovery (DC-DR)” documentation.
  * Published DC-DR overview, deployment/operation guide, and a comprehensive runbook.

* **Documentation**
  * Expanded guidance on DC-DR components, topology/replica placement requirements, and keyspace replication configuration.
  * Added details on read/write behavior, consistency-level correctness, monitoring via `status.disasterRecovery`, and operational troubleshooting (including switchover/failback, scaling, and cleanup).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->