### PR TITLE
docs(mariadb): fix mysql client, sts->petset, and secret-read commands found by executing the guides

### DIFF
--- a/docs/guides/mariadb/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mariadb/autoscaler/storage/cluster/index.md
@@ -100,7 +100,7 @@ sample-mariadb   11.8.5    Ready    3m46s
 Let's check volume size from petset, and from the persistent volume,
 
 ```bash
-$ kubectl get sts -n demo sample-mariadb -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo sample-mariadb -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1Gi"
 
 $ kubectl get pv -n demo
@@ -296,7 +296,7 @@ Events:
 Now, we are going to verify from the `Petset`, and the `Persistent Volume` whether the volume of the replicaset database has expanded to meet the desired state, Let's check,
 
 ```bash
-$ kubectl get sts -n demo sample-mariadb -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo sample-mariadb -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1594884096"
 $ kubectl get pv -n demo
 NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS          REASON   AGE

--- a/docs/guides/mariadb/backup/stash/logical/cluster/index.md
+++ b/docs/guides/mariadb/backup/stash/logical/cluster/index.md
@@ -107,7 +107,7 @@ Once the database pod is in `Running` state, verify that all 3 nodes joined the 
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 26
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -138,7 +138,7 @@ Here, we are going to use the root user (`MYSQL_ROOT_USERNAME`) credential `MYSQ
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 341
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -420,7 +420,7 @@ Now, let's simulate an accidental deletion scenario. Here, we are going to exec 
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 341
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -514,7 +514,7 @@ Now, let's exec into the database pod and verify whether data actual data was re
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 341
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution

--- a/docs/guides/mariadb/backup/stash/logical/standalone/index.md
+++ b/docs/guides/mariadb/backup/stash/logical/standalone/index.md
@@ -121,7 +121,7 @@ Here, we are going to use the root user (`MYSQL_ROOT_USERNAME`) credential `MYSQ
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 341
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -405,7 +405,7 @@ Now, let's simulate an accidental deletion scenario. Here, we are going to exec 
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 341
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -502,7 +502,7 @@ Now, let's exec into the database pod and verify whether data actual data was re
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 341
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution

--- a/docs/guides/mariadb/clustering/galera-cluster/index.md
+++ b/docs/guides/mariadb/clustering/galera-cluster/index.md
@@ -139,7 +139,7 @@ status:
   phase: Ready
 
 
-$ kubectl get sts,svc,secret,pvc,pv,pod -n demo
+$ kubectl get petset,svc,secret,pvc,pv,pod -n demo
 NAME                              READY   AGE
 petset.apps/sample-mariadb   3/3     116m
 
@@ -175,7 +175,7 @@ Once the database is in running state we can conncet to each of three nodes. We 
 ```bash
 # First Node
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 26
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -198,7 +198,7 @@ Bye
 
 # Second Node
 $ kubectl exec -it -n demo sample-mariadb-1 -- bash
-root@sample-mariadb-1:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-1:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 94
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -221,7 +221,7 @@ Bye
 
 # Third Node
 $ kubectl exec -it -n demo sample-mariadb-2 -- bash
-root@sample-mariadb-2:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-2:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 78
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -248,7 +248,7 @@ Now, we are ready to check newly created cluster status. Connect and run the fol
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 137
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -274,7 +274,7 @@ In a MariaDB Galera Cluster, Each member can read and write. In this section, we
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 202
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -308,7 +308,7 @@ Bye
 root@sample-mariadb-0:/ exit
 exit
 ~ $ kubectl exec -it -n demo sample-mariadb-1 -- bash
-root@sample-mariadb-1:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-1:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 209
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -345,7 +345,7 @@ Bye
 root@sample-mariadb-1:/ exit
 exit
 ~ $ kubectl exec -it -n demo sample-mariadb-2 -- bash
-root@sample-mariadb-2:/  mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-2:/  mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 209
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -383,7 +383,7 @@ To test automatic failover, we will force the one of three pods to restart and c
 
 ```bash
 kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 11
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -414,7 +414,7 @@ pod "sample-mariadb-0" deleted
 
 # Wait for sample-mariadb-0 to restart
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 10
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution

--- a/docs/guides/mariadb/configuration/using-config-file/index.md
+++ b/docs/guides/mariadb/configuration/using-config-file/index.md
@@ -141,7 +141,7 @@ Now, we will check if the database has started with the custom configuration we 
 ```bash
 # Connceting to the database
  $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 23
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution

--- a/docs/guides/mariadb/configuration/using-pod-template/index.md
+++ b/docs/guides/mariadb/configuration/using-pod-template/index.md
@@ -128,7 +128,7 @@ Now, we will check if the database has started with the custom configuration we 
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 22
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution

--- a/docs/guides/mariadb/distributed/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mariadb/distributed/autoscaler/storage/cluster/index.md
@@ -186,7 +186,7 @@ sample-mariadb-1   3/3     Running   0          3m46s
 Let's check volume size from petset, and from the persistent volume on `demo-worker`,
 
 ```bash
-$ kubectl get sts -n demo sample-mariadb -o json --context demo-worker | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo sample-mariadb -o json --context demo-worker | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1Gi"
 
 $ kubectl get pv -n demo --context demo-worker
@@ -337,7 +337,7 @@ Status:
 Now, we are going to verify from the `Petset` and the `Persistent Volume` whether the volume of the distributed replicaset database has expanded to meet the desired state, Let's check,
 
 ```bash
-$ kubectl get sts -n demo sample-mariadb -o json --context demo-worker | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo sample-mariadb -o json --context demo-worker | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1594884096"
 $ kubectl get pv -n demo --context demo-worker
 NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS          REASON   AGE

--- a/docs/guides/mariadb/initialization/git-sync.md
+++ b/docs/guides/mariadb/initialization/git-sync.md
@@ -89,7 +89,7 @@ Next, we will connect to the MariaDB database and verify the data inserted from 
 kubectl exec -it -n demo sample-mariadb-0 -- bash
 Defaulted container "mariadb" out of: mariadb, mariadb-init (init), git-sync (init)
 
-mysql@sample-mariadb-0:/$ mysql -uroot -p$MYSQL_ROOT_PASSWORD
+mysql@sample-mariadb-0:/$ mariadb -uroot -p$MYSQL_ROOT_PASSWORD
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 6
 Server version: 10.5.23-MariaDB-1:11.8.5+maria~ubu2004 mariadb.org binary distribution

--- a/docs/guides/mariadb/initialization/using-script/index.md
+++ b/docs/guides/mariadb/initialization/using-script/index.md
@@ -126,7 +126,7 @@ Now, we will connect to this database and check the data inserted by the initliz
 ```bash
 # Connecting to the database
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 40
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution

--- a/docs/guides/mariadb/quickstart/overview/index.md
+++ b/docs/guides/mariadb/quickstart/overview/index.md
@@ -273,10 +273,10 @@ If you want to use an existing secret please specify that when creating the Mari
 Now, we need `username` and `password` to connect to this database from `kubeclt exec` command. In this example, `sample-mariadb-auth`  secret holds username and password.
 
 ```bash
-$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.password}' | base64 -d
 w*yOU$b53dTbjsjJ
 ```
 
@@ -336,7 +336,7 @@ mariadb.kubedb.com "sample-mariadb" deleted
 Now, run the following command to get all mariadb resources in `demo` namespaces,
 
 ```bash
-$ kubectl get sts,svc,secret,pvc -n demo
+$ kubectl get petset,svc,secret,pvc -n demo
 NAME                         TYPE                                  DATA   AGE
 secret/default-token-w2pgw   kubernetes.io/service-account-token   3      31m
 secret/sample-mariadb-auth   kubernetes.io/basic-auth              2      39s
@@ -363,7 +363,7 @@ mariadb.kubedb.com "sample-mariadb" deleted
 Now, run the following command to get all mariadb resources in `demo` namespaces,
 
 ```bash
-$ kubectl get sts,svc,secret,pvc -n demo
+$ kubectl get petset,svc,secret,pvc -n demo
 NAME                         TYPE                                  DATA   AGE
 secret/default-token-w2pgw   kubernetes.io/service-account-token   3      31m
 secret/sample-mariadb-auth   kubernetes.io/basic-auth              2      39s
@@ -387,7 +387,7 @@ mariadb.kubedb.com "sample-mariadb" deleted
 Now, run the following command to get all mariadb resources in `demo` namespaces,
 
 ```bash
-$ kubectl get sts,svc,secret,pvc -n demo
+$ kubectl get petset,svc,secret,pvc -n demo
 No resources found in demo namespace.
 ```
 

--- a/docs/guides/mariadb/reconfigure-tls/cluster/index.md
+++ b/docs/guides/mariadb/reconfigure-tls/cluster/index.md
@@ -76,14 +76,14 @@ sample-mariadb   11.8.5    Ready    9m17s
 ```
 
 ```bash
