### PR TITLE
Add RabbitMQ cross data center disaster recovery (DC-DR) docs

### DIFF
--- a/docs/guides/rabbitmq/dr/_index.md
+++ b/docs/guides/rabbitmq/dr/_index.md
@@ -1,0 +1,10 @@
+---
+title: Disaster Recovery
+menu:
+  docs_{{ .version }}:
+    identifier: rm-dr-rabbitmq
+    name: DR
+    parent: rm-guides
+    weight: 115
+menu_name: docs_{{ .version }}
+---

--- a/docs/guides/rabbitmq/dr/guide/index.md
+++ b/docs/guides/rabbitmq/dr/guide/index.md
@@ -1,0 +1,346 @@
+---
+title: DC-DR User Guide
+menu:
+  docs_{{ .version }}:
+    identifier: rm-dr-guide-rabbitmq
+    name: User Guide
+    parent: rm-dr-rabbitmq
+    weight: 20
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+# Running RabbitMQ in DC-DR Mode: User Guide
+
+This guide covers every aspect of operating a distributed RabbitMQ in cross data center
+disaster recovery (DC-DR) mode: the components, the naming contract, deployment, what
+the operator creates, publishing to the active endpoint, consumers resuming after a
+flip, monitoring federation lag, the publish fence, switchover, failback, scaling, and
+day-2 operations.
+
+Read the [DC-DR Overview](/docs/guides/rabbitmq/dr/overview/index.md) first for the
+architecture, and the [DC-DR Runbook](/docs/guides/rabbitmq/dr/runbook/index.md) for
+scenario-by-scenario procedures.
+
+> **New to KubeDB?** Please start [here](/docs/README.md).
+
+## Components and where they run
+
+| Component | Runs in | Responsibility |
+| --- | --- | --- |
+| **`dr-controlplane`** + 3-site etcd quorum | across the data centers (an OCM control plane) | Publishes one `coordination.k8s.io` **Lease** per failover scope. The Lease holder is the active publish DC. This is the single cross-DC failover authority. |
+| **`dr-controlplane` agent** | each spoke (DC) | Contends for the primary-DC Lease for its DC and projects the Lease decision into the local spoke as the primary-dc marker the publish fence reads. |
+| **KubeDB RabbitMQ operator (hub)** | the OCM hub | Expands the `RabbitMQ` CR into per-DC RabbitMQ clusters and the Federation upstreams and policies on the standby. On a Lease change it flips the AMQP endpoint, reverses the federation direction, and moves the publish fence, then writes `status.disasterRecovery`. |
+| **Per-DC RabbitMQ clusters** | each Member DC | Each is a self-contained RabbitMQ with its own intra-DC nodes and quorum-queue Raft groups. Raft never crosses the DC boundary. |
+| **Federation upstreams and policies** | on the standby DC | One upstream on the standby cluster pulling from the active cluster's endpoint, plus the policies that mark which exchanges and queues are federated, mirroring active to standby. |
+| **The publish fence** | each Member DC | Denies client publishes on a non-active cluster, fail closed, so only the Lease holder takes publishes. |
+| **KubeSlice (or external listeners)** | each spoke | Provides the flat cross-DC pod network so Federation can reach the remote cluster and the AMQP endpoint resolves across DCs. |
+
+## The DC-name contract
+
+One string identifies a data center everywhere. **Keep these identical:**
+
+- the OCM spoke cluster name
+- the agent `--dc-name`
+- the primary-DC Lease `holderIdentity`
+- the marker `data.activeDC`
+- the pod label `open-cluster-management.io/cluster-name`
+- the `PlacementPolicy` `distributionRule.clusterName`
+
+## Deploying
+
+### PlacementPolicy
+
+Map the global pod ordinals to data centers and tag each DC with its role:
+
+```yaml
+apiVersion: apps.k8s.appscode.com/v1
+kind: PlacementPolicy
+metadata:
+  name: rm-dcdr
+spec:
+  clusterSpreadConstraint:
+    slice:
+      projectNamespace: kubeslice-demo
+      sliceName: demo-slice
+    failoverPolicy:
+      mode: TwoDC          # two Member DCs plus an Arbiter DC
+      trigger:
+        scope: Global      # one cluster-wide failover scope
+    distributionRules:
+    - clusterName: dc-a
+      role: Member
+      replicaIndices: [0, 1, 2]
+    - clusterName: dc-b
+      role: Member
+      replicaIndices: [3, 4, 5]
+    - clusterName: dc-c
+      role: Arbiter
+      replicaIndices: []
+```
+
+- A data-bearing **Member** rule carries `replicaIndices` that map to a self-contained
+  RabbitMQ cluster with its own quorum-queue Raft. The **Arbiter** DC carries an empty
+  `replicaIndices` and holds only the `dr-controlplane` etcd member, never RabbitMQ.
+- `mode: TwoDC` expects exactly two Member DCs plus the Arbiter DC. Three or more data
+  DCs is a separate design and out of scope.
+- Roles are `Member` and `Arbiter` only.
+
+### RabbitMQ
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: RabbitMQ
+metadata:
+  name: rm-dcdr
+  namespace: demo
+spec:
+  version: "3.13.2"
+  distributed: true
+  replicas: 6
+  storageType: Durable
+  podTemplate:
+    spec:
+      podPlacementPolicy:
+        name: rm-dcdr
+  storage:
+    accessModes: [ReadWriteOnce]
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+### What the operator creates
+
+- **One self-contained RabbitMQ cluster per Member DC** (`rm-dcdr` materialized into a
+  cluster in `dc-a` and a cluster in `dc-b`), each with its own nodes and quorum-queue
+  Raft groups. The two clusters never share a Raft group. `spec.replicas: 6` is the
+  total node count across both Member DCs; the `replicaIndices` split it into a
+  three-node cluster per DC (ordinals 0, 1, 2 in `dc-a` and 3, 4, 5 in `dc-b`).
+- **Federation upstreams and policies on the standby cluster**, because a federation
+  upstream lives on the target (standby) side and pulls from the active source. The
+  reverse-direction upstream stays defined but disabled until a failover needs it.
+- **The Lease-gated AMQP Service** that resolves to the active cluster's nodes.
+
+RabbitMQ Federation is configured through runtime parameters (the upstream) and a
+policy (which resources federate). There is no KubeDB `Connector` CRD for RabbitMQ: the
+operator manages the federation runtime parameters and policies directly on the standby
+cluster (they ride on the broker configuration and the management/federation endpoint).
+Conceptually the operator defines, on the standby cluster (`dc-b` while `dc-a` is
+active), a federation upstream pointing at the active cluster:
+
+```jsonc
+// federation upstream parameter, set by the operator on the standby (dc-b) cluster
+{
+  "component": "federation-upstream",
+  "name": "dcdr-upstream-from-dc-a",
+  "value": {
+    // the active cluster's Lease-routed AMQP endpoint
+    "uri": "amqp://rm-dcdr-dc-a.demo.svc:5672",
+    "ack-mode": "on-confirm",
+    "trust-user-id": false
+  }
+}
+```
+
+and a policy selecting which queues federate from that upstream:
+
+```jsonc
+// federation policy, set by the operator on the standby (dc-b) cluster
+{
+  "name": "dcdr-federation",
+  "pattern": "^(?!amq\\.).*",        // federate user queues and exchanges
+  "apply-to": "queues",
+  "definition": {
+    "federation-upstream-set": "dcdr-upstream-from-dc-a"
+  }
+}
+```
+
+The operator owns these federation parameters and policies so the direction stays
+operator-controlled and the two directions never overlap. Use quorum queues on both
+clusters so intra-DC HA survives node loss; classic queues are non-replicated and
+provide no intra-DC redundancy.
+
+## Connecting and publishing
+
+A DC-DR RabbitMQ exposes one user-facing **AMQP Service** that resolves to the active
+cluster's nodes. Publishers and consumers always connect to that single endpoint and
+reach the publish cluster without reconfiguration. Because Federation preserves queue
+and exchange names on both clusters, after the endpoint flips clients keep using the
+same queues.
+
+```bash
+# Publish to the active cluster through the single AMQP endpoint:
+$ kubectl run perf-test -n demo --image=pivotalrabbitmq/perf-test -- \
+    --uri "amqp://admin:password@rm-dcdr.demo.svc:5672/" --queue orders --quorum-queue
+```
+
+Only the active cluster accepts client publishes. If clients somehow reach a standby
+cluster, its publish fence rejects the write (see below), which is the split-brain
+guard. AMQP is on port 5672; inter-node traffic is on 25672; the management and
+federation endpoint is on 15672.
+
+### Consumers resume after a flip
+
+Federation replicates messages (and, with the right upstream settings, acknowledgements)
+into the standby cluster's queues, so after a failover or switchover a consumer
+reconnecting through the flipped endpoint finds its queues and resumes from the
+federated state on the new active cluster rather than re-reading from the beginning.
+Because Federation is asynchronous and does not deduplicate across the flip, a
+just-failed-over consumer can see a small window of redelivered messages: make consumers
+idempotent, or apply a dedup window across the flip.
+
+## Monitoring and observability
+
+### status.disasterRecovery
+
+The single CR carries the whole cross-DC view:
+
+```bash
+$ kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{.status.disasterRecovery}' | jq
+```
+
+| Field | Meaning |
+| --- | --- |
+| `activeDC` | The DC that holds the Lease and takes client publishes. |
+| `phase` | `Steady`, `FailingOver`, `FailingBack`, or `Degraded`. |
+| `lastTransitionTime` | When `activeDC` last changed. |
+| `dataCenters[].clusterName` | The data center, by its OCM managed cluster name. |
+| `dataCenters[].role` | `Member` or `Arbiter`. |
+| `dataCenters[].writable` | True only for the active cluster. |
+| `dataCenters[].nodesReady` | Ready RabbitMQ node count in that DC's cluster. |
+| `dataCenters[].federationLagMessages` | The standby's federation backlog behind the active, in messages. |
+| `dataCenters[].healthy` | DC health: a Member DC is healthy when its nodes are ready; the Arbiter DC is healthy when its `dr-controlplane` etcd member is reachable (so an Arbiter reports `healthy: true` with `nodesReady: 0`). |
+
+### Federation lag
+
+Cross-DC lag comes from Federation's own view: the gap between the active (upstream)
+cluster's position and the standby (downstream) cluster's position for the federated
+resources, exposed through the management/federation endpoint (federation link status
+and per-queue message counts). The hub surfaces this into `federationLagMessages`; there
+is no lag field in the base `RabbitMQStatus`.
+
+### Useful checks
+
+```bash
+# Which DC the Lease intends as active (from the coordination plane):
+$ kubectl --kubeconfig <coord> -n dc-failover get lease primary-dc \
+    -o jsonpath='{.spec.holderIdentity}'
+
+# Per-DC nodes and roles:
+$ kubectl get pods -n demo -l app.kubernetes.io/instance=rm-dcdr \
+    -L kubedb.com/role,open-cluster-management.io/cluster-name
+
+# Federation link status on the standby cluster (via rabbitmqctl):
+$ kubectl exec -n demo rm-dcdr-dc-b-0 -- rabbitmqctl list_federation_links
+```
+
+## The publish fence
+
+A non-active cluster must refuse client publishes, fail closed: a cluster that cannot
+confirm it holds the Lease denies publishes. There are two fence mechanisms.
+
+- **Permission fence:** revoke the `write` (configure/write/read) permission for the
+  CLIENT users on the non-active cluster's virtual hosts, so client channels cannot
+  publish. This requires the operator to manage per-user permissions per cluster.
+- **Listener-gate fence:** gate the AMQP client listener (5672) on the non-active cluster
+  so publishers cannot connect at all. This is the default-posture fence when
+  per-user permission management is not in play.
+
+DC-DR requires one of the two. Two rules keep the fence from breaking replication:
+
+- **Never fence the federation user.** The fence must target only client users.
+  Fencing the user the federation upstream authenticates as (or the operator's
+  management user) would break replication along with client publish.
+- **Do not federate the fence state.** The fence is per-cluster runtime state (revoked
+  permissions or a gated listener). Do not let a synced-definitions or policy import
+  path copy the active cluster's client permissions onto the standby and re-grant
+  publish there, undoing the fence. The operator manages client permissions per cluster.
+
+## Planned switchover (drained, zero message loss)
+
+Move the active DC on purpose by annotating the RabbitMQ:
+
+```bash
+$ kubectl annotate rabbitmq -n demo rm-dcdr dr.kubedb.com/switchover-to=dc-b
+```
+
+The hub then:
+
+1. checks the target is a known, healthy DC within the federation lag budget;
+2. sets `phase: FailingOver` and quiesces publishers by closing the active cluster's
+   publish fence;
+3. waits for Federation to drain to near-zero lag, so the target holds every message;
+4. flips the AMQP endpoint to the target, opens the target's fence, and reverses the
+   federation direction (tears down the old direction's upstream, then sets up the new
+   direction's on the other DC's cluster), never both at once;
+5. moves the Lease to the target.
+
+Because Federation fully drained before the flip, no confirmed message is lost. This is
+a hub-driven annotation, not a `RabbitMQOpsRequest` type: the engine-aware quiesce and
+federation drain run in the hub, not in the engine-agnostic `dr-controlplane`.
+
+## Failback
+
+Failback is not a rewind. When a failed DC returns, it becomes the Federation target of
+the new active. The messages it accepted but never federated before the failover are a
+forked tail RabbitMQ cannot rewind, and because Federation only adds and never deletes,
+a naive re-federation leaves those orphan messages on top of the new active's data (and
+they could resurface if that DC is ever made active again). For correctness:
+
+- **re-seed the affected queues from the new active** (purge the returned cluster's copy
+  and re-federate from scratch), or
+- **accept and document the orphan tail** as bounded loss, and make consumers idempotent
+  (or apply a dedup window) across the flip.
+
+Once the returned DC is caught up, a drained planned switchover returns the active DC:
+
+```bash
+$ kubectl annotate rabbitmq -n demo rm-dcdr dr.kubedb.com/switchover-to=dc-a
+```
+
+## Scaling and day-2 operations
+
+The standard `RabbitMQOpsRequest` operations (`UpdateVersion`, `HorizontalScaling`,
+`VerticalScaling`, `VolumeExpansion`, `Restart`, `Reconfigure`, `ReconfigureTLS`,
+`RotateAuth`) apply to a DC-DR cluster. They act on the per-DC RabbitMQ clusters.
+Horizontal scaling operates per DC (each Member DC's cluster scales its own nodes and
+handles quorum-queue membership intra-DC), so a scaling request targets the data centers
+rather than a single flat node set.
+
+There is no failover ops type: unplanned failover is driven by the Lease, and the
+planned switchover is the `dr.kubedb.com/switchover-to` annotation, not an ops request.
+
+> **Note:** the distributed RabbitMQ substrate and the DC-DR layer are net-new for
+> RabbitMQ. Treat the field names and flows in this guide as the intended user
+> experience; confirm availability in your release before relying on them in production.
+
+## Deletion and cleanup
+
+```bash
+$ kubectl delete rabbitmq -n demo rm-dcdr
+```
+
+Per `deletionPolicy`, the operator removes the per-DC RabbitMQ clusters, the
+operator-managed Federation upstreams and policies, and the cluster-scoped per-DC
+`PlacementPolicies` it generated (these carry no owner reference, so the operator
+deletes them explicitly). The user-provided base `PlacementPolicy` is left for you to
+delete.
+
+## Limitations
+
+- **No zero-RPO on an unplanned failover.** Federation is asynchronous, so an unplanned
+  active-DC loss loses the un-federated tail (bounded by federation lag). Use a drained
+  planned switchover for a zero-message-loss move.
+- **No rewind on failback.** A returned old-active cluster's un-federated forked tail
+  cannot be rewound. Re-seed the affected queues or accept the orphan tail as bounded
+  loss, and make consumers idempotent across the flip.
+- **Two data DCs only.** Active/passive Federation is inherently two-cluster. Three or
+  more data DCs (fan-out federation, three-way failover) is a separate, larger design.
+- **Cross-DC reachability is required.** RabbitMQ advertises in-cluster `.svc`
+  endpoints, so Federation and the cross-DC AMQP endpoint need flat pod networking
+  (KubeSlice) or external listeners.
+- **Use quorum queues.** Only quorum queues replicate intra-DC and survive node loss;
+  classic queues are non-replicated and are not covered by the intra-DC HA guarantee.

