### PR TITLE
docs(postgres): fix incorrect commands and fields found by executing the guides

### DIFF
--- a/docs/examples/postgres/custom-config/pg-custom-config.yaml
+++ b/docs/examples/postgres/custom-config/pg-custom-config.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   version: "18.3"
   configuration:
-    secretName: pg-custom-config
+    secretName: pg-configuration
   storage:
     storageClassName: "standard"
     accessModes:

--- a/docs/examples/postgres/custom-rbac/pg-custom-role-two.yaml
+++ b/docs/examples/postgres/custom-rbac/pg-custom-role-two.yaml
@@ -5,17 +5,17 @@ metadata:
   namespace: demo
 rules:
   - apiGroups:
-      - apps
+      - apps.k8s.appscode.com
     resourceNames:
-      - miniute-postgres
+      - minute-postgres
     resources:
-      - statefulsets
+      - petsets
     verbs:
       - get
   - apiGroups:
       - ""
     resourceNames:
-      - miniute-postgres-leader-lock
+      - minute-postgres-leader-lock
     resources:
       - configmaps
     verbs:

--- a/docs/examples/postgres/custom-rbac/pg-custom-role.yaml
+++ b/docs/examples/postgres/custom-rbac/pg-custom-role.yaml
@@ -5,11 +5,11 @@ metadata:
   namespace: demo
 rules:
   - apiGroups:
-      - apps
+      - apps.k8s.appscode.com
     resourceNames:
       - quick-postgres
     resources:
-      - statefulsets
+      - petsets
     verbs:
       - get
   - apiGroups:

--- a/docs/guides/postgres/clustering/streaming_replication.md
+++ b/docs/guides/postgres/clustering/streaming_replication.md
@@ -108,35 +108,38 @@ KubeDB operator creates three Pod as PostgreSQL server.
 $ kubectl get pods -n demo --selector="app.kubernetes.io/instance=ha-postgres" --show-labels
 NAME            READY   STATUS    RESTARTS   AGE   LABELS
 ha-postgres-0   1/1     Running   0          20s   controller-revision-hash=ha-postgres-6b7998ccfd,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres,kubedb.com/role=primary,petset.kubernetes.io/pod-name=ha-postgres-0
-ha-postgres-1   1/1     Running   0          16s   controller-revision-hash=ha-postgres-6b7998ccfd,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres,kubedb.com/role=replica,petset.kubernetes.io/pod-name=ha-postgres-1
-ha-postgres-2   1/1     Running   0          10s   controller-revision-hash=ha-postgres-6b7998ccfd,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres,kubedb.com/role=replica,petset.kubernetes.io/pod-name=ha-postgres-2
+ha-postgres-1   1/1     Running   0          16s   controller-revision-hash=ha-postgres-6b7998ccfd,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres,kubedb.com/role=standby,petset.kubernetes.io/pod-name=ha-postgres-1
+ha-postgres-2   1/1     Running   0          10s   controller-revision-hash=ha-postgres-6b7998ccfd,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres,kubedb.com/role=standby,petset.kubernetes.io/pod-name=ha-postgres-2
 ```
 
 Here,
 
 - Pod `ha-postgres-0` is serving as *primary* server, indicated by label `kubedb.com/role=primary`
-- Pod `ha-postgres-1` & `ha-postgres-2` both are serving as *standby* server, indicated by label `kubedb.com/role=replica`
+- Pod `ha-postgres-1` & `ha-postgres-2` both are serving as *standby* server, indicated by label `kubedb.com/role=standby`
 
-And two services for Postgres `ha-postgres` are created.
+Services for Postgres `ha-postgres` are created.
 
 ```bash
 $ kubectl get svc -n demo --selector="app.kubernetes.io/instance=ha-postgres"
-NAME                   TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
-ha-postgres            ClusterIP   10.102.19.49   <none>        5432/TCP   4m
-ha-postgres-replicas   ClusterIP   10.97.36.117   <none>        5432/TCP   4m
+NAME                  TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)                               AGE
+ha-postgres           ClusterIP   10.102.19.49   <none>        5432/TCP,2379/TCP                     4m
+ha-postgres-pods      ClusterIP   None           <none>        5432/TCP,2380/TCP,2379/TCP,2384/TCP   4m
+ha-postgres-standby   ClusterIP   10.97.36.117   <none>        5432/TCP                              4m
 ```
 
 ```bash
 $ kubectl get svc -n demo --selector="app.kubernetes.io/instance=ha-postgres" -o=custom-columns=NAME:.metadata.name,SELECTOR:.spec.selector
