### PR TITLE
docs(mysql): fix sts->petset and secret-read commands found by executing the guides

### DIFF
--- a/docs/guides/mysql/autoscaler/storage/cluster/index.md
+++ b/docs/guides/mysql/autoscaler/storage/cluster/index.md
@@ -102,7 +102,7 @@ sample-mysql   10.5.23    Ready    3m46s
 Let's check volume size from petset, and from the persistent volume,
 
 ```bash
-$ kubectl get sts -n demo sample-mysql -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo sample-mysql -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1Gi"
 
 $ kubectl get pv -n demo
@@ -298,7 +298,7 @@ Events:
 Now, we are going to verify from the `Petset`, and the `Persistent Volume` whether the volume of the replicaset database has expanded to meet the desired state, Let's check,
 
 ```bash
-$ kubectl get sts -n demo sample-mysql -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo sample-mysql -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1594884096"
 $ kubectl get pv -n demo
 NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS          REASON   AGE

--- a/docs/guides/mysql/clients/index.md
+++ b/docs/guides/mysql/clients/index.md
@@ -86,8 +86,8 @@ Every 3.0s: kubectl get my -n demo my-group                      suaas-appscode:
 NAME       VERSION   STATUS    AGE
 my-group   8.4.8    Running   16m
 
-$ watch -n 3 kubectl get sts -n demo my-group
-ery 3.0s: kubectl get sts -n demo my-group                     suaas-appscode: Wed Sep  9 10:53:52 2020
+$ watch -n 3 kubectl get petset -n demo my-group
+ery 3.0s: kubectl get petset -n demo my-group                     suaas-appscode: Wed Sep  9 10:53:52 2020
 
 NAME       READY   AGE
 my-group   3/3     15m