-$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.password}' | base64 -d
 U6(h_pYrekLZ2OOd
 
 $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb  -- bash
-root@sample-mariadb-0:/  mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/  mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 108
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -225,7 +225,7 @@ root@sample-mariadb-0:/ ls /etc/mysql/certs/client
 ca.crt  tls.crt  tls.key
 root@sample-mariadb-0:/ ls /etc/mysql/certs/server
 ca.crt  tls.crt  tls.key
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 58
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -530,7 +530,7 @@ Now, Let's exec into the database and find out that TLS is disabled or not.
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb  -- bash
-root@sample-mariadb-0:/  mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/  mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 108
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution

--- a/docs/guides/mariadb/reconfigure/cluster/index.md
+++ b/docs/guides/mariadb/reconfigure/cluster/index.md
@@ -105,10 +105,10 @@ Now, we will check if the database has started with the custom configuration we 
 First we need to get the username and password to connect to a mariadb instance,
 
 ```bash
-$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.\username}' | base64 -d                                                                       
+$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.username}' | base64 -d                                                                       
 root
 
-$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.\password}' | base64 -d                                                                         
+$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.password}' | base64 -d                                                                         
 nrKuxni0wDSMrgwy
 ```
 
@@ -116,7 +116,7 @@ Now, we will check if the database has started with the custom configuration we 
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 23
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -270,7 +270,7 @@ Now let's connect to a mariadb instance and run a mariadb internal command to ch
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 23
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -339,7 +339,7 @@ Before applying this yaml we are going to check the existing value of our new fi
 
 ```bash
 $ kubectl exec -it sample-mariadb-0 -n demo -c mariadb -- bash
-root@sample-mariadb-0:/# mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/# mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 23
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -449,7 +449,7 @@ Now let's connect to a mariadb instance and run a mariadb internal command to ch
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 23
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -543,7 +543,7 @@ Now let's connect to a mariadb instance and run a mariadb internal command to ch
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 23
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution

--- a/docs/guides/mariadb/reconfigure/standalone/index.md
+++ b/docs/guides/mariadb/reconfigure/standalone/index.md
@@ -103,10 +103,10 @@ Now, we will check if the database has started with the custom configuration we 
 First we need to get the username and password to connect to a mariadb instance,
 
 ```bash
-$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.\username}' | base64 -d                                                                       
+$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.username}' | base64 -d                                                                       
 root
 
-$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.\password}' | base64 -d                                                                         
+$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.password}' | base64 -d                                                                         
 PlWA6JNLkNFudl4I
 ```
 
@@ -114,7 +114,7 @@ Now, we will check if the database has started with the custom configuration we 
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
-root@sample-mariadb-0:/# mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/# mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 11
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -265,7 +265,7 @@ Now let's connect to a mariadb instance and run a mariadb internal command to ch
 
 ```bash
 $ $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
-root@sample-mariadb-0:/# mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/# mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 21
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -332,7 +332,7 @@ Before applying this yaml we are going to check the existing value of our new fi
 
 ```bash
 $ kubectl exec -it sample-mariadb-0 -n demo -c mariadb -- bash
-root@sample-mariadb-0:/# mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/# mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 21
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -442,7 +442,7 @@ Now let's connect to a mariadb instance and run a mariadb internal command to ch
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
-root@sample-mariadb-0:/# mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/# mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 24
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -534,7 +534,7 @@ Now let's connect to a mariadb instance and run a mariadb internal command to ch
 
 ```bash
 $ kubectl exec -it -n demo sample-mariadb-0 -- bash
-root@sample-mariadb-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@sample-mariadb-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 8
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution

--- a/docs/guides/mariadb/scaling/horizontal-scaling/cluster/index.md
+++ b/docs/guides/mariadb/scaling/horizontal-scaling/cluster/index.md
@@ -87,7 +87,7 @@ Let's check the number of replicas this database has from the MariaDB object, nu
 ```bash
 $ kubectl get mariadb -n demo sample-mariadb -o json | jq '.spec.replicas'
 3
-$ kubectl get sts -n demo sample-mariadb -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo sample-mariadb -o json | jq '.spec.replicas'
 3
 ```
 
@@ -97,10 +97,10 @@ Also, we can verify the replicas of the replicaset from an internal mariadb comm
 
 First we need to get the username and password to connect to a mariadb instance,
 ```bash
-$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo sample-mariadb-auth -o jsonpath='{.data.password}' | base64 -d
 nrKuxni0wDSMrgwy
 ```
 