-NAME                   SELECTOR
-ha-postgres            map[app.kubernetes.io/name:postgreses.kubedb.com app.kubernetes.io/instance:ha-postgres kubedb.com/role:primary]
-ha-postgres-replicas   map[app.kubernetes.io/name:postgreses.kubedb.com app.kubernetes.io/instance:ha-postgres]
+NAME                  SELECTOR
+ha-postgres           map[app.kubernetes.io/name:postgreses.kubedb.com app.kubernetes.io/instance:ha-postgres kubedb.com/role:primary]
+ha-postgres-pods      map[app.kubernetes.io/name:postgreses.kubedb.com app.kubernetes.io/instance:ha-postgres]
+ha-postgres-standby   map[app.kubernetes.io/name:postgreses.kubedb.com app.kubernetes.io/instance:ha-postgres kubedb.com/role:standby]
 ```
 
 Here,
 
 - Service `ha-postgres` targets Pod `ha-postgres-0`, which is *primary* server, by selector `app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres,kubedb.com/role=primary`.
-- Service `ha-postgres-replicas` targets all Pods (*`ha-postgres-0`*, *`ha-postgres-1`* and *`ha-postgres-2`*) with label `app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres`.
+- Service `ha-postgres-pods` targets all Pods (*`ha-postgres-0`*, *`ha-postgres-1`* and *`ha-postgres-2`*) with label `app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres`.
+- Service `ha-postgres-standby` targets the *standby* Pods by selector `app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres,kubedb.com/role=standby`.
 
 >These *standby* servers are asynchronous *warm standby* server. That means, you can only connect to *primary* sever.
 
@@ -152,14 +155,14 @@ Now connect to this *primary* server Pod `ha-postgres-0` using pgAdmin installed
 - Username: Run following command to get *username*,
 
   ```bash
-  $ kubectl get secrets -n demo ha-postgres-auth -o jsonpath='{.data.\POSTGRES_USER}' | base64 -d
+  $ kubectl get secrets -n demo ha-postgres-auth -o jsonpath='{.data.username}' | base64 -d
   postgres
   ```
 
 - Password: Run the following command to get *password*,
 
   ```bash
-  $ kubectl get secrets -n demo ha-postgres-auth -o jsonpath='{.data.\POSTGRES_PASSWORD}' | base64 -d
+  $ kubectl get secrets -n demo ha-postgres-auth -o jsonpath='{.data.password}' | base64 -d
   MHRrOcuyddfh3YpU
   ```
 
@@ -217,7 +220,7 @@ spec:
     storageClassName: standard
   storageType: Durable
   deletionPolicy: Halt
-  version: "10.2"-v5
+  version: "18.3"
 status:
   observedGeneration: 2$4213139756412538772
   phase: Running
@@ -244,9 +247,9 @@ kubectl delete pod -n demo ha-postgres-0
 ```bash
 $ kubectl get pods -n demo --selector="app.kubernetes.io/instance=ha-postgres" --show-labels
 NAME            READY     STATUS    RESTARTS   AGE       LABELS
-ha-postgres-0   1/1       Running   0          10s       controller-revision-hash=ha-postgres-b8b4b5fc4,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres,kubedb.com/role=replica,petset.kubernetes.io/pod-name=ha-postgres-0
+ha-postgres-0   1/1       Running   0          10s       controller-revision-hash=ha-postgres-b8b4b5fc4,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres,kubedb.com/role=standby,petset.kubernetes.io/pod-name=ha-postgres-0
 ha-postgres-1   1/1       Running   0          52m       controller-revision-hash=ha-postgres-b8b4b5fc4,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres,kubedb.com/role=primary,petset.kubernetes.io/pod-name=ha-postgres-1