@@ -299,10 +299,10 @@ KubeDB operator has created a new Secret called `my-group-auth` **(format: {mysq
 Now, you can connect to this database from your terminal using the `mysql` user and password.
 
 ```bash
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.password}' | base64 -d
 RmxLjEomvE6tVj4-
 ```
 

--- a/docs/guides/mysql/clustering/group-replication/index.md
+++ b/docs/guides/mysql/clustering/group-replication/index.md
@@ -283,10 +283,10 @@ If you want to use an existing secret please specify that when creating the MySQ
 Now, you can connect to this database from your terminal using the `mysql` user and password.
 
 ```bash
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.password}' | base64 -d
 d)q2MVmJK$Oex=mW
 ```
 

--- a/docs/guides/mysql/clustering/innodb-cluster/index.md
+++ b/docs/guides/mysql/clustering/innodb-cluster/index.md
@@ -296,10 +296,10 @@ If you want to use an existing secret please specify that when creating the MySQ
 Now, you can connect to this database from your terminal using the `mysql` user and password.
 
 ```bash
-$ kubectl get secrets -n demo innodb-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo innodb-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo innodb-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo innodb-auth -o jsonpath='{.data.password}' | base64 -d
 ny5jSirIzVtWDcZ7
 ```
 

--- a/docs/guides/mysql/clustering/remote-replica/index.md
+++ b/docs/guides/mysql/clustering/remote-replica/index.md
@@ -163,10 +163,10 @@ mysql-singapore   8.4.8    Ready    22h
 Now, you can connect to this database from your terminal using the `mysql` user and password.
 
 ```bash
-$ kubectl get secrets -n demo mysql-singapore-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mysql-singapore-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mysql-singapore-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mysql-singapore-auth -o jsonpath='{.data.password}' | base64 -d
 pass
 ```
 

--- a/docs/guides/mysql/clustering/semi-sync/index.md
+++ b/docs/guides/mysql/clustering/semi-sync/index.md
@@ -326,10 +326,10 @@ If you want to use an existing secret please specify that when creating the MySQ
 Now, you can connect to this database from your terminal using the `mysql` user and password.
 
 ```bash
-$ kubectl get secrets -n demo semi-sync-mysql-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo semi-sync-mysql-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo semi-sync-mysql-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo semi-sync-mysql-auth -o jsonpath='{.data.password}' | base64 -d
 y~EC~984Et1Yfs~i
 ```
 

--- a/docs/guides/mysql/configuration/config-file/index.md
+++ b/docs/guides/mysql/configuration/config-file/index.md
@@ -195,7 +195,7 @@ $ kubectl get pods custom-mysql-0 -n demo -o yaml | grep IP
 $ kubectl get secrets -n demo custom-mysql-auth -o jsonpath='{.data.\user}' | base64 -d
 root
 
-$ kubectl get secrets -n demo custom-mysql-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo custom-mysql-auth -o jsonpath='{.data.password}' | base64 -d
 MLO5_fPVKcqPiEu9
 ```
 

--- a/docs/guides/mysql/configuration/podtemplating/index.md
+++ b/docs/guides/mysql/configuration/podtemplating/index.md
@@ -178,7 +178,7 @@ $ kubectl get pods mysql-misc-config-0 -n demo -o yaml | grep IP
 $ kubectl get secrets -n demo mysql-misc-config-auth -o jsonpath='{.data.\user}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mysql-misc-config-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mysql-misc-config-auth -o jsonpath='{.data.password}' | base64 -d
 MLO5_fPVKcqPiEu9
 ```
 

--- a/docs/guides/mysql/initialization/using_script.md
+++ b/docs/guides/mysql/initialization/using_script.md
@@ -471,7 +471,7 @@ $ kubectl get pods mysql-init-script-0 -n demo -o yaml | grep IP
 $ kubectl get secrets -n demo mysql-init-script-auth -o jsonpath='{.data.\user}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mysql-init-script-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mysql-init-script-auth -o jsonpath='{.data.password}' | base64 -d
 1Pc7bwSygrv1MX1Q
 ```
 

--- a/docs/guides/mysql/quickstart/index.md
+++ b/docs/guides/mysql/quickstart/index.md
@@ -353,10 +353,10 @@ Now, we need `username` and `password` to connect to this database from `kubectl
 $ kubectl get pods mysql-quickstart-0 -n demo -o yaml | grep podIP
   podIP: 10.244.0.30
 
-$ kubectl get secrets -n demo mysql-quickstart-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mysql-quickstart-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mysql-quickstart-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mysql-quickstart-auth -o jsonpath='{.data.password}' | base64 -d
 H(Y.s)pg&cX1Ds3J
 ```
 we will exec into the pod `mysql-quickstart-0` and connect to the database using username and password
@@ -514,7 +514,7 @@ mysql.kubedb.com "mysql-quickstart" deleted
 Now, run the following command to get all mysql resources in `demo` namespaces,
 
 ```bash
-$ kubectl get sts,svc,secret,pvc -n demo
+$ kubectl get petset,svc,secret,pvc -n demo
 NAME                           TYPE                                  DATA   AGE
 secret/default-token-lgbjm     kubernetes.io/service-account-token   3      23h
 secret/mysql-quickstart-auth   Opaque                                2      20h
@@ -543,7 +543,7 @@ mysql.kubedb.com "mysql-quickstart" deleted
 Now, run the following command to get all mysql resources in `demo` namespaces,
 
 ```bash
-$ kubectl get sts,svc,secret,pvc -n demo
+$ kubectl get petset,svc,secret,pvc -n demo
 NAME                           TYPE                                  DATA   AGE
 secret/default-token-lgbjm     kubernetes.io/service-account-token   3      24h
 secret/mysql-quickstart-auth   Opaque
@@ -567,7 +567,7 @@ mysql.kubedb.com "mysql-quickstart" deleted
 Now, run the following command to get all mysql resources in `demo` namespaces,
 
 ```bash
-$ kubectl get sts,svc,secret,pvc -n demo
+$ kubectl get petset,svc,secret,pvc -n demo
 No resources found in demo namespace.
 ```
 

--- a/docs/guides/mysql/reconfigure-tls/reconfigure/index.md
+++ b/docs/guides/mysql/reconfigure-tls/reconfigure/index.md
@@ -329,10 +329,10 @@ Now, we can connect to this database through `mysql-shell` and verify that the T
 
 
 ```bash
-$ kubectl get secrets -n demo mysql-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mysql-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mysql-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mysql-auth -o jsonpath='{.data.password}' | base64 -d
 f8EyKG)mNMIMdS~a
 
 $ kubectl exec -it mysql-0 -n demo -- mysql -u root --password='f8EyKG)mNMIMdS~a'  --host=mysql-0.mysql-pods.demo -e "show variables like '%require_secure_transport%';";

--- a/docs/guides/mysql/reconfigure/reconfigure-steps/index.md
+++ b/docs/guides/mysql/reconfigure/reconfigure-steps/index.md
@@ -242,10 +242,10 @@ Now, we will check if the database has started with the custom configuration we 
 First we need to get the username and password to connect to a mysql instance,
 
 ```bash
-$ kubectl get secrets -n demo sample-mysql-auth -o jsonpath='{.data.\username}' | base64 -d                                                                       
+$ kubectl get secrets -n demo sample-mysql-auth -o jsonpath='{.data.username}' | base64 -d                                                                       
 root
 
-$ kubectl get secrets -n demo sample-mysql-auth -o jsonpath='{.data.\password}' | base64 -d                                                                         
+$ kubectl get secrets -n demo sample-mysql-auth -o jsonpath='{.data.password}' | base64 -d                                                                         
 86TwLJ!2Kpq*vv1y
 ```
 

--- a/docs/guides/mysql/replication-mode-transform/replication-mode-transform/index.md
+++ b/docs/guides/mysql/replication-mode-transform/replication-mode-transform/index.md
@@ -165,10 +165,10 @@ mysql-singapore   8.4.8    Ready    22h
 Now, you can connect to this database from your terminal using the `mysql` user and password.
 
 ```bash
-$ kubectl get secrets -n demo mysql-singapore-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mysql-singapore-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mysql-singapore-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mysql-singapore-auth -o jsonpath='{.data.password}' | base64 -d
 pass
 ```
 

--- a/docs/guides/mysql/scaling/horizontal-scaling/cluster/index.md
+++ b/docs/guides/mysql/scaling/horizontal-scaling/cluster/index.md
@@ -228,8 +228,8 @@ Every 3.0s: kubectl get my -n demo my-group                     suaas-appscode: 
 NAME       VERSION   STATUS    AGE
 my-group   8.4.8    Running   16m
 
-$ watch -n 3 kubectl get sts -n demo my-group
-Every 3.0s: kubectl get sts -n demo my-group                     Every 3.0s: kubectl get sts -n demo my-group                    suaas-appscode: Tue Jun 30 22:44:35 2020
+$ watch -n 3 kubectl get petset -n demo my-group
+Every 3.0s: kubectl get petset -n demo my-group                     Every 3.0s: kubectl get petset -n demo my-group                    suaas-appscode: Tue Jun 30 22:44:35 2020
 
 NAME       READY   AGE
 my-group   3/3     16m
@@ -246,10 +246,10 @@ my-group-2   2/2     Running   0          11m
 Let's verify that the PetSet's pods have joined into a group replication cluster,
 
 ```bash
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.password}' | base64 -d
 sWfUMoqRpOJyomgb
 
 $ kubectl exec -it -n demo my-group-0 -c mysql -- mysql -u root --password=sWfUMoqRpOJyomgb --host=my-group-0.my-group-pods.demo -e "select * from performance_schema.replication_group_members"
@@ -383,10 +383,10 @@ Events:
 Now, we are going to verify whether the number of members has increased to meet up the desired state, Let's check,
 
 ```bash
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.password}' | base64 -d
 Y28qkWFQ8QHVzq2h
 
 $ kubectl exec -it -n demo my-group-0 -c mysql -- mysql -u root --password=Y28qkWFQ8QHVzq2h --host=my-group-0.my-group-pods.demo -e "select * from performance_schema.replication_group_members"