@@ -108,7 +108,7 @@ Now let's connect to a mariadb instance and run a mariadb internal command to ch
 
 ```bash
 $  kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
-root@sample-mariadb-0:/ mysql -uroot -p$MYSQL_ROOT_PASSWORD -e "show status like 'wsrep_cluster_size';"
+root@sample-mariadb-0:/ mariadb -uroot -p$MYSQL_ROOT_PASSWORD -e "show status like 'wsrep_cluster_size';"
 +--------------------+-------+
 | Variable_name      | Value |
 +--------------------+-------+
@@ -174,7 +174,7 @@ We can see from the above output that the `MariaDBOpsRequest` has succeeded. Now
 ```bash
 $ kubectl get mariadb -n demo sample-mariadb -o json | jq '.spec.replicas'
 5
-$ kubectl get sts -n demo sample-mariadb -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo sample-mariadb -o json | jq '.spec.replicas'
 5
 ```
 
@@ -182,7 +182,7 @@ Now let's connect to a mariadb instance and run a mariadb internal command to ch
 
 ```bash
 $ $  kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
-root@sample-mariadb-0:/ mysql -uroot -p$MYSQL_ROOT_PASSWORD -e "show status like 'wsrep_cluster_size';"
+root@sample-mariadb-0:/ mariadb -uroot -p$MYSQL_ROOT_PASSWORD -e "show status like 'wsrep_cluster_size';"
 +--------------------+-------+
 | Variable_name      | Value |
 +--------------------+-------+
@@ -245,14 +245,14 @@ We can see from the above output that the `MariaDBOpsRequest` has succeeded. Now
 ```bash
 $ kubectl get mariadb -n demo sample-mariadb -o json | jq '.spec.replicas' 
 3
-$ kubectl get sts -n demo sample-mariadb -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo sample-mariadb -o json | jq '.spec.replicas'
 3
 ```
 
 Now let's connect to a mariadb instance and run a mariadb internal command to check the number of replicas,
 ```bash
 $ $  kubectl exec -it -n demo sample-mariadb-0 -c mariadb -- bash
-root@sample-mariadb-0:/ mysql -uroot -p$MYSQL_ROOT_PASSWORD -e "show status like 'wsrep_cluster_size';"
+root@sample-mariadb-0:/ mariadb -uroot -p$MYSQL_ROOT_PASSWORD -e "show status like 'wsrep_cluster_size';"
 +--------------------+-------+
 | Variable_name      | Value |
 +--------------------+-------+

--- a/docs/guides/mariadb/tls/configure/index.md
+++ b/docs/guides/mariadb/tls/configure/index.md
@@ -146,7 +146,7 @@ $ kubectl get mariadb -n demo md-standalone-tls
 NAME             VERSION   STATUS   AGE
 md-standalone-tls   11.8.5    Ready    5m48s
 
-$ kubectl get sts -n demo md-standalone-tls
+$ kubectl get petset -n demo md-standalone-tls
 NAME             READY   AGE
 md-standalone-tls   1/1     7m5s
 ```
@@ -183,7 +183,7 @@ ca.crt  tls.crt  tls.key
 root@md-standalone-tls-0:/ ls /etc/mysql/certs/server
 ca.crt  tls.crt  tls.key
 
-root@md-standalone-tls-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@md-standalone-tls-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 64
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -231,7 +231,7 @@ Let's connect to the database server with a secure connection,
 
 ```bash
 $ kubectl exec -it -n demo md-standalone-tls-0 -- bash
-root@md-standalone-tls-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@md-standalone-tls-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 92
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -250,11 +250,11 @@ MariaDB [(none)]> exit
 Bye
 
 #  accessing the database server with newly created user
-root@md-standalone-tls-0:/ mysql -unew_user -p1234
+root@md-standalone-tls-0:/ mariadb -unew_user -p1234
 ERROR 1045 (28000): Access denied for user 'new_user'@'localhost' (using password: YES)
 
 # accessing the database server newly created user with certificates
-root@md-standalone-tls-0:/ mysql -unew_user -p1234 --ssl-ca=/etc/mysql/certs/server/ca.crt  --ssl-cert=/etc/mysql/certs/server/tls.crt --ssl-key=/etc/mysql/certs/server/tls.key
+root@md-standalone-tls-0:/ mariadb -unew_user -p1234 --ssl-ca=/etc/mysql/certs/server/ca.crt  --ssl-cert=/etc/mysql/certs/server/tls.crt --ssl-key=/etc/mysql/certs/server/tls.key
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 116
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -362,7 +362,7 @@ ca.crt  tls.crt  tls.key
 root@md-cluster-tls-0:/ ls /etc/mysql/certs/server
 ca.crt  tls.crt  tls.key
 
-root@md-cluster-tls-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@md-cluster-tls-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 64
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -408,7 +408,7 @@ root@md-cluster-tls-1:/ ls /etc/mysql/certs/client
 ca.crt  tls.crt  tls.key
 root@md-cluster-tls-1:/ ls /etc/mysql/certs/server
 ca.crt  tls.crt  tls.key
-root@md-cluster-tls-1:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@md-cluster-tls-1:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 34
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -456,7 +456,7 @@ Let's connect to the database server with a secure connection,
 
 ```bash
 $ kubectl exec -it -n demo md-cluster-tls-0 -- bash