-ha-postgres-2   1/1       Running   0          51m       controller-revision-hash=ha-postgres-b8b4b5fc4,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres,kubedb.com/role=replica,petset.kubernetes.io/pod-name=ha-postgres-2
+ha-postgres-2   1/1       Running   0          51m       controller-revision-hash=ha-postgres-b8b4b5fc4,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=ha-postgres,kubedb.com/role=standby,petset.kubernetes.io/pod-name=ha-postgres-2
 ```
 
 Here,
@@ -329,14 +332,14 @@ KubeDB operator creates three Pod as PostgreSQL server.
 $ kubectl get pods -n demo --selector="app.kubernetes.io/instance=hot-postgres" --show-labels
 NAME             READY     STATUS    RESTARTS   AGE       LABELS
 hot-postgres-0   1/1       Running   0          1m        controller-revision-hash=hot-postgres-6c48cfb5bb,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=hot-postgres,kubedb.com/role=primary,petset.kubernetes.io/pod-name=hot-postgres-0
-hot-postgres-1   1/1       Running   0          1m        controller-revision-hash=hot-postgres-6c48cfb5bb,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=hot-postgres,kubedb.com/role=replica,petset.kubernetes.io/pod-name=hot-postgres-1
-hot-postgres-2   1/1       Running   0          48s       controller-revision-hash=hot-postgres-6c48cfb5bb,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=hot-postgres,kubedb.com/role=replica,petset.kubernetes.io/pod-name=hot-postgres-2
+hot-postgres-1   1/1       Running   0          1m        controller-revision-hash=hot-postgres-6c48cfb5bb,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=hot-postgres,kubedb.com/role=standby,petset.kubernetes.io/pod-name=hot-postgres-1
+hot-postgres-2   1/1       Running   0          48s       controller-revision-hash=hot-postgres-6c48cfb5bb,app.kubernetes.io/name=postgreses.kubedb.com,app.kubernetes.io/instance=hot-postgres,kubedb.com/role=standby,petset.kubernetes.io/pod-name=hot-postgres-2
 ```
 
 Here,
 
 - Pod `hot-postgres-0` is serving as *primary* server, indicated by label `kubedb.com/role=primary`
-- Pod `hot-postgres-1` & `hot-postgres-2` both are serving as *standby* server, indicated by label `kubedb.com/role=replica`
+- Pod `hot-postgres-1` & `hot-postgres-2` both are serving as *standby* server, indicated by label `kubedb.com/role=standby`
 
 > These *standby* servers are asynchronous *hot standby* servers.
 
@@ -347,21 +350,21 @@ Now connect to one of our *hot standby* servers Pod `hot-postgres-2` using pgAdm
 **Connection information:**
 
 - Host name/address: you can use any of these
-  - Service: `hot-postgres-replicas.demo`
+  - Service: `hot-postgres-standby.demo`
   - Pod IP: (`$kubectl get pods hot-postgres-2 -n demo -o yaml | grep podIP`)
 - Port: `5432`
 - Maintenance database: `postgres`
 - Username: Run following command to get *username*,
 
   ```bash
-  $ kubectl get secrets -n demo hot-postgres-auth -o jsonpath='{.data.\POSTGRES_USER}' | base64 -d
+  $ kubectl get secrets -n demo hot-postgres-auth -o jsonpath='{.data.username}' | base64 -d
   postgres
   ```
 
 - Password: Run the following command to get *password*,
 
   ```bash
-  $ kubectl get secrets -n demo hot-postgres-auth -o jsonpath='{.data.\POSTGRES_PASSWORD}' | base64 -d
+  $ kubectl get secrets -n demo hot-postgres-auth -o jsonpath='{.data.password}' | base64 -d
   ZZgjjQMUdKJYy1W9
   ```
 
@@ -375,9 +378,9 @@ ERROR:  cannot execute CREATE DATABASE in a read-only transaction
 Failed to execute write operation. But it can execute following read query
 
 ```bash
-postgres=# select pg_last_xlog_receive_location();
- pg_last_xlog_receive_location
--------------------------------
+postgres=# select pg_last_wal_receive_lsn();
+ pg_last_wal_receive_lsn
+-------------------------
  0/7000220
 ```
 

--- a/docs/guides/postgres/configuration/pgtune.md
+++ b/docs/guides/postgres/configuration/pgtune.md
@@ -151,7 +151,7 @@ $ kubectl get secret -n demo pg-ha-tuning-eba1da -o jsonpath='{.data.pgtune\.con
 # Tuned by KubeDB
 # https://kubedb.com
 