@@ -516,10 +516,10 @@ Events:
 Now, we are going to verify whether the number of members has decreased to meet up the desired state, Let's check,
 
 ```bash
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.password}' | base64 -d
 Y28qkWFQ8QHVzq2h
 
 $ kubectl exec -it -n demo my-group-0 -c mysql -- mysql -u root --password=5pwciRRUWHhSJ6qQ --host=my-group-0.my-group-pods.demo -e "select * from performance_schema.replication_group_members"

--- a/docs/guides/mysql/scaling/vertical-scaling/cluster/index.md
+++ b/docs/guides/mysql/scaling/vertical-scaling/cluster/index.md
@@ -216,8 +216,8 @@ Every 3.0s: kubectl get my -n demo my-group                     suaas-appscode: 
 NAME       VERSION   STATUS    AGE
 my-group   8.4.8    Running   16m
 
-$ watch -n 3 kubectl get sts -n demo my-group
-Every 3.0s: kubectl get sts -n demo my-group                     Every 3.0s: kubectl get sts -n demo my-group                    suaas-appscode: Tue Jun 30 22:44:35 2020
+$ watch -n 3 kubectl get petset -n demo my-group
+Every 3.0s: kubectl get petset -n demo my-group                     Every 3.0s: kubectl get petset -n demo my-group                    suaas-appscode: Tue Jun 30 22:44:35 2020
 
 NAME       READY   AGE
 my-group   3/3     16m

--- a/docs/guides/mysql/scaling/vertical-scaling/standalone/index.md
+++ b/docs/guides/mysql/scaling/vertical-scaling/standalone/index.md
@@ -111,8 +111,8 @@ Every 3.0s: kubectl get my -n demo my-standalone                 suaas-appscode:
 NAME            VERSION      STATUS    AGE
 my-standalone   8.4.8    Running   2m58s
 
-$ watch -n 3 kubectl get sts -n demo my-standalone
-Every 3.0s: kubectl get sts -n demo my-standalone                suaas-appscode: Wed Jul  1 17:48:52 2020
+$ watch -n 3 kubectl get petset -n demo my-standalone
+Every 3.0s: kubectl get petset -n demo my-standalone                suaas-appscode: Wed Jul  1 17:48:52 2020
 
 NAME            READY   AGE
 my-standalone   1/1     3m36s

--- a/docs/guides/mysql/tls/configure/index.md
+++ b/docs/guides/mysql/tls/configure/index.md
@@ -318,8 +318,8 @@ Every 3.0s: kubectl get my -n demo some-mysql                 suaas-appscode: Th
 NAME           VERSION   STATUS    AGE
 some-mysql   8.4.8    Running   9m41s
 
-$ watch -n 3 kubectl get sts -n demo some-mysql
-Every 3.0s: kubectl get sts -n demo some-mysql                suaas-appscode: Thu Aug 13 19:02:42 2020
+$ watch -n 3 kubectl get petset -n demo some-mysql
+Every 3.0s: kubectl get petset -n demo some-mysql                suaas-appscode: Thu Aug 13 19:02:42 2020
 
 NAME           READY   AGE
 some-mysql   3/3     9m51s

--- a/docs/guides/mysql/update-version/majorversion/group-replication/index.md
+++ b/docs/guides/mysql/update-version/majorversion/group-replication/index.md
@@ -191,7 +191,7 @@ $ watch -n 3 kubectl get my -n demo my-group
 NAME       VERSION      STATUS    AGE
 my-group   8.4.8    Running   5m52s
 
-$ watch -n 3 kubectl get sts -n demo my-group
+$ watch -n 3 kubectl get petset -n demo my-group
 
 NAME       READY   AGE
 my-group   3/3     7m12s
@@ -210,7 +210,7 @@ Let's verify the `MySQL`, the `PetSet` and its `Pod` image version,
 $ kubectl get my -n demo my-group -o=jsonpath='{.spec.version}{"\n"}'
 8.4.8
 
-$ kubectl get sts -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
+$ kubectl get petset -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
 "kubedb/mysql:8.4.8"
 
 $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.containers[1].image'
@@ -222,10 +222,10 @@ $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubern
 Let's also verify that the PetSet’s pods have joined into a group replication,
 
 ```bash
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.password}' | base64 -d
 7gUARa&Jkg.ypJE8
 
 $ kubectl exec -it -n demo my-group-0 -c mysql -- mysql -u root --password='7gUARa&Jkg.ypJE8' --host=my-group-0.my-group-pods.demo -e "select * from performance_schema.replication_group_members"