-root@md-cluster-tls-0:/ mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
+root@md-cluster-tls-0:/ mariadb -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 92
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution
@@ -475,11 +475,11 @@ MariaDB [(none)]> exit
 Bye
 
 #  accessing the database server with newly created user
-root@md-cluster-tls-0:/ mysql -unew_user -p1234
+root@md-cluster-tls-0:/ mariadb -unew_user -p1234
 ERROR 1045 (28000): Access denied for user 'new_user'@'localhost' (using password: YES)
 
 # accessing the database server newly created user with certificates
-root@md-cluster-tls-0:/ mysql -unew_user -p1234 --ssl-ca=/etc/mysql/certs/server/ca.crt  --ssl-cert=/etc/mysql/certs/server/tls.crt --ssl-key=/etc/mysql/certs/server/tls.key
+root@md-cluster-tls-0:/ mariadb -unew_user -p1234 --ssl-ca=/etc/mysql/certs/server/ca.crt  --ssl-cert=/etc/mysql/certs/server/tls.crt --ssl-key=/etc/mysql/certs/server/tls.key
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 116
 Server version: 11.8.5-MariaDB-1:11.8.5+maria~focal mariadb.org binary distribution

--- a/docs/guides/mariadb/update-version/cluster/index.md
+++ b/docs/guides/mariadb/update-version/cluster/index.md
@@ -139,7 +139,7 @@ Now, we are going to verify whether the `MariaDB` and the related `PetSets` and 
 $ kubectl get mariadb -n demo sample-mariadb -o=jsonpath='{.spec.version}{"\n"}'
 12.1.2
 
-$ kubectl get sts -n demo sample-mariadb -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+$ kubectl get petset -n demo sample-mariadb -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
 mariadb:12.1.2
 
 $ kubectl get pods -n demo sample-mariadb-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'


### PR DESCRIPTION
Fixes found by running the MariaDB guides on a live KubeDB cluster (MariaDB 12.1.2), confirmed against cluster behavior.

## Fixes

### mysql -> mariadb client (real, breaking)
The guides connect with `mysql -u${MYSQL_ROOT_USERNAME} -p${MYSQL_ROOT_PASSWORD}`. On the MariaDB 12.1.2 image the `mysql` binary does not exist (`/usr/bin/mysql`: No such file; `command -v mysql` empty; exit 127). The client is `mariadb` (`/usr/bin/mariadb`), which works. The quickstart already used `mariadb`; galera and other guides still used `mysql`. Replaced `mysql -u` -> `mariadb -u` across the guide tree.

### kubectl get sts -> kubectl get petset
`kubectl get sts <db>` returns `statefulsets.apps not found` — KubeDB manages a PetSet. Replaced across the affected guides.

### stray-backslash secret reads
`jsonpath='{.data.\username}'` / `'{.data.\password}'` cleaned to `{.data.username}` / `{.data.password}`.

## Verified on cluster
- quickstart: sample-mariadb 12.1.2 Ready; auth secret basic-auth keys username/password (root); `mariadb` connection + `show databases` work.
- galera-cluster: 3-node GaleraCluster, `wsrep_cluster_size=3`, multi-primary confirmed (write on node-1, read on node-2).

No em-dashes introduced. Guides not individually executed received only the above confirmed-pattern fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MariaDB guides to use the `mariadb` client in examples instead of `mysql`.
  * Corrected credential lookup examples so username and password fields are referenced properly.
  * Switched several verification commands to query `petset` resources instead of `statefulset`/`sts`.
  * Refreshed autoscaling, scaling, TLS, reconfiguration, backup, initialization, quickstart, and version-check walkthroughs for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->