-# DB Version: 17
+# DB Version: 18
 # OS Type: linux
 # DB Type: web
 # Total Memory (RAM): 2 GB

--- a/docs/guides/postgres/configuration/using-config-file.md
+++ b/docs/guides/postgres/configuration/using-config-file.md
@@ -54,7 +54,7 @@ shared_buffers=256MB
 Now, create a Secret with this configuration file.
 
 ```bash
-$ kubectl create secret generic -n demo pg-configuration --from-literal=user.conf="$(curl -fsSL https://raw.githubusercontent.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/postgres/custom-config/user.conf)"
+$ kubectl create secret generic -n demo pg-configuration --from-literal=user.conf="$(curl -fsSL https://raw.githubusercontent.com/kubedb/docs/{{< param "info.version" >}}/docs/examples/postgres/custom-config/user.conf)"
 secret/pg-configuration created
 ```
 
@@ -80,7 +80,7 @@ metadata:
 Now, create Postgres crd specifying `spec.configuration.secretName` field.
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/postgres/configuration/pg-configuration.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/postgres/custom-config/pg-custom-config.yaml
 postgres.kubedb.com/custom-postgres created
 ```
 

--- a/docs/guides/postgres/custom-rbac/using-custom-rbac.md
+++ b/docs/guides/postgres/custom-rbac/using-custom-rbac.md
@@ -84,7 +84,7 @@ metadata:
   namespace: demo
 rules:
 - apiGroups:
-  - apps
+  - apps.k8s.appscode.com
   resourceNames:
   - quick-postgres
   resources:
@@ -256,9 +256,9 @@ metadata:
   namespace: demo
 rules:
 - apiGroups:
-  - apps
+  - apps.k8s.appscode.com
   resourceNames:
-  - miniute-postgres
+  - minute-postgres
   resources:
   - petsets
   verbs:
@@ -266,7 +266,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - miniute-postgres-leader-lock
+  - minute-postgres-leader-lock
   resources:
   - configmaps
   verbs:

--- a/docs/guides/postgres/initialization/script_source.md
+++ b/docs/guides/postgres/initialization/script_source.md
@@ -157,12 +157,12 @@ Database Secret:
                   app.kubernetes.io/instance=script-postgres
   Annotations:  <none>
 
-Type:  Opaque
+Type:  kubernetes.io/basic-auth
 
 Data
 ====
-  POSTGRES_PASSWORD:  16 bytes
-  POSTGRES_USER:      8 bytes
+  password:  16 bytes
+  username:  8 bytes
 
 Topology:
   Type     Pod                StartTime                      Phase
@@ -199,14 +199,14 @@ Now let's connect to our Postgres `script-postgres`  using pgAdmin we have insta
 - Username: Run following command to get *username*,
 
   ```bash
-  $ kubectl get secrets -n demo script-postgres-auth -o jsonpath='{.data.\POSTGRES_USER}' | base64 -d
+  $ kubectl get secrets -n demo script-postgres-auth -o jsonpath='{.data.username}' | base64 -d
   postgres
   ```
 
 - Password: Run the following command to get *password*,
 
   ```bash
-  $ kubectl get secrets -n demo script-postgres-auth -o jsonpath='{.data.\POSTGRES_PASSWORD}' | base64 -d
+  $ kubectl get secrets -n demo script-postgres-auth -o jsonpath='{.data.password}' | base64 -d
   NC1fEq0q5XqHazB8
   ```
 

--- a/docs/guides/postgres/quickstart/quickstart.md
+++ b/docs/guides/postgres/quickstart/quickstart.md
@@ -444,8 +444,8 @@ KubeDB operator has created a new Secret called `quick-postgres-auth` for storin
  $ kubectl get secret -n demo quick-postgres-auth -o yaml
 apiVersion: v1
 data:
-  POSTGRES_PASSWORD: REQ4aTU2VUJJY3M2M1BWTw==
-  POSTGRES_USER: cG9zdGdyZXM=
+  password: REQ4aTU2VUJJY3M2M1BWTw==
+  username: cG9zdGdyZXM=
 kind: Secret
 metadata:
   creationTimestamp: 2018-09-03T11:25:39Z
@@ -455,13 +455,12 @@ metadata:
   name: quick-postgres-auth
   namespace: demo
   resourceVersion: "1677"
-  selfLink: /api/v1/namespaces/demo/secrets/quick-postgres-auth
   uid: 15b3e8a1-af6c-11e8-996d-0800270d7bae
-type: Opaque
+type: kubernetes.io/basic-auth
 ```
 