@@ -369,7 +369,7 @@ Now, we are going to verify whether the `MySQL` and `PetSet` and it's `Pod` have
 $ kubectl get my -n demo my-group -o=jsonpath='{.spec.version}{"\n"}'
 8.0.36
 
-$ kubectl get sts -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
+$ kubectl get petset -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
 "kubedb/mysql:8.0.36"
 
 $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.containers[1].image'
@@ -381,10 +381,10 @@ $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubern
 Let's also check the PetSet pods have joined the `MySQL` group replication,
 
 ```bash
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.password}' | base64 -d
 7gUARa&Jkg.ypJE8
 
 $ kubectl exec -it -n demo my-group-0 -c mysql -- mysql -u root --password='7gUARa&Jkg.ypJE8' --host=my-group-0.my-group-pods.demo -e "select * from performance_schema.replication_group_members"

--- a/docs/guides/mysql/update-version/majorversion/standalone/index.md
+++ b/docs/guides/mysql/update-version/majorversion/standalone/index.md
@@ -188,7 +188,7 @@ $ watch -n 3 kubectl get my -n demo my-standalone
 NAME            VERSION      STATUS    AGE
 my-standalone   8.4.8    Running   3m
 
-$ watch -n 3 kubectl get sts -n demo my-standalone
+$ watch -n 3 kubectl get petset -n demo my-standalone
 
 NAME            READY   AGE
 my-standalone   1/1     3m42s
@@ -205,7 +205,7 @@ Let's verify the `MySQL`, the `PetSet` and its `Pod` image version,
 $ kubectl get my -n demo my-standalone -o=jsonpath='{.spec.version}{"\n"}'
 8.4.8
 
-$ kubectl get sts -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+$ kubectl get petset -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
 kubedb/my:8.4.8
 
 $ kubectl get pod -n demo my-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
@@ -332,7 +332,7 @@ Now, we are going to verify whether the `MySQL`, `PetSet` and it's `Pod` have up
 $ kubectl get my -n demo my-standalone -o=jsonpath='{.spec.version}{"\n"}'
 8.0.36
 
-$ kubectl get sts -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+$ kubectl get petset -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
 mysql:8.0.36
 
 $ kubectl get pod -n demo my-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'

--- a/docs/guides/mysql/update-version/minorversion/group-replication/index.md
+++ b/docs/guides/mysql/update-version/minorversion/group-replication/index.md
@@ -194,7 +194,7 @@ $ watch -n 3 kubectl get my -n demo my-group
 NAME       VERSION   STATUS         AGE
 my-group   8.0.36    Ready          5m
 
-$ watch -n 3 kubectl get sts -n demo my-group
+$ watch -n 3 kubectl get petset -n demo my-group
 
 NAME       READY   AGE
 my-group   3/3     7m12s
@@ -213,7 +213,7 @@ Let's verify the `MySQL`, the `PetSet` and its `Pod` image version,
 $ kubectl get my -n demo my-group -o=jsonpath='{.spec.version}{"\n"}'
 8.0.36
 
-$ kubectl get sts -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
+$ kubectl get petset -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
 "mysql:8.0.36"
 
 $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.containers[1].image'
@@ -225,10 +225,10 @@ $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubern
 Let's also verify that the PetSet’s pods have joined into the group replication,
 
 ```bash
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.password}' | base64 -d
 XbUHi_Cp&SLSXTmo
 
 $ kubectl exec -it -n demo my-group-0 -c mysql -- mysql -u root --password='XbUHi_Cp&SLSXTmo' --host=my-group-0.my-group-pods.demo -e "select * from performance_schema.replication_group_members"