--- a/docs/guides/rabbitmq/dr/overview/index.md
+++ b/docs/guides/rabbitmq/dr/overview/index.md
@@ -1,0 +1,305 @@
+---
+title: DC-DR Overview
+menu:
+  docs_{{ .version }}:
+    identifier: rm-dr-overview-rabbitmq
+    name: Overview
+    parent: rm-dr-rabbitmq
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+# Cross Data Center Disaster Recovery (DC-DR) for RabbitMQ
+
+KubeDB can run a single distributed `RabbitMQ` across two data centers (DCs) so a
+RabbitMQ workload survives the loss of an entire data center. Exactly one DC is the
+active publish cluster at any instant. The other DC runs a self-contained standby
+cluster that receives an asynchronous replica of the active cluster's messages. When
+the active DC is lost, the single AMQP publish endpoint is flipped to the standby, the
+standby is allowed to take client publishes, and clients continue against identical
+queue and exchange names.
+
+This page is the conceptual overview and a quick start. See also:
+
+- [DC-DR User Guide](/docs/guides/rabbitmq/dr/guide/index.md) for every aspect of
+  running in DC-DR mode (components, the naming contract, connecting, monitoring, the
+  publish fence, switchover, failback, day-2 ops).
+- [DC-DR Runbook](/docs/guides/rabbitmq/dr/runbook/index.md) for what to do in each
+  operational scenario.
+
+> **New to KubeDB?** Please start [here](/docs/README.md).
+
+## Why RabbitMQ DC-DR is its own camp
+
+Most KubeDB engines have a single writable primary and a leader-to-leader replication
+stream. Postgres promotes a survivor, MongoDB elects a new primary, and the endpoint
+follows the writable node. **RabbitMQ has none of that.**
+
+RabbitMQ is not a single-writer database. A quorum queue has its own Raft group with a
+per-queue leader among that queue's replicas, inside one cluster. There is no
+cluster-wide primary, and the quorum queue's own Raft already handles queue leadership
+intra-cluster (majority via the pod disruption budget). So the single-primary DR
+pattern (one writable leader, a leader-to-leader stream, promote the survivor) does not
+map. For RabbitMQ:
+
+- **Cross-DC replication is asynchronous message replication, not a leader stream.**
+  RabbitMQ's built-in **Federation** plugin (or the **Shovel** plugin) copies messages
+  from exchanges and queues on a source cluster to a target cluster. Both are open
+  source (not Enterprise) and are pre-enabled in the KubeDB RabbitMQ image. There is no
+  new replication engine to build.
+- **The active DC is a publish-endpoint routing decision, not an engine state.**
+  Publishers write to whichever cluster the clients are pointed at. DR is
+  active/passive: one cluster takes publishes, Federation replicates them to the
+  standby, and on failover the clients are redirected. The `dr-controlplane` Lease
+  decides which cluster is the publish target; a local publish fence stops clients
+  writing to a non-active cluster.
+- **There is no rewind and no zero-RPO.** Federation is asynchronous, so an unplanned
+  failover loses the un-federated tail (bounded by federation lag), and a returned
+  old-active cluster may hold messages that were never federated. RabbitMQ cannot
+  rewind a queue. Failback reverses the federation direction and reconciles or accepts
+  the un-federated tail as bounded loss.
+
+So RabbitMQ DC-DR is two independent RabbitMQ clusters (one per Member DC), each with
+its own intra-DC quorum-queue Raft, joined by asynchronous Federation, with the Lease
+choosing the publish cluster and a publish fence preventing split writes.
+
+## How it works
+
+DC-DR for RabbitMQ rests on five rules.
+
+- **Quorum-queue Raft stays intra-DC.** Each Member DC runs its own self-contained
+  RabbitMQ cluster: its own nodes, its own quorum queues, and each queue's own Raft
+  group. The Raft group never crosses the DC boundary, so inter-DC latency or a
+  partition can never flap queue leadership or stall a queue. There is no cross-DC
+  RabbitMQ voter. Use quorum queues (not classic queues) so intra-DC HA survives node
+  loss; classic queues are non-replicated.
+- **The active cluster is chosen only by the `dr-controlplane` primary-DC Lease.** A
+  small control plane, backed by a three-site etcd quorum, publishes one Lease per
+  failover scope. The Lease holder is the active publish DC. Exactly one cluster is the
+  publish target at any instant.
+- **Cross-DC replication is Federation, active to standby.** A federation upstream on
+  the standby cluster pulls messages from the active cluster's exchanges and queues
+  asynchronously. One cross-DC link carries each federated resource, and the intra-DC
+  quorum-queue replicas fan out locally (the WAN one-copy rule). The upstream points at
+  the active cluster's Lease-routed endpoint, so an intra-active-DC queue-leader change
+  is transparent to the standby. Because a federation direction is one way (upstream on
+  the standby, pulling from the active), the operator enables only the active-to-standby
+  direction and never both directions at once. A failover swaps which DC holds the
+  active upstream.
+- **Writability is gated by the Lease and fenced locally, fail closed.** A non-active
+  cluster must refuse client publishes. The fence, driven by the primary-dc marker,
+  denies the publish operation on the non-active cluster (revokes the publish
+  permission or gates the AMQP listener) and fails closed: a cluster that cannot confirm
+  it holds the Lease denies publishes. This local fence, plus the etcd majority, is the
+  split-brain guarantee. Without it a partitioned old-active cluster that still sees
+  publishers would keep accepting messages that never federate, diverging the two
+  clusters.
+- **One AMQP endpoint follows the active cluster.** The single user-facing AMQP Service
+  resolves to the active cluster's nodes (selected by the Lease), so publishers and
+  consumers always reach the publish cluster. Because Federation preserves queue and
+  exchange names on both clusters, after the endpoint flips clients keep using the same
+  queues and resume from the federated state.
+
+> **Why never both directions at once?** Federation moves messages between two clusters
+> without a rename loop guard. If both federation directions overlap, the same message
+> can ping-pong between the two clusters. A failover therefore disables the old
+> direction's upstream before (or atomically with) enabling the new direction's.
+
+### Data center roles
+
+Each DC plays one role, set on the `PlacementPolicy` `distributionRule.role`:
+
+| Role | Holds RabbitMQ | Purpose |
+| --- | --- | --- |
+| **Member** | yes | A self-contained RabbitMQ cluster with its own quorum-queue Raft. One Member is the active publish cluster; the other is the Federation target while standby. |
+| **Arbiter** | no | The arbiter DC. Holds only the `dr-controlplane` etcd member and never RabbitMQ, because RabbitMQ has no cross-DC voter. Supplies the tie-break etcd vote. |
+
+## The single-CR, single-endpoint model
+
+The user creates **one** distributed `RabbitMQ` object (with `spec.distributed` and a
+`PlacementPolicy` carrying `distributionRules` and a `failoverPolicy`) and gets **one**
+AMQP endpoint. The operator expands the CR across the data centers:
+
+- one self-contained **`RabbitMQ`** cluster per Member DC, each with its own intra-DC
+  quorum-queue Raft;
+- operator-managed **Federation upstreams and policies** wiring the active cluster to
+  the standby (active-to-standby direction only);
+- the Lease-gated AMQP publish endpoint plus the local publish fence.
+
+The single CR's `status.disasterRecovery` carries the whole cross-DC view: the active
+DC, each cluster's node health, the federation lag, and the DR phase.
+
+> **Scope.** This spec targets the even two-data-DC layout (two Member DCs plus an
+> Arbiter DC). Active/passive Federation is inherently two-cluster, so spanning three or
+> more data DCs (fan-out federation and a three-way failover) is a separate, larger
+> design and is out of scope here.
+
+## Prerequisites
+
+- A distributed RabbitMQ substrate: an Open Cluster Management (OCM) hub and spoke
+  clusters, and **flat cross-DC pod networking (KubeSlice) or external listeners**.
+  RabbitMQ nodes advertise in-cluster `.svc` endpoints, so Federation's cross-cluster
+  reach and the cross-DC publish endpoint need routable connectivity between the
+  clusters. Wiring the endpoints for cross-DC reach is part of the DC-DR setup.
+- The `dr-controlplane` service and its three-site etcd quorum installed across the
+  data centers, with a `dr-controlplane` agent in each spoke (DC). The third etcd
+  member sits in the Arbiter DC.
+- The KubeDB RabbitMQ operator started with the DC-DR flags (coordination kubeconfig and
+  the operator's local DC name).
+- One consistent **DC name** per data center, used everywhere: the OCM spoke cluster
+  name, the agent `--dc-name`, the Lease `holderIdentity`, the marker `activeDC`, the
+  pod label `open-cluster-management.io/cluster-name`, and the `PlacementPolicy`
+  `distributionRule.clusterName`. Keep them identical.
+
+## Deploy a DC-DR RabbitMQ
+
+### 1. PlacementPolicy
+
+Assign global pod ordinals to data centers and tag each DC with its role. Here two
+Member DCs (`dc-a`, `dc-b`) each hold a three-node RabbitMQ cluster, and `dc-c` is the
+Arbiter DC:
+
+```yaml
+apiVersion: apps.k8s.appscode.com/v1
+kind: PlacementPolicy
+metadata:
+  name: rm-dcdr
+spec:
+  clusterSpreadConstraint:
+    slice:
+      projectNamespace: kubeslice-demo
+      sliceName: demo-slice
+    failoverPolicy:
+      mode: TwoDC
+      trigger:
+        scope: Global
+    distributionRules:
+    - clusterName: dc-a
+      role: Member
+      replicaIndices: [0, 1, 2]
+    - clusterName: dc-b
+      role: Member
+      replicaIndices: [3, 4, 5]
+    - clusterName: dc-c
+      role: Arbiter
+      replicaIndices: []
+```
+
+- A data-bearing **Member** rule carries `replicaIndices` mapping its ordinals to a
+  self-contained RabbitMQ cluster. The **Arbiter** DC carries an empty `replicaIndices`
+  and holds no RabbitMQ, only the `dr-controlplane` etcd member.
+- `failoverPolicy.mode: TwoDC` expects two Member DCs plus the Arbiter DC.
+- `failoverPolicy.trigger.scope: Global` makes this one cluster-wide failover scope.
+
+### 2. RabbitMQ
+
+Reference the `PlacementPolicy` and opt the RabbitMQ into DC-DR expansion:
+
+```yaml
+apiVersion: kubedb.com/v1alpha2
+kind: RabbitMQ
+metadata:
+  name: rm-dcdr
+  namespace: demo
+spec:
+  version: "3.13.2"
+  distributed: true
+  replicas: 6
+  storageType: Durable
+  podTemplate:
+    spec:
+      podPlacementPolicy:
+        name: rm-dcdr
+  storage:
+    accessModes: [ReadWriteOnce]
+    resources:
+      requests:
+        storage: 1Gi
+  deletionPolicy: WipeOut
+```
+
+`spec.replicas: 6` is the total node count across both Member DCs. The `PlacementPolicy`
+`replicaIndices` split it into a three-node cluster in `dc-a` (ordinals 0, 1, 2) and a
+three-node cluster in `dc-b` (ordinals 3, 4, 5). The operator expands this into one
+self-contained RabbitMQ cluster in `dc-a` and one in `dc-b`, and wires the Federation
+upstreams and policies on the standby cluster to replicate the active cluster into the
+standby.
+
+## Observe the DC-DR state
+
+The single `RabbitMQ` object's `status.disasterRecovery` carries the whole cross-DC
+view:
+
+```bash
+$ kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{.status.disasterRecovery}' | jq
+```
+
+```json
+{
+  "activeDC": "dc-a",
+  "phase": "Steady",
+  "lastTransitionTime": "2026-06-30T10:00:00Z",
+  "dataCenters": [
+    { "clusterName": "dc-a", "role": "Member",  "writable": true,  "nodesReady": 3, "federationLagMessages": 0,    "healthy": true },
+    { "clusterName": "dc-b", "role": "Member",  "writable": false, "nodesReady": 3, "federationLagMessages": 1200, "healthy": true },
+    { "clusterName": "dc-c", "role": "Arbiter", "writable": false, "nodesReady": 0, "federationLagMessages": 0,    "healthy": true }
+  ]
+}
+```
+
+- `activeDC` is the DC that holds the Lease and takes client publishes.
+- `phase` is `Steady`, `FailingOver`, `FailingBack`, or `Degraded`.
+- Each `dataCenters` entry reports the DC role, whether it is the writable cluster, how
+  many nodes are ready, its federation lag in messages (the standby's backlog behind the
+  active), and its health.
+
+## Unplanned failover
+
+When the active DC is lost, the standby is already a near-current Federation replica.
+The orchestrator observes the Lease move to the standby, flips the AMQP endpoint to the
+standby's nodes, opens the standby's publish fence, and reverses the federation
+direction (tearing down the old active's upstream if it is reachable, and setting up the
+survivor's upstream for when the old DC returns).
+`status.disasterRecovery.phase` moves to `FailingOver` and back to `Steady`.
+
+The RPO is the un-federated tail: messages the active cluster accepted but had not yet
+federated when it died are lost. There is no rewind.
+
+## Planned switchover (drained, zero message loss)
+
+To move the active DC on purpose without losing messages, annotate the RabbitMQ with the
+target DC:
+
+```bash
+$ kubectl annotate rabbitmq -n demo rm-dcdr dr.kubedb.com/switchover-to=dc-b
+```
+
+The orchestrator quiesces publishers by closing the active cluster's publish fence,
+waits for Federation to drain to near-zero lag (so the target has every message), then
+flips the AMQP endpoint, opens the target's fence, and reverses the federation
+direction. Because Federation has fully drained before the flip, no confirmed message is
+lost. The Lease then follows to `dc-b`.
+
+## Failback
+
+Failback is not a rewind. A returned old-active cluster becomes the Federation target of
+the new active. Messages it accepted but never federated before the failover are a
+forked tail RabbitMQ cannot rewind, and because Federation only adds and never deletes,
+a naive re-federation leaves those orphan messages on top of the new active's data. For
+correctness, re-seed the affected queues from the new active (purge and re-federate) or
+accept and document the orphan tail as bounded loss, and make consumers idempotent (or
+apply a dedup window) across the flip. Once the returned DC is caught up, a drained
+planned switchover returns the active DC.
+
+## Cleanup
+
+```bash
+$ kubectl delete rabbitmq -n demo rm-dcdr
+$ kubectl delete placementpolicy rm-dcdr
+```
+
+Deleting the `RabbitMQ` removes the per-DC RabbitMQ clusters, the operator-managed
+Federation upstreams and policies, and the generated cluster-scoped per-DC
+`PlacementPolicies` (which carry no owner reference, so the operator deletes them
+explicitly). The user-provided base `PlacementPolicy` is left for you to delete.

--- a/docs/guides/rabbitmq/dr/runbook/index.md
+++ b/docs/guides/rabbitmq/dr/runbook/index.md
@@ -1,0 +1,346 @@
+---
+title: DC-DR Runbook
+menu:
+  docs_{{ .version }}:
+    identifier: rm-dr-runbook-rabbitmq
+    name: Runbook
+    parent: rm-dr-rabbitmq
+    weight: 30
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+---
+
+# RabbitMQ DC-DR Runbook
+
+Scenario-by-scenario procedures for operating a RabbitMQ workload in cross data center
+disaster recovery (DC-DR) mode. Each scenario lists the **symptoms**, what KubeDB does
+**automatically**, how to **verify**, and the **action** to take.
+
+Read the [User Guide](/docs/guides/rabbitmq/dr/guide/index.md) for the concepts and
+commands referenced here. Throughout, `<coord>` is the coordination control plane
+kubeconfig, and `rm-dcdr`/`demo` are the example database and namespace.
+
+> **New to KubeDB?** Please start [here](/docs/README.md).
+
+## Quick reference
+
+```bash
+# Active DC, phase, and per-DC view:
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{.status.disasterRecovery}' | jq
+
+# Lease holder (the DC the coordination plane makes the active publish cluster):
+kubectl --kubeconfig <coord> -n dc-failover get lease primary-dc -o jsonpath='{.spec.holderIdentity}'
+
+# Per-DC nodes, roles, and DCs:
+kubectl get pods -n demo -l app.kubernetes.io/instance=rm-dcdr -L kubedb.com/role,open-cluster-management.io/cluster-name
+
+# Federation link status on the standby cluster:
+kubectl exec -n demo rm-dcdr-dc-b-0 -- rabbitmqctl list_federation_links
+```
+
+Golden rules:
+
+- **The Lease decides the active publish cluster.** Exactly one DC is `writable: true`
+  in `status.disasterRecovery` at any instant.
+- **The publish fence fails closed.** A cluster that cannot confirm it holds the Lease
+  denies client publishes, so a partitioned old-active cluster stops taking publishes on
+  its own.
+- **Federation is asynchronous.** An unplanned failover loses the un-federated tail
+  (bounded by federation lag). Only a drained planned switchover is zero message loss.
+- **Never enable both federation directions at once** and never fence the federation
+  user or the management user.
+
+---
+
+## 1. Intra-DC node loss (single node in a DC fails)
+
+**Symptoms:** one RabbitMQ node pod in a DC is down; some quorum queues briefly
+re-elect a leader within that cluster.
+
+**Automatic:** the loss is handled entirely inside that DC's RabbitMQ cluster. Each
+affected quorum queue's Raft group re-elects a leader among the surviving replicas, and
+the pod reschedules. There is **no cross-DC effect**: the active DC stays active, the
+standby stays a federation target, and the Lease does not move.
+
+**Verify:**
+
+```bash
+kubectl get pods -n demo -l app.kubernetes.io/instance=rm-dcdr -L kubedb.com/role,open-cluster-management.io/cluster-name
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{.status.disasterRecovery.activeDC}'   # unchanged
+```
+
+**Action:** none required. Ensure the failed node rejoins its cluster. Use quorum queues
+(not classic queues) so intra-DC HA tolerates one node loss; a three-node DC cluster
+keeps quorum with one node down.
+
+---
+
+## 2. Full active-DC loss (zone/cluster failure)
+
+**Symptoms:** the active DC's nodes are gone/unreachable; publishes to the AMQP endpoint
+fail briefly.
+
+**Automatic:** the standby is already a near-current Federation replica. The
+`dr-controlplane` Lease moves to the standby, and the orchestrator flips the AMQP
+endpoint to the standby's nodes, opens the standby's publish fence, and reverses the
+federation direction (setting up the survivor-to-old-active upstream for when the old DC
+returns). `phase` moves `FailingOver` to `Steady` and the survivor becomes
+`writable: true`.
+
+**Verify:**
+
+```bash
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{.status.disasterRecovery.activeDC}'   # the survivor
+kubectl get pods -n demo -l app.kubernetes.io/instance=rm-dcdr -L kubedb.com/role,open-cluster-management.io/cluster-name
+```
+
+**Action:** none required for availability. Note the RPO: messages the old active
+accepted but had not yet federated are lost (bounded by the federation lag at the moment
+of loss). There is no rewind. When the failed DC returns, see scenario 6 (failback).
+
+---
+
+## 3. Clean DC-vs-DR partition (both DCs up, cannot reach each other)
+
+**Symptoms:** the two data DCs are up but the network between them is cut. Federation lag
+on the standby climbs; the old active may still see local publishers.
+
+**Automatic:** the publish fence is the split-brain guard. The old active loses its Lease
+renewal across the partition and its fence **fails closed**, so it stops accepting client
+publishes on its own **before** the hub reacts. The etcd majority (two sites plus the
+Arbiter DC) keeps or grants the Lease to one side only, so exactly one cluster is ever
+writable and the two clusters cannot diverge.
+
+**Verify there is exactly one writable DC:**
+
+```bash
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName}={.writable} {end}'
+```
+
+**Action:** heal the network. Once the partition clears, the non-active cluster resumes
+as the Federation target and catches up. If both sides took publishes before the fence
+closed (should not happen with a fail-closed fence), treat the non-active side's forked
+tail as scenario 6 (re-seed the affected queues).
+
+---
+
+## 4. Planned switchover (maintenance on the active DC)
+
+**Action:**
+
+```bash
+kubectl annotate rabbitmq -n demo rm-dcdr dr.kubedb.com/switchover-to=dc-b
+```
+
+**Automatic:** the hub gates on the target's health and federation lag budget, then
+quiesces publishers by closing the active cluster's publish fence, waits for Federation
+to drain to near-zero lag (so the target holds every message), flips the AMQP endpoint to
+the target, opens the target's fence, reverses the federation direction, and moves the
+Lease. Because Federation fully drained before the flip, **zero confirmed messages are
+lost**.
+
+**Verify:**
+
+```bash
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{.status.disasterRecovery.activeDC}'  # dc-b
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{.status.disasterRecovery.phase}'     # Steady
+```
+
+**If it does not complete:** see scenario 8 (federation lag high / switchover stuck).
+
+---
+
+## 5. Consumers not resuming after a flip
+
+**Symptoms:** after a failover or switchover, a consumer re-reads messages it already
+processed, or misses messages, on the new active cluster.
+
+**Cause:** Federation is asynchronous and does not deduplicate across the flip. The
+consumer either reconnected before the un-federated tail arrived, or is re-seeing the
+redelivery window from the federated backlog.
+
+**Diagnose:**
+
+```bash
+# Is the federation link up and draining on the (now active) side?
+kubectl exec -n demo rm-dcdr-dc-b-0 -- rabbitmqctl list_federation_links
+# Per-DC federation lag:
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} lag={.federationLagMessages}{"\n"}{end}'
+```
+
+**Action:** make consumers idempotent, or apply a dedup window across the flip so a
+redelivered message is a no-op. Do not treat a small redelivery window as data loss: it
+is the expected cost of asynchronous federation. For a zero-loss move, use a drained
+planned switchover (scenario 4) rather than an unplanned failover.
+
+---
+
+## 6. Failback (return a recovered DC to active)
+
+**Symptoms:** the previously lost DC is back but holds a forked tail (messages it
+accepted before the failover that were never federated).
+
+**Automatic:** the returned cluster becomes the Federation target of the new active. But
+Federation only adds and never deletes, so a naive re-federation leaves the orphan forked
+tail on top of the new active's data.
+
+**Action:**
+
+1. **Re-seed** the affected queues from the new active: purge the returned cluster's copy
+   and re-federate from scratch, so the forked tail is removed. Or **accept and document**
+   the orphan tail as bounded loss.
+2. Once the returned DC is caught up (low federation lag), perform a **drained planned
+   switchover** back to it:
+
+   ```bash
+   kubectl annotate rabbitmq -n demo rm-dcdr dr.kubedb.com/switchover-to=dc-a
+   ```
+
+There is no rewind; RabbitMQ cannot roll back a queue, so the re-seed is what restores
+consistency.
+
+---
+
+## 7. A standby DC is lost
+
+**Symptoms:** the non-active DC's nodes are gone; that DC shows `healthy: false` and
+federation lag is unavailable.
+
+**Impact:** none on publishes. The active DC keeps taking client publishes; you lose the
+DR copy until the standby returns.
+
+**Verify the active DC is still writable:**
+
+```bash
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[?(@.writable==true)]}{.clusterName}{end}'
+```
+
+**Action:** recover the standby cluster's nodes. When it returns, Federation resumes
+replicating from the active and the standby catches up. You are running without DR
+protection until then.
+
+---
+
+## 8. Federation lag high (replica falling behind)
+
+**Symptoms:** `federationLagMessages` on the standby climbs; a planned switchover stays in
+`FailingOver` because Federation has not drained.
+
+**Diagnose:**
+
+```bash
+# Per-DC federation lag and health:
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName} lag={.federationLagMessages} healthy={.healthy}{"\n"}{end}'
+# Federation link status:
+kubectl exec -n demo rm-dcdr-dc-b-0 -- rabbitmqctl list_federation_links
+```
+
+**Causes & action:**
+
+- **Cross-DC network bottleneck or publisher burst:** relieve the bottleneck (network,
+  active-cluster publish load) so Federation drains. A planned switchover intentionally
+  waits for the lag to reach near-zero after quiescing publishers.
+- **A federation link is down or blocked:** check `list_federation_links` and the
+  upstream parameter; restart the link on the standby cluster (or the standby nodes).
+- **Abort a stuck switchover:** remove the annotation to cancel:
+  `kubectl annotate rabbitmq -n demo rm-dcdr dr.kubedb.com/switchover-to-`. The active
+  DC's publish fence reopens and it stays active.
+
+---
+
+## 9. Arbiter DC lost
+
+**Symptoms:** the Arbiter DC is gone; its `dr-controlplane` etcd member is unreachable.
+
+**Impact:** none on publishes. The two data DCs plus the lost arbiter leave the etcd
+quorum with two of three members, still a majority, so the Lease can still be renewed and
+the active DC keeps taking publishes. You lose the tie-break, so a subsequent **second**
+failure can no longer keep an etcd majority.
+
+**Verify the cluster is still writable:**
+
+```bash
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[?(@.writable==true)]}{.clusterName}{end}'
+```
+
+**Action:** restore the Arbiter DC's etcd member to regain single-fault tolerance. The
+Arbiter DC never runs RabbitMQ, so no node recovery is involved.
+
+---
+
+## 10. Coordination plane (dr-controlplane / etcd) unavailable
+
+**Symptoms:** the Lease cannot be read or renewed across the spokes.
+
+**Automatic:** the current active cluster keeps taking publishes as long as its fence can
+still confirm the Lease it last held; but if the fence cannot confirm the Lease it
+**fails closed** and denies publishes, so a total coordination-plane outage can make the
+active cluster go read-only. What you always lose is **failover and planned switchover**:
+the hub cannot move the active DC until the etcd quorum returns.
+
+**Verify:**
+
+```bash
+kubectl --kubeconfig <coord> -n dc-failover get lease primary-dc   # error / stale
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{.status.disasterRecovery.phase}'   # may be Degraded
+```
+
+**Action:** restore the `dr-controlplane` etcd quorum (its third member lives in the
+Arbiter DC). Once the Lease is renewable, the fence reopens on the active cluster and
+failover/switchover resume.
+
+---
+
+## 11. Which DC is active?
+
+**Question:** confirm which cluster is taking publishes right now.
+
+```bash
+# The DR status view (authoritative for what the hub applied):
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{.status.disasterRecovery.activeDC}'
+# The Lease holder (what the coordination plane intends):
+kubectl --kubeconfig <coord> -n dc-failover get lease primary-dc -o jsonpath='{.spec.holderIdentity}'
+# Where the AMQP endpoint resolves and which DC is writable:
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName}={.writable} {end}'
+```
+
+In steady state the `activeDC`, the Lease `holderIdentity`, and the single
+`writable: true` DC all name the same data center. A brief mismatch during
+`FailingOver` is expected; it should converge back to `Steady`.
+
+---
+
+## 12. Suspected split writes (two clusters taking publishes)
+
+This should be impossible: the etcd majority grants the Lease to one DC only, and the
+publish fence on any non-Lease-holder fails closed. If `status.disasterRecovery` ever
+shows two `writable: true` DCs, or publishes succeed against both endpoints:
+
+**Diagnose immediately:**
+
+```bash
+kubectl get rabbitmq -n demo rm-dcdr -o jsonpath='{range .status.disasterRecovery.dataCenters[*]}{.clusterName}={.writable} {end}'
+kubectl --kubeconfig <coord> -n dc-failover get lease primary-dc -o yaml
+kubectl exec -n demo rm-dcdr-dc-b-0 -- rabbitmqctl list_federation_links   # both directions must not be enabled
+```
+
+**Action:** confirm the publish fence is engaged on the non-Lease-holder (write
+permission revoked for client users, or the AMQP listener gated) and that only one
+federation direction is enabled. Never enable both directions at once: Federation has no
+rename loop guard, so overlapping directions ping-pong a message between clusters. Tear
+down the wrong-direction upstream, restore the fence on the non-active cluster, then treat
+any forked tail as scenario 6 (re-seed).
+
+---
+
+## Escalation checklist
+
+When unsure, collect:
+
+```bash
+kubectl get rabbitmq -n demo rm-dcdr -o yaml
+kubectl --kubeconfig <coord> -n dc-failover get lease -o yaml
+kubectl get pods -n demo -l app.kubernetes.io/instance=rm-dcdr -L kubedb.com/role,open-cluster-management.io/cluster-name -o wide
+kubectl exec -n demo rm-dcdr-dc-b-0 -- rabbitmqctl list_federation_links
+kubectl exec -n demo rm-dcdr-dc-b-0 -- rabbitmqctl list_parameters
+```


### PR DESCRIPTION
Adds documentation for KubeDB RabbitMQ cross data center disaster recovery (DC-DR), mirroring the structure of the Kafka DR docs and adapting it to RabbitMQ semantics.

New pages under `docs/guides/rabbitmq/dr/`:

- `_index.md` menu entry (Disaster Recovery).
- `overview/index.md`: concept overview and quick start. Explains why RabbitMQ DR is the async-replication camp (no cluster-wide primary; quorum queues run their own intra-DC Raft), the five architecture rules, DC roles (Member/Arbiter), the single-CR single-endpoint model, deploy walkthrough, `status.disasterRecovery`, failover, planned switchover, failback, cleanup.
- `guide/index.md`: full user guide. Components, DC-name contract, deployment, operator-managed Federation upstreams and policies, connecting/publishing over AMQP, consumers resuming after a flip, monitoring federation lag, the publish fence (permission or listener gate), planned switchover, failback, scaling and day-2 ops, limitations.
- `runbook/index.md`: 12 scenario-by-scenario procedures plus an escalation checklist.

RabbitMQ-specific mechanics vs the Kafka template:

- Cross-DC replication is the RabbitMQ Federation plugin (or Shovel), active-to-standby, not MirrorMaker 2. No `Connector` CRD; the operator manages federation runtime parameters and policies.
- Quorum queues run per-queue Raft intra-DC; the Arbiter DC is engine-free.
- AMQP (5672) publish endpoint follows the active cluster; inter-node 25672; management/federation 15672.
- Writability is Lease-gated and fenced fail-closed (revoke write permission or gate the AMQP listener).
- `status.disasterRecovery` reports `activeDC`, `phase`, and per-DC `nodesReady`/`federationLagMessages`/`writable`/`healthy`. Planned switchover is annotation-triggered (`dr.kubedb.com/switchover-to`), no Switchover ops type.

The pages hedge that the distributed substrate and DC-DR layer are net-new and forward-looking, matching the Kafka docs' tone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new RabbitMQ Disaster Recovery docs section with an overview, step-by-step guide, and runbook.
  * Documented cross–data center active/passive behavior, failover and failback workflows, deployment prerequisites, monitoring tips, and cleanup steps.
  * Included scenario-based operational guidance and troubleshooting commands for common disaster recovery situations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->