-This secret contains superuser name for `postgres` database as `POSTGRES_USER` key and
-password as `POSTGRES_PASSWORD` key. By default, superuser name is `postgres` and password is randomly generated.
+This secret contains superuser name for `postgres` database as `username` key and
+password as `password` key. By default, superuser name is `postgres` and password is randomly generated.
 
 If you want to use custom password, please create the secret manually and specify that when creating the Postgres object using `spec.authSecret.name`. For more details see [here](/docs/guides/postgres/concepts/postgres.md#specdatabasesecret).
 
@@ -480,14 +479,14 @@ Now, you can connect to this database from the pgAdmin dashboard using `quick-po
 - Username: Run following command to get *username*,
 
   ```bash
-  $ kubectl get secrets -n demo quick-postgres-auth -o jsonpath='{.data.\POSTGRES_USER}' | base64 -d
+  $ kubectl get secrets -n demo quick-postgres-auth -o jsonpath='{.data.username}' | base64 -d
   postgres
   ```
 
 - Password: Run the following command to get *password*,
 
   ```bash
-  $ kubectl get secrets -n demo quick-postgres-auth -o jsonpath='{.data.\POSTGRES_PASSWORD}' | base64 -d
+  $ kubectl get secrets -n demo quick-postgres-auth -o jsonpath='{.data.password}' | base64 -d
   DD8i56UBIcs63PVO
   ```
 

--- a/docs/guides/postgres/reconfigure/cluster.md
+++ b/docs/guides/postgres/reconfigure/cluster.md
@@ -166,7 +166,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are reconfiguring `ha-postgres` database.
 - `spec.type` specifies that we are performing `Reconfigure` on our database.
-- `spec.configuration.secretName` specifies the name of the new secret.
+- `spec.configuration.configSecret.name` specifies the name of the new secret.
 
 Let's create the `PostgresOpsRequest` CR we have shown above,
 

--- a/docs/guides/postgres/rotate-authentication/rotateauth.md
+++ b/docs/guides/postgres/rotate-authentication/rotateauth.md
@@ -386,9 +386,9 @@ Events:
 ```shell
 $ kubectl get pg -n demo quick-postgres -ojson | jq .spec.authSecret.name
 "quick-postgres-user-auth"
-$ kubectl get secret -n demo quick-postgres-user-auth-new -o=jsonpath='{.data.username}' | base64 -d
+$ kubectl get secret -n demo quick-postgres-user-auth -o=jsonpath='{.data.username}' | base64 -d
 postgres                                        
-$ kubectl get secret -n demo quick-postgres-user-auth-new -o=jsonpath='{.data.password}' | base64 -d
+$ kubectl get secret -n demo quick-postgres-user-auth -o=jsonpath='{.data.password}' | base64 -d
 postgres-secret                                                                
 ```
 Also, there will be two more new keys in the secret that stores the previous credentials. The keys are `username.prev` and `password.prev`. You can find the secret and its data by running the following command:

--- a/docs/guides/postgres/scaling/horizontal-scaling/scale-horizontally/index.md
+++ b/docs/guides/postgres/scaling/horizontal-scaling/scale-horizontally/index.md
@@ -113,7 +113,7 @@ spec:
 Let's create the `Postgres` cr we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/scaling/horizontal-scaling/scale-horizontally/postgres.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/scaling/horizontal-scaling/scale-horizontally/yamls/postgres.yaml
 postgres.kubedb.com/pg created
 ```
 
@@ -130,8 +130,8 @@ NAME   VERSION   STATUS   AGE
 pg     18.3      Ready    4h40m
 
 
-$ watch -n 3 kubectl get sts -n demo pg
-Every 3.0s: kubectl get sts -n demo pg                             emon-r7: Thu Dec  2 15:31:38 2021
+$ watch -n 3 kubectl get petset -n demo pg
+Every 3.0s: kubectl get petset -n demo pg                             emon-r7: Thu Dec  2 15:31:38 2021
 
 NAME   READY   AGE
 pg     3/3     4h41m
@@ -151,10 +151,10 @@ pg-2   2/2     Running   0          4h26m
 Let's verify that the PetSet's pods have joined into cluster,
 
 ```bash
-$ kubectl get secrets -n demo pg-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo pg-auth -o jsonpath='{.data.username}' | base64 -d
 postgres
 
-$ kubectl get secrets -n demo pg-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo pg-auth -o jsonpath='{.data.password}' | base64 -d
 b3b5838EhjwsiuFU
 
 ```

--- a/docs/guides/postgres/scaling/vertical-scaling/scale-vertically/index.md
+++ b/docs/guides/postgres/scaling/vertical-scaling/scale-vertically/index.md
@@ -125,8 +125,8 @@ Every 3.0s: kubectl get postgres -n demo pg                         emon-r7: Thu
 NAME   VERSION   STATUS   AGE
 pg     18.3      Ready    3m16s
 
-$ watch -n 3 kubectl get sts -n demo pg
-Every 3.0s: kubectl get sts -n demo pg                              emon-r7: Thu Dec  2 10:54:31 2021
+$ watch -n 3 kubectl get petset -n demo pg
+Every 3.0s: kubectl get petset -n demo pg                              emon-r7: Thu Dec  2 10:54:31 2021
 
 NAME   READY   AGE
 pg     3/3     3m54s

--- a/docs/guides/postgres/synchronous/index.md
+++ b/docs/guides/postgres/synchronous/index.md
@@ -63,8 +63,8 @@ spec:
   deletionPolicy: DoNotTerminate
 ```
 
-By default, KubeDB create a Synchronous Replication where one Replica Postgres server out of all the replicas will be in `sync` with Current `primary`. 
-And others are `potential` candidate to be in sync with primary if the `synchronous` replica failed in any case. 
+By default, KubeDB creates a quorum-based Synchronous Replication (`synchronous_standby_names = ANY 1 (...)`) where any one of the replica Postgres servers must confirm each commit with the current `primary`. 
+All participating replicas therefore report `sync_state` as `quorum`. 
 
 Let's check in the postgres cluster that we have deployed. Now, exec into the current primary, in our case it is Pod `demo-pg-0`.
 ```bash
@@ -76,8 +76,8 @@ Type "help" for help.
 postgres=# select application_name, client_addr, state, sent_lsn, write_lsn, flush_lsn, replay_lsn, sync_state from pg_stat_replication;
  application_name | client_addr |   state   | sent_lsn  | write_lsn | flush_lsn | replay_lsn | sync_state 
 ------------------+-------------+-----------+-----------+-----------+-----------+------------+------------
- demo-pg-1        | 10.244.0.22 | streaming | 0/5000060 | 0/5000060 | 0/5000060 | 0/5000060  | sync
- demo-pg-2        | 10.244.0.24 | streaming | 0/5000060 | 0/5000060 | 0/5000060 | 0/5000060  | potential
+ demo-pg-1        | 10.244.0.22 | streaming | 0/5000060 | 0/5000060 | 0/5000060 | 0/5000060  | quorum
+ demo-pg-2        | 10.244.0.24 | streaming | 0/5000060 | 0/5000060 | 0/5000060 | 0/5000060  | quorum
 
 ```
 But Users can also configure a Synchronous replication cluster where all the replica are in `sync` with current primary. 

--- a/docs/guides/postgres/tls/configure/index.md
+++ b/docs/guides/postgres/tls/configure/index.md
@@ -143,7 +143,7 @@ NAMESPACE   NAME   VERSION   STATUS   AGE
 demo        pg     18.3      Ready    62s
 
 
-$ watch -n 3 kubectl get sts -n demo pg
+$ watch -n 3 kubectl get petset -n demo pg
 NAME   READY   AGE
 pg     3/3     2m30s
 

--- a/docs/guides/postgres/update-version/versionupgrading/index.md
+++ b/docs/guides/postgres/update-version/versionupgrading/index.md
@@ -202,10 +202,10 @@ $ watch -n 3 kubectl get postgres -n demo
 Every 3.0s: kubectl get postgres -n demo     
             
 NAME   VERSION   STATUS   AGE
-pg     11.11     Ready    3m17s
+pg     17.9      Ready    3m17s
 
-$ watch -n 3 kubectl get sts -n demo pg
-Every 3.0s: kubectl get sts -n demo pg                              ac-emon: Tue Nov 30 11:38:12 2021
+$ watch -n 3 kubectl get petset -n demo pg
+Every 3.0s: kubectl get petset -n demo pg                              ac-emon: Tue Nov 30 11:38:12 2021
 
 NAME   READY   AGE
 pg     3/3     4m17s
@@ -226,13 +226,13 @@ Let's verify the `Postgres`, the `PetSet` and its `Pod` image version,
 
 ```bash
 $ kubectl get pg -n demo pg -o=jsonpath='{.spec.version}{"\n"}'
-11.11
+17.9
 
-$  kubectl get sts -n demo pg -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-postgres:11.11-alpine
+$  kubectl get petset -n demo pg -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+ghcr.io/appscode-images/postgres:17.9-alpine
 
 $ kubectl get pod -n demo pg-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-postgres:11.11-alpine
+ghcr.io/appscode-images/postgres:17.9-alpine
 ```
 
 We are ready to apply updating on this `Postgres` Instance.
@@ -268,7 +268,7 @@ Here,
 Let's create the `PostgresOpsRequest` cr we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/update-version/versionupgrading/yamls/update_version.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/update-version/versionupgrading/yamls/upgrade_version.yaml
 postgresopsrequest.ops.kubedb.com/pg-update created
 ```
 
@@ -449,13 +449,13 @@ Now, we are going to verify whether the `Postgres`, `PetSet` and it's `Pod` have
 
 ```bash
 $ kubectl get postgres -n demo pg -o=jsonpath='{.spec.version}{"\n"}'
-13.2
+18.3
 
-$ kubectl get sts -n demo pg -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-postgres:13.2-alpine
+$ kubectl get petset -n demo pg -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+ghcr.io/appscode-images/postgres:18.3-alpine
 
 $ kubectl get pod -n demo pg-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-postgres:13.2-alpine
+ghcr.io/appscode-images/postgres:18.3-alpine
 ```
 
 You can see above that our `Postgres` has been updated with the new version. It verifies that we have successfully updated our Postgres Instance.

--- a/docs/guides/postgres/volume-expansion/ha-cluster/HA Cluster.md
+++ b/docs/guides/postgres/volume-expansion/ha-cluster/HA Cluster.md
@@ -99,7 +99,7 @@ pg-ha-cluster   18.3     Ready    3m6s
 Let's check volume size from petset, and from the persistent volume,
 
 ```bash
-$ kubectl get sts -n demo pg-ha-cluster -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo pg-ha-cluster -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "10Gi"
 
 $ kubectl get pv -n demo
@@ -233,7 +233,7 @@ Events:
 Now, we are going to verify from the `Petset`, and the `Persistent Volume` whether the volume of the `pg-ha-cluster` has expanded to meet the desired state, Let's check that particular petset,
 
 ```bash
-$ kubectl get sts -n demo pg-ha-cluster -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo pg-ha-cluster -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "12Gi"
 
 $ kubectl get pv -n demo

--- a/docs/guides/postgres/volume-expansion/standalone/standalone.md
+++ b/docs/guides/postgres/volume-expansion/standalone/standalone.md
@@ -99,7 +99,7 @@ pg-standalone   18.3      Ready     3m47s
 Let's check volume size from petset, and from the persistent volume,
 
 ```bash
-$ kubectl get sts -n demo pg-standalone -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo pg-standalone -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "10Gi"
 
 $ kubectl get pv -n demo
@@ -233,7 +233,7 @@ Events:
 Now, we are going to verify from the `Petset`, and the `Persistent Volume` whether the volume of the standalone database has expanded to meet the desired state, Let's check,
 
 ```bash
-$ kubectl get sts -n demo pg-standalone -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo pg-standalone -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "12Gi"
 
 $ kubectl get pv -n demo


### PR DESCRIPTION
## Postgres docs refresher: fixes found by executing the guides

Every fix below was found by running the postgres guides on a live KubeDB cluster (v2026.6.19, PostgreSQL 18.3) and comparing real output to what the docs claim. Each was confirmed against the source of truth (apimachinery API types, `kubectl api-resources`, or observed cluster behavior) and re-verified after the fix.

### Auth secret keys (wrong key names returned empty)

- `quickstart/quickstart.md`, `initialization/script_source.md`, `clustering/streaming_replication.md`: the auth secret was read with `POSTGRES_USER` / `POSTGRES_PASSWORD` keys, which return nothing. The real keys are `username` / `password` (secret type `kubernetes.io/basic-auth`, keys `core.BasicAuthUsernameKey`/`BasicAuthPasswordKey`). Fixed the read commands, the example secret YAML, and the `kubectl dba describe` output (`Type: Opaque` -> `kubernetes.io/basic-auth`).

### StatefulSet -> PetSet

- `update-version`, `scaling/vertical-scaling`, `scaling/horizontal-scaling`, `tls/configure`, `volume-expansion/standalone`, `volume-expansion/ha-cluster`: `kubectl get sts -n demo <db>` returns `statefulsets.apps "..." not found`. KubeDB manages a PetSet; changed `sts` -> `petset`.

### Clustering (streaming_replication.md)

- Standby role label is `kubedb.com/role=standby`, not `replica`.
- The standby Service is `<db>-standby` (all-pods service is `<db>-pods`); the doc's `<db>-replicas` service does not exist. Fixed the service listing and the hot-standby connection host.
- `select pg_last_xlog_receive_location();` errors on PG18 (function removed); replaced with `pg_last_wal_receive_lsn()`.
- Malformed `version: "10.2"-v5` -> `version: "18.3"`.

### Broken paths / URLs (404)

- `update-version`: `yamls/update_version.yaml` -> `yamls/upgrade_version.yaml`.
- `scaling/horizontal-scaling`: deploy path was missing `/yamls/`.
- `configuration/using-config-file`: the `curl` URL used `raw.githubusercontent.com/.../raw/...` (404); removed the extra `/raw/`. The `kubectl apply` path pointed to a non-existent `configuration/pg-configuration.yaml`; pointed it to the real `custom-config/pg-custom-config.yaml` and aligned that file's `secretName` to `pg-configuration`.

### rotate-authentication

- After user-defined rotation the doc read secret `quick-postgres-user-auth-new`, which does not exist. The rotated secret is `quick-postgres-user-auth`.

### custom-rbac

- The Role granted `petsets` under apiGroup `apps`; PetSets are in `apps.k8s.appscode.com`. Fixed the group in the doc and both example role YAMLs (which were even staler, using `statefulsets`). Also fixed the `miniute-postgres` typo -> `minute-postgres`.

### Stale output that no longer matches

- `synchronous`: default is now quorum-based (`synchronous_standby_names = ANY 1 (...)`); replicas report `sync_state = quorum`, not `sync`/`potential`.
- `configuration/pgtune`: generated config header shows `# DB Version: 18` for a 18.3 database (doc said `17`).
- `update-version`: before/after version-verify outputs showed `11.11`/`13.2`, contradicting the guide's own 17.9 -> 18.3 flow.
- `reconfigure/cluster`: one explanatory bullet said `spec.configuration.secretName` while the ops YAML uses `spec.configuration.configSecret.name`.

### Verification

All fixes were re-run on the cluster and produce the documented result (readiness reached, ops requests `Successful`, corrected commands return the expected values). No em-dashes were introduced. Some guides were blocked by missing cluster infrastructure (no expandable StorageClass for volume expansion, no prometheus-operator, no object storage for backup/pitr, no gitops operator, no second cluster for remote-replica) and were not modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PostgreSQL guides and examples to match current command output, resource names, and connection steps.
  * Refreshed credential and secret examples to use `username`/`password` keys and basic-auth secret types.
  * Reworked clustering, scaling, upgrade, and volume-expansion examples to use `petset` where applicable.
  * Corrected RBAC and configuration examples, including updated API group and resource names.
  * Adjusted version references and replication outputs to reflect newer PostgreSQL behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->