@@ -368,7 +368,7 @@ Now, we are going to verify whether the `MySQL` and `PetSet` and it's `Pod` have
 $ kubectl get my -n demo my-group -o=jsonpath='{.spec.version}{"\n"}'
 8.4.8
 
-$ kubectl get sts -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
+$ kubectl get petset -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
 "mysql:8.4.8"
 
 $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.containers[1].image'
@@ -380,10 +380,10 @@ $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubern
 Let's also check the PetSet pods have joined the `MySQL` group replication,
 
 ```bash
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo my-group-auth -o jsonpath='{.data.password}' | base64 -d
 XbUHi_Cp&SLSXTmo
 
 $ kubectl exec -it -n demo my-group-0 -c mysql -- mysql -u root --password='XbUHi_Cp&SLSXTmo' --host=my-group-0.my-group-pods.demo -e "select * from performance_schema.replication_group_members"

--- a/docs/guides/mysql/update-version/minorversion/standalone/index.md
+++ b/docs/guides/mysql/update-version/minorversion/standalone/index.md
@@ -188,7 +188,7 @@ $ watch -n 3 kubectl get my -n demo my-standalone
 NAME            VERSION      STATUS    AGE
 my-standalone   8.4.8    Running   3m
 
-$ watch -n 3 kubectl get sts -n demo my-standalone
+$ watch -n 3 kubectl get petset -n demo my-standalone
 
 NAME            READY   AGE
 my-standalone   1/1     3m42s
@@ -205,7 +205,7 @@ Let's verify the `MySQL`, the `PetSet` and its `Pod` image version,
 $ kubectl get my -n demo my-standalone -o=jsonpath='{.spec.version}{"\n"}'
 8.4.8
 
-$ kubectl get sts -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+$ kubectl get petset -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
 mysql:8.4.8
 
 $ kubectl get pod -n demo my-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
@@ -332,7 +332,7 @@ Now, we are going to verify whether the `MySQL`, `PetSet` and it's `Pod` have up
 $ kubectl get my -n demo my-standalone -o=jsonpath='{.spec.version}{"\n"}'
 9.0.1
 
-$ kubectl get sts -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+$ kubectl get petset -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
 kubedb/my:9.0.1
 
 $ kubectl get pod -n demo my-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'

--- a/docs/guides/mysql/volume-expansion/volume-expansion/index.md
+++ b/docs/guides/mysql/volume-expansion/volume-expansion/index.md
@@ -227,7 +227,7 @@ sample-mysql     8.4.8    Ready    5m4s
 Let's check volume size from petset, and from the persistent volume,
 
 ```bash
-$ kubectl get sts -n demo sample-mysql -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo sample-mysql -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1Gi"
 
 $ kubectl get pv -n demo
@@ -350,7 +350,7 @@ Events:
 Now, we are going to verify from the `Petset`, and the `Persistent Volumes` whether the volume of the database has expanded to meet the desired state, Let's check,
 
 ```bash
-$ kubectl get sts -n demo sample-mysql -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo sample-mysql -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "2Gi"
 
 $ kubectl get pv -n demo


### PR DESCRIPTION
Fixes found by running the MySQL guides on a live KubeDB cluster (MySQL 9.6.0), confirmed against cluster behavior.

## Fixes
- **kubectl get sts -> kubectl get petset**: `kubectl get sts <db>` returns `statefulsets.apps not found`; KubeDB manages a PetSet. Fixed across affected guides.
- **stray-backslash secret reads**: `jsonpath='{.data.\username}'` / `'{.data.\password}'` cleaned to `{.data.username}` / `{.data.password}`.

## Notes
- `mysql -u...` was deliberately NOT changed: unlike MariaDB, the MySQL image ships `/usr/bin/mysql` and it works (verified in-container).

## Verified on cluster
- quickstart: mysql-quickstart 9.6.0 Ready; auth secret basic-auth keys username/password (root); `mysql` client + `show databases` work.

No em-dashes introduced. Guides beyond quickstart received only the above confirmed-pattern fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple MySQL guides to use the right resource checks during readiness, scaling, and version-upgrade walkthroughs.
  * Fixed several credential lookup examples so username and password commands work as shown.
  * Updated storage and volume-expansion verification steps to match the current resource listings and claim checks.
  * Adjusted quickstart and connection examples to improve copy-paste reliability for database access and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->