### PR TITLE
docs(mongodb): fix mongo->mongosh client and sts->petset found by executing the guides

### DIFF
--- a/docs/guides/mongodb/arbiter/replicaset.md
+++ b/docs/guides/mongodb/arbiter/replicaset.md
@@ -611,7 +611,7 @@ Now verify the automatic failover, Let's exec in `mongo-arb-0` pod,
 
 ```bash
 $ kubectl exec -it mongo-arb-0  -n demo bash
-mongodb@mongo-arb-1:/$ mongosh admin -u root -p 'OX4yb!IFm;~yAHkD'
+mongodb@mongo-arb-0:/$ mongosh admin -u root -p 'OX4yb!IFm;~yAHkD'
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin
 MongoDB server version: 4.4.26

--- a/docs/guides/mongodb/arbiter/replicaset.md
+++ b/docs/guides/mongodb/arbiter/replicaset.md
@@ -342,15 +342,15 @@ Now, you can connect to this database through [mongo-arb](https://docs.mongodb.c
 At first, insert data inside primary member `rs0:PRIMARY`.
 
 ```bash
-$ kubectl get secrets -n demo mongo-arb-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mongo-arb-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mongo-arb-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mongo-arb-auth -o jsonpath='{.data.password}' | base64 -d
 OX4yb!IFm;~yAHkD
 
 $ kubectl exec -it mongo-arb-0 -n demo bash
 
-mongodb@mongo-arb-0:/$ mongo admin -u root -p 'OX4yb!IFm;~yAHkD'
+mongodb@mongo-arb-0:/$ mongosh admin -u root -p 'OX4yb!IFm;~yAHkD'
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin
 MongoDB server version: 4.4.26
@@ -540,7 +540,7 @@ We will exec in `mongo-arb-1`(which is secondary member right now) to check the 
 
 ```bash
 $ kubectl exec -it mongo-arb-1 -n demo bash
-mongodb@mongo-arb-1:/$ mongo admin -u root -p 'OX4yb!IFm;~yAHkD'
+mongodb@mongo-arb-1:/$ mongosh admin -u root -p 'OX4yb!IFm;~yAHkD'
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin
 MongoDB server version: 4.4.26
@@ -611,7 +611,7 @@ Now verify the automatic failover, Let's exec in `mongo-arb-0` pod,
 
 ```bash
 $ kubectl exec -it mongo-arb-0  -n demo bash
-mongodb@mongo-arb-1:/$ mongo admin -u root -p 'OX4yb!IFm;~yAHkD'
+mongodb@mongo-arb-1:/$ mongosh admin -u root -p 'OX4yb!IFm;~yAHkD'
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin
 MongoDB server version: 4.4.26
@@ -703,7 +703,7 @@ Now, If you again exec into the primary `pod` and look for previous data, you wi
 ```bash
 $ kubectl exec -it mongo-arb-1 -n demo bash
 
-mongodb@mongo-arb-1:/$ mongo admin -u root -p 'OX4yb!IFm;~yAHkD'
+mongodb@mongo-arb-1:/$ mongosh admin -u root -p 'OX4yb!IFm;~yAHkD'
 
 rs0:PRIMARY> use mydb
 switched to db mydb

--- a/docs/guides/mongodb/arbiter/sharding.md
+++ b/docs/guides/mongodb/arbiter/sharding.md
@@ -319,14 +319,14 @@ If you want to use custom or existing secret please specify that when creating t
 - Username: Run following command to get _username_,
 
   ```bash
-  $ kubectl get secrets -n demo mongo-sh-arb-auth -o jsonpath='{.data.\username}' | base64 -d
+  $ kubectl get secrets -n demo mongo-sh-arb-auth -o jsonpath='{.data.username}' | base64 -d
   root
   ```
 
 - Password: Run the following command to get _password_,
 
   ```bash
-  $ kubectl get secrets -n demo mongo-sh-arb-auth -o jsonpath='{.data.\password}' | base64 -d
+  $ kubectl get secrets -n demo mongo-sh-arb-auth -o jsonpath='{.data.password}' | base64 -d
   6&UiN5;qq)Tnai=7
   ```
 
@@ -344,7 +344,7 @@ mongo-sh-arb-mongos-1   1/1     Running   0          6m20s
 
 $ kubectl exec -it mongo-sh-arb-mongos-0 -n demo bash
 
-mongodb@mongo-sh-mongos-0:/$ mongo admin -u root -p '6&UiN5;qq)Tnai=7'
+mongodb@mongo-sh-mongos-0:/$ mongosh admin -u root -p '6&UiN5;qq)Tnai=7'
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin?compressors=disabled&gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("bf87addd-4245-45b1-a470-fabb3dcc19ab") }
@@ -450,7 +450,7 @@ As `sh.status()` command only shows the data bearing members, if we want to assu
 ```bash
 kubectl exec -it pod/mongo-sh-arb-shard0-1 -n demo bash
 
-root@mongo-sh-arb-shard0-1:/ mongo admin -u root -p '6&UiN5;qq)Tnai=7'
+root@mongo-sh-arb-shard0-1:/ mongosh admin -u root -p '6&UiN5;qq)Tnai=7'
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin
 MongoDB server version: 4.4.26
@@ -775,7 +775,7 @@ mongo-sh-arb-mongos-1   1/1     Running   0          29s
 
 $ kubectl exec -it mongo-sh-arb-mongos-0 -n demo bash
 
-mongodb@mongo-sh-mongos-0:/$ mongo admin -u root -p '6&UiN5;qq)Tnai=7'
+mongodb@mongo-sh-mongos-0:/$ mongosh admin -u root -p '6&UiN5;qq)Tnai=7'
 
 mongos> use songs
 switched to db songs

--- a/docs/guides/mongodb/autoscaler/storage/replicaset.md
+++ b/docs/guides/mongodb/autoscaler/storage/replicaset.md
@@ -100,7 +100,7 @@ mg-rs     4.4.26      Ready     2m53s
 Let's check volume size from petset, and from the persistent volume,
 
 ```bash
-$ kubectl get sts -n demo mg-rs -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo mg-rs -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1Gi"
 
 $ kubectl get pv -n demo
@@ -366,7 +366,7 @@ Events:
 Now, we are going to verify from the `Petset`, and the `Persistent Volume` whether the volume of the replicaset database has expanded to meet the desired state, Let's check,
 
 ```bash
-$ kubectl get sts -n demo mg-rs -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo mg-rs -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1594884096"
 $ kubectl get pv -n demo
 NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS          REASON   AGE

--- a/docs/guides/mongodb/autoscaler/storage/sharding.md
+++ b/docs/guides/mongodb/autoscaler/storage/sharding.md
@@ -110,7 +110,7 @@ mg-sh     4.4.26      Ready     3m51s
 Let's check volume size from one of the shard petset, and from the persistent volume,
 
 ```bash
-$ kubectl get sts -n demo mg-sh-shard0 -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo mg-sh-shard0 -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1Gi"
 
 $ kubectl get pv -n demo
@@ -385,7 +385,7 @@ Events:
 Now, we are going to verify from the `Petset`, and the `Persistent Volume` whether the volume of the shard nodes of the database has expanded to meet the desired state, Let's check,
 
 ```bash
-$ kubectl get sts -n demo mg-sh-shard0 -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo mg-sh-shard0 -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1594884096"
 $ kubectl get pv -n demo
 NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                            STORAGECLASS          REASON   AGE

--- a/docs/guides/mongodb/autoscaler/storage/standalone.md
+++ b/docs/guides/mongodb/autoscaler/storage/standalone.md
@@ -97,7 +97,7 @@ mg-standalone   4.4.26      Ready     2m53s
 Let's check volume size from petset, and from the persistent volume,
 
 ```bash
-$ kubectl get sts -n demo mg-standalone -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo mg-standalone -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1Gi"
 
 $ kubectl get pv -n demo
@@ -361,7 +361,7 @@ Events:
 Now, we are going to verify from the `Petset`, and the `Persistent Volume` whether the volume of the standalone database has expanded to meet the desired state, Let's check,
 
 ```bash
-$ kubectl get sts -n demo mg-standalone -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo mg-standalone -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1594884096"
 $ kubectl get pv -n demo
 NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                          STORAGECLASS          REASON   AGE

--- a/docs/guides/mongodb/backup/kubestash/application-level/index.md
+++ b/docs/guides/mongodb/backup/kubestash/application-level/index.md
@@ -204,11 +204,11 @@ sample-mongodb-2   2/2     Running   0          13m
 Now, let’s exec into the pod and create a table,
 
 ```bash
-$ export USER=$(kubectl get secrets -n demo sample-mongodb-auth -o jsonpath='{.data.\username}' | base64 -d)
+$ export USER=$(kubectl get secrets -n demo sample-mongodb-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export PASSWORD=$(kubectl get secrets -n demo sample-mongodb-auth -o jsonpath='{.data.\password}' | base64 -d)
+$ export PASSWORD=$(kubectl get secrets -n demo sample-mongodb-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo sample-mongodb-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mongodb-0 -- mongosh admin -u $USER -p $PASSWORD
 
 replicaset:PRIMARY> show dbs
 admin          0.000GB
@@ -654,11 +654,11 @@ sample-mongodb-2    2/2     Running   0          12m
 Now, lets exec one of the Pod and verify restored data.
 
 ```bash
-$ export USER=$(kubectl get secrets -n dev sample-mongodb-auth -o jsonpath='{.data.\username}' | base64 -d)
+$ export USER=$(kubectl get secrets -n dev sample-mongodb-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export PASSWORD=$(kubectl get secrets -n dev sample-mongodb-auth -o jsonpath='{.data.\password}' | base64 -d)
+$ export PASSWORD=$(kubectl get secrets -n dev sample-mongodb-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo sample-mongodb-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mongodb-0 -- mongosh admin -u $USER -p $PASSWORD
 
 ---
 replicaset:PRIMARY> show dbs

--- a/docs/guides/mongodb/backup/kubestash/application-level/index.md
+++ b/docs/guides/mongodb/backup/kubestash/application-level/index.md
@@ -658,7 +658,7 @@ $ export USER=$(kubectl get secrets -n dev sample-mongodb-auth -o jsonpath='{.da
 
 $ export PASSWORD=$(kubectl get secrets -n dev sample-mongodb-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo sample-mongodb-0 -- mongosh admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n dev sample-mongodb-0 -- mongosh admin -u $USER -p $PASSWORD
 
 ---
 replicaset:PRIMARY> show dbs

--- a/docs/guides/mongodb/backup/kubestash/logical/replicaset/index.md
+++ b/docs/guides/mongodb/backup/kubestash/logical/replicaset/index.md
@@ -121,11 +121,11 @@ sample-mg-rs-2   2/2     Running   0          5m14s
 Now, let's exec into the pod and create a table,
 
 ```bash
-$ export USER=$(kubectl get secrets -n demo sample-mg-rs-auth -o jsonpath='{.data.\username}' | base64 -d)
+$ export USER=$(kubectl get secrets -n demo sample-mg-rs-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export PASSWORD=$(kubectl get secrets -n demo sample-mg-rs-auth -o jsonpath='{.data.\password}' | base64 -d)
+$ export PASSWORD=$(kubectl get secrets -n demo sample-mg-rs-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo sample-mg-rs-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mg-rs-0 -- mongosh admin -u $USER -p $PASSWORD
 
 rs0:PRIMARY> show dbs
 admin          0.000GB
@@ -446,11 +446,11 @@ sample-mg-rs-restore   4.4.26     Ready    2m45s
 Let's verify all the databases of this `sample-mg-rs-restore` by exec into its pod
 
 ```bash
-$ export USER=$(kubectl get secrets -n demo sample-mg-rs-restore-auth -o jsonpath='{.data.\username}' | base64 -d)
+$ export USER=$(kubectl get secrets -n demo sample-mg-rs-restore-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export PASSWORD=$(kubectl get secrets -n demo sample-mg-rs-restore-auth -o jsonpath='{.data.\password}' | base64 -d)
+$ export PASSWORD=$(kubectl get secrets -n demo sample-mg-rs-restore-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo sample-mg-rs-restore-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mg-rs-restore-0 -- mongosh admin -u $USER -p $PASSWORD
 
 rs0:PRIMARY> show dbs
 admin          0.000GB
@@ -543,7 +543,7 @@ In this section, we are going to verify that the desired data has been restored 
 Lets, exec into the database pod and list available tables,
 
 ```bash
-$ kubectl exec -it -n demo sample-mg-rs-restore-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mg-rs-restore-0 -- mongosh admin -u $USER -p $PASSWORD
 
 rs0:PRIMARY> show dbs
 admin          0.000GB

--- a/docs/guides/mongodb/backup/kubestash/logical/sharding/index.md
+++ b/docs/guides/mongodb/backup/kubestash/logical/sharding/index.md
@@ -133,11 +133,11 @@ sample-mg-sh-mongos-1   1/1     Running   0          21m
 Now, let's exec into the pod and create a table,
 
 ```bash
-$ export USER=$(kubectl get secrets -n demo sample-mg-sh-auth -o jsonpath='{.data.\username}' | base64 -d)
+$ export USER=$(kubectl get secrets -n demo sample-mg-sh-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export PASSWORD=$(kubectl get secrets -n demo sample-mg-sh-auth -o jsonpath='{.data.\password}' | base64 -d)
+$ export PASSWORD=$(kubectl get secrets -n demo sample-mg-sh-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo sample-mg-sh-mongos-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mg-sh-mongos-0 -- mongosh admin -u $USER -p $PASSWORD
 
 mongos> show dbs
 admin          0.000GB
@@ -462,11 +462,11 @@ sample-mg-sh-restore   4.4.26     Ready    7m47s
 Let's verify all the databases of this `sample-mg-sh-restore` by exec into its mongos pod
 
 ```bash
-$ export USER=$(kubectl get secrets -n demo sample-mg-sh-restore-auth -o jsonpath='{.data.\username}' | base64 -d)
+$ export USER=$(kubectl get secrets -n demo sample-mg-sh-restore-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export PASSWORD=$(kubectl get secrets -n demo sample-mg-sh-restore-auth -o jsonpath='{.data.\password}' | base64 -d)
+$ export PASSWORD=$(kubectl get secrets -n demo sample-mg-sh-restore-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo sample-mg-sh-restore-mongos-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mg-sh-restore-mongos-0 -- mongosh admin -u $USER -p $PASSWORD
 
 mongos> show dbs
 admin          0.000GB
@@ -558,7 +558,7 @@ In this section, we are going to verify that the desired data has been restored 
 Lets, exec into the database's mongos pod and list available tables,
 
 ```bash
-$ kubectl exec -it -n demo sample-mg-sh-restore-mongos-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mg-sh-restore-mongos-0 -- mongosh admin -u $USER -p $PASSWORD
 
 mongos> show dbs
 admin          0.000GB

--- a/docs/guides/mongodb/backup/kubestash/logical/standalone/index.md
+++ b/docs/guides/mongodb/backup/kubestash/logical/standalone/index.md
@@ -116,11 +116,11 @@ sample-mongodb-0   1/1     Running   0          12m
 Now, let's exec into the pod and create a table,
 
 ```bash
-$ export USER=$(kubectl get secrets -n demo sample-mongodb-auth -o jsonpath='{.data.\username}' | base64 -d)
+$ export USER=$(kubectl get secrets -n demo sample-mongodb-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export PASSWORD=$(kubectl get secrets -n demo sample-mongodb-auth -o jsonpath='{.data.\password}' | base64 -d)
+$ export PASSWORD=$(kubectl get secrets -n demo sample-mongodb-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo sample-mongodb-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mongodb-0 -- mongosh admin -u $USER -p $PASSWORD
 
 > show dbs
 admin          0.000GB
@@ -439,11 +439,11 @@ restore-mongodb   4.4.26     Ready    3m30s
 Let's verify all the databases of this `restore-mongodb` by exec into its pod
 
 ```bash
-$ export USER=$(kubectl get secrets -n demo restore-mongodb-auth -o jsonpath='{.data.\username}' | base64 -d)
+$ export USER=$(kubectl get secrets -n demo restore-mongodb-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export PASSWORD=$(kubectl get secrets -n demo restore-mongodb-auth -o jsonpath='{.data.\password}' | base64 -d)
+$ export PASSWORD=$(kubectl get secrets -n demo restore-mongodb-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo restore-mongodb-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo restore-mongodb-0 -- mongosh admin -u $USER -p $PASSWORD
 
 > show dbs
 admin          0.000GB
@@ -536,7 +536,7 @@ In this section, we are going to verify that the desired data has been restored 
 Lets, exec into the database pod and list available tables,
 
 ```bash
-$ kubectl exec -it -n demo restore-mongodb-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo restore-mongodb-0 -- mongosh admin -u $USER -p $PASSWORD
 
 > show dbs
 admin          0.000GB

--- a/docs/guides/mongodb/backup/stash/logical/replicaset/index.md
+++ b/docs/guides/mongodb/backup/stash/logical/replicaset/index.md
@@ -198,11 +198,11 @@ sample-mgo-rs-2   1/1     Running   0          15m
 Now, let's exec into the pod and create a table,
 
 ```bash
-$ export USER=$(kubectl get secrets -n demo sample-mgo-rs-auth -o jsonpath='{.data.\username}' | base64 -d)
+$ export USER=$(kubectl get secrets -n demo sample-mgo-rs-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export PASSWORD=$(kubectl get secrets -n demo sample-mgo-rs-auth -o jsonpath='{.data.\password}' | base64 -d)
+$ export PASSWORD=$(kubectl get secrets -n demo sample-mgo-rs-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo sample-mgo-rs-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mgo-rs-0 -- mongosh admin -u $USER -p $PASSWORD
 
 rs0:PRIMARY> rs.isMaster().primary
 sample-mgo-rs-0.sample-mgo-rs-gvr.demo.svc.cluster.local:27017
@@ -411,7 +411,7 @@ Notice the `PAUSED` column. Value `true` for this field means that the BackupCon
 
 Now, let’s simulate an accidental deletion scenario. Here, we are going to exec into the database pod and delete the `newdb` database we had created earlier.
 ```bash
-$ kubectl exec -it -n demo sample-mgo-rs-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mgo-rs-0 -- mongosh admin -u $USER -p $PASSWORD
 
 rs0:PRIMARY> rs.isMaster().primary
 sample-mgo-rs-0.sample-mgo-rs-gvr.demo.svc.cluster.local:27017
@@ -487,7 +487,7 @@ In this section, we are going to verify that the desired data has been restored 
 Lets, exec into the database pod and list available tables,
 
 ```bash
-$ kubectl exec -it -n demo sample-mgo-rs-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mgo-rs-0 -- mongosh admin -u $USER -p $PASSWORD
 
 rs0:PRIMARY> rs.isMaster().primary
 restored-mgo-rs-0.restored-mgo-rs-gvr.demo.svc.cluster.local:27017
@@ -671,13 +671,13 @@ restored-mongodb   4.4.26         Ready   2m
 Now, exec into the database pod and list available tables,
 
 ```bash
-$ export USER=$(kubectl get secrets -n demo restored-mongodb-auth -o jsonpath='{.data.\username}' | base64 -d)
+$ export USER=$(kubectl get secrets -n demo restored-mongodb-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export PASSWORD=$(kubectl get secrets -n demo restored-mongodb-auth -o jsonpath='{.data.\password}' | base64 -d)
+$ export PASSWORD=$(kubectl get secrets -n demo restored-mongodb-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo restored-mongodb-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo restored-mongodb-0 -- mongosh admin -u $USER -p $PASSWORD
 
-mongodb@restored-mongodb-0:/$ mongo admin -u root -p CRz6EuxvKdFjopfP
+mongodb@restored-mongodb-0:/$ mongosh admin -u root -p CRz6EuxvKdFjopfP
 
 > show dbs
 admin   0.000GB

--- a/docs/guides/mongodb/backup/stash/logical/replicaset/index.md
+++ b/docs/guides/mongodb/backup/stash/logical/replicaset/index.md
@@ -677,8 +677,6 @@ $ export PASSWORD=$(kubectl get secrets -n demo restored-mongodb-auth -o jsonpat
 
 $ kubectl exec -it -n demo restored-mongodb-0 -- mongosh admin -u $USER -p $PASSWORD
 
-mongodb@restored-mongodb-0:/$ mongosh admin -u root -p CRz6EuxvKdFjopfP
-
 > show dbs
 admin   0.000GB
 config  0.000GB

--- a/docs/guides/mongodb/backup/stash/logical/sharding/index.md
+++ b/docs/guides/mongodb/backup/stash/logical/sharding/index.md
@@ -212,11 +212,11 @@ sample-mgo-sh-mongos-9459cfc44-6d2st   1/1     Running   0          60m
 Now, let's exec into the pod and create a table,
 
 ```bash
-$ export USER=$(kubectl get secrets -n demo sample-mgo-sh-auth -o jsonpath='{.data.\username}' | base64 -d)
+$ export USER=$(kubectl get secrets -n demo sample-mgo-sh-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export PASSWORD=$(kubectl get secrets -n demo sample-mgo-sh-auth -o jsonpath='{.data.\password}' | base64 -d)
+$ export PASSWORD=$(kubectl get secrets -n demo sample-mgo-sh-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo sample-mgo-sh-mongos-9459cfc44-4jthd -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mgo-sh-mongos-9459cfc44-4jthd -- mongosh admin -u $USER -p $PASSWORD
 
 mongos> show dbs
 admin   0.000GB
@@ -424,7 +424,7 @@ Notice the `PAUSED` column. Value `true` for this field means that the BackupCon
 
 Now, let’s simulate an accidental deletion scenario. Here, we are going to exec into the database pod and delete the `newdb` database we had created earlier.
 ```bash
-$ kubectl exec -it -n demo sample-mgo-sh-mongos-9459cfc44-4jthd -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mgo-sh-mongos-9459cfc44-4jthd -- mongosh admin -u $USER -p $PASSWORD
 
 mongos> use newdb
 switched to db newdb
@@ -499,7 +499,7 @@ Lets, exec into the database pod and list available tables,
 
 ```bash
 
-$ kubectl exec -it -n demo sample-mgo-sh-mongos-9459cfc44-4jthd -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mgo-sh-mongos-9459cfc44-4jthd -- mongosh admin -u $USER -p $PASSWORD
 
 mongos> show dbs
 admin   0.000GB
@@ -680,11 +680,11 @@ restored-mongodb   4.4.26         Ready   56s
 Now, exec into the database pod and list available tables,
 
 ```bash
-$ export USER=$(kubectl get secrets -n demo restored-mongodb-auth -o jsonpath='{.data.\username}' | base64 -d)
+$ export USER=$(kubectl get secrets -n demo restored-mongodb-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export PASSWORD=$(kubectl get secrets -n demo restored-mongodb-auth -o jsonpath='{.data.\password}' | base64 -d)
+$ export PASSWORD=$(kubectl get secrets -n demo restored-mongodb-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo restored-mongodb-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo restored-mongodb-0 -- mongosh admin -u $USER -p $PASSWORD
 
 > show dbs
 admin   0.000GB

--- a/docs/guides/mongodb/backup/stash/logical/standalone/index.md
+++ b/docs/guides/mongodb/backup/stash/logical/standalone/index.md
@@ -190,11 +190,11 @@ sample-mongodb-0   1/1     Running   0          12m
 Now, let's exec into the pod and create a table,
 
 ```bash
-$ export USER=$(kubectl get secrets -n demo sample-mongodb-auth -o jsonpath='{.data.\username}' | base64 -d)
+$ export USER=$(kubectl get secrets -n demo sample-mongodb-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export PASSWORD=$(kubectl get secrets -n demo sample-mongodb-auth -o jsonpath='{.data.\password}' | base64 -d)
+$ export PASSWORD=$(kubectl get secrets -n demo sample-mongodb-auth -o jsonpath='{.data.password}' | base64 -d)
 
-$ kubectl exec -it -n demo sample-mongodb-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mongodb-0 -- mongosh admin -u $USER -p $PASSWORD
 
 > show dbs
 admin  0.000GB
@@ -400,7 +400,7 @@ Notice the `PAUSED` column. Value `true` for this field means that the BackupCon
 
 Now, let’s simulate an accidental deletion scenario. Here, we are going to exec into the database pod and delete the `newdb` database we had created earlier.
 ```bash
-$ kubectl exec -it -n demo sample-mongodb-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mongodb-0 -- mongosh admin -u $USER -p $PASSWORD
 > use newdb
 switched to db newdb
 
@@ -471,7 +471,7 @@ In this section, we are going to verify that the desired data has been restored 
 Lets, exec into the database pod and list available tables,
 
 ```bash
-$ kubectl exec -it -n demo sample-mongodb-0 -- mongo admin -u $USER -p $PASSWORD
+$ kubectl exec -it -n demo sample-mongodb-0 -- mongosh admin -u $USER -p $PASSWORD
 
 > show dbs
 admin   0.000GB

--- a/docs/guides/mongodb/clustering/replicaset.md
+++ b/docs/guides/mongodb/clustering/replicaset.md
@@ -361,15 +361,15 @@ Now, you can connect to this database through [mgo-replicaset](https://docs.mong
 At first, insert data inside primary member `rs0:PRIMARY`.
 
 ```bash
-$ kubectl get secrets -n demo mgo-replicaset-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mgo-replicaset-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mgo-replicaset-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mgo-replicaset-auth -o jsonpath='{.data.password}' | base64 -d
 5O4R2ze2bWXcWsdP
 
 $ kubectl exec -it mgo-replicaset-0 -n demo bash
 
-mongodb@mgo-replicaset-0:/$ mongo admin -u root -p 5O4R2ze2bWXcWsdP
+mongodb@mgo-replicaset-0:/$ mongosh admin -u root -p 5O4R2ze2bWXcWsdP
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin
 MongoDB server version: 4.4.26
@@ -420,7 +420,7 @@ We will exec in `mgo-replicaset-1`(which is secondary member right now) to check
 
 ```bash
 $ kubectl exec -it mgo-replicaset-1 -n demo bash
-mongodb@mgo-replicaset-1:/$ mongo admin -u root -p 5O4R2ze2bWXcWsdP
+mongodb@mgo-replicaset-1:/$ mongosh admin -u root -p 5O4R2ze2bWXcWsdP
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin
 MongoDB server version: 4.4.26
@@ -488,7 +488,7 @@ Now verify the automatic failover, Let's exec in `mgo-replicaset-1` pod,
 
 ```bash
 $ kubectl exec -it mgo-replicaset-1 -n demo bash
-mongodb@mgo-replicaset-1:/$ mongo admin -u root -p 5O4R2ze2bWXcWsdP
+mongodb@mgo-replicaset-1:/$ mongosh admin -u root -p 5O4R2ze2bWXcWsdP
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin
 MongoDB server version: 4.4.26
@@ -593,7 +593,7 @@ Now, If you again exec into the primary `pod` and look for previous data, you wi
 ```bash
 $ kubectl exec -it mgo-replicaset-1 -n demo bash
 
-mongodb@mgo-replicaset-1:/$ mongo admin -u root -p 7QiqLcuSCmZ8PU5a
+mongodb@mgo-replicaset-1:/$ mongosh admin -u root -p 7QiqLcuSCmZ8PU5a
 
 rs0:PRIMARY> use newdb
 switched to db newdb

--- a/docs/guides/mongodb/clustering/replicaset.md
+++ b/docs/guides/mongodb/clustering/replicaset.md
@@ -593,7 +593,7 @@ Now, If you again exec into the primary `pod` and look for previous data, you wi
 ```bash
 $ kubectl exec -it mgo-replicaset-1 -n demo bash
 
-mongodb@mgo-replicaset-1:/$ mongosh admin -u root -p 7QiqLcuSCmZ8PU5a
+mongodb@mgo-replicaset-1:/$ mongosh admin -u root -p 5O4R2ze2bWXcWsdP
 
 rs0:PRIMARY> use newdb
 switched to db newdb

--- a/docs/guides/mongodb/clustering/sharding.md
+++ b/docs/guides/mongodb/clustering/sharding.md
@@ -351,14 +351,14 @@ If you want to use custom or existing secret please specify that when creating t
 - Username: Run following command to get _username_,
 
   ```bash
-  $ kubectl get secrets -n demo mongo-sh-auth -o jsonpath='{.data.\username}' | base64 -d
+  $ kubectl get secrets -n demo mongo-sh-auth -o jsonpath='{.data.username}' | base64 -d
   root
   ```
 
 - Password: Run the following command to get _password_,
 
   ```bash
-  $ kubectl get secrets -n demo mongo-sh-auth -o jsonpath='{.data.\password}' | base64 -d
+  $ kubectl get secrets -n demo mongo-sh-auth -o jsonpath='{.data.password}' | base64 -d
   7QiqLcuSCmZ8PU5a
   ```
 
@@ -376,7 +376,7 @@ mongo-sh-mongos-1   1/1     Running   0          49m
 
 $ kubectl exec -it mongo-sh-mongos-0 -n demo bash
 
-mongodb@mongo-sh-mongos-0:/$ mongo admin -u root -p 7QiqLcuSCmZ8PU5a
+mongodb@mongo-sh-mongos-0:/$ mongosh admin -u root -p 7QiqLcuSCmZ8PU5a
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin?gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("8b7abf57-09e4-4e30-b4a0-a37ebf065e8f") }
@@ -683,7 +683,7 @@ mongo-sh-mongos-1   1/1     Running   0          3m52s
 
 $ kubectl exec -it mongo-sh-mongos-0 -n demo bash
 
-mongodb@mongo-sh-mongos-0:/$ mongo admin -u root -p 7QiqLcuSCmZ8PU5a
+mongodb@mongo-sh-mongos-0:/$ mongosh admin -u root -p 7QiqLcuSCmZ8PU5a
 
 mongos> use test;
 switched to db test

--- a/docs/guides/mongodb/clustering/standalone.md
+++ b/docs/guides/mongodb/clustering/standalone.md
@@ -468,7 +468,7 @@ Now, If you again exec into the primary `pod` and look for previous data, you wi
 ```bash
 $ kubectl exec -it mg-alone-1 -n demo bash
 
-mongodb@mg-alone-1:/$ mongosh admin -u root -p 7QiqLcuSCmZ8PU5a
+mongodb@mg-alone-1:/$ mongosh admin -u root -p 5O4R2ze2bWXcWsdP
 
 > use newdb
 switched to db newdb

--- a/docs/guides/mongodb/clustering/standalone.md
+++ b/docs/guides/mongodb/clustering/standalone.md
@@ -194,7 +194,7 @@ Events:
 
 
 
-$ kubectl get sts,svc,pvc,pv -n demo
+$ kubectl get petset,svc,pvc,pv -n demo
 NAME                        READY   AGE
 petset.apps/mg-alone   1/1     65s
 
@@ -248,7 +248,7 @@ spec:
           command:
             - bash
             - -c
-            - "set -x; if [[ $(mongo admin --host=localhost  --username=$MONGO_INITDB_ROOT_USERNAME
+            - "set -x; if [[ $(mongosh admin --host=localhost  --username=$MONGO_INITDB_ROOT_USERNAME
             --password=$MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase=admin
             --quiet --eval \"db.adminCommand('ping').ok\" ) -eq \"1\" ]]; then \n
             \         exit 0\n        fi\n        exit 1"
@@ -261,7 +261,7 @@ spec:
           command:
             - bash
             - -c
-            - "set -x; if [[ $(mongo admin --host=localhost  --username=$MONGO_INITDB_ROOT_USERNAME
+            - "set -x; if [[ $(mongosh admin --host=localhost  --username=$MONGO_INITDB_ROOT_USERNAME
             --password=$MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase=admin
             --quiet --eval \"db.adminCommand('ping').ok\" ) -eq \"1\" ]]; then \n
             \         exit 0\n        fi\n        exit 1"
@@ -335,15 +335,15 @@ Now, you can connect to this database through [mg-alone](https://docs.mongodb.co
 At first, insert data inside primary member `rs0:PRIMARY`.
 
 ```bash
-$ kubectl get secrets -n demo mg-alone-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mg-alone-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mg-alone-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mg-alone-auth -o jsonpath='{.data.password}' | base64 -d
 5O4R2ze2bWXcWsdP
 
 $ kubectl exec -it mg-alone-0 -n demo bash
 
-mongodb@mg-alone-0:/$ mongo admin -u root -p 5O4R2ze2bWXcWsdP
+mongodb@mg-alone-0:/$ mongosh admin -u root -p 5O4R2ze2bWXcWsdP
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin
 MongoDB server version: 4.4.26
@@ -468,7 +468,7 @@ Now, If you again exec into the primary `pod` and look for previous data, you wi
 ```bash
 $ kubectl exec -it mg-alone-1 -n demo bash
 
-mongodb@mg-alone-1:/$ mongo admin -u root -p 7QiqLcuSCmZ8PU5a
+mongodb@mg-alone-1:/$ mongosh admin -u root -p 7QiqLcuSCmZ8PU5a
 
 > use newdb
 switched to db newdb

--- a/docs/guides/mongodb/configuration/using-config-file.md
+++ b/docs/guides/mongodb/configuration/using-config-file.md
@@ -127,15 +127,15 @@ Now, we will check if the database has started with the custom configuration we 
 Now, you can connect to this database through [mongo-shell](https://docs.mongodb.com/v4.2/mongo/). In this tutorial, we are connecting to the MongoDB server from inside the pod.
 
 ```bash
-$ kubectl get secrets -n demo mgo-custom-config-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mgo-custom-config-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mgo-custom-config-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mgo-custom-config-auth -o jsonpath='{.data.password}' | base64 -d
 ErialNojWParBFoP
 
 $ kubectl exec -it mgo-custom-config-0 -n demo sh
 
-> mongo admin
+> mongosh admin
 
 > db.auth("root","ErialNojWParBFoP")
 1

--- a/docs/guides/mongodb/configuration/using-podtemplate.md
+++ b/docs/guides/mongodb/configuration/using-podtemplate.md
@@ -114,15 +114,15 @@ Now, check if the database has started with the custom configuration we have pro
 Now, you can connect to this database through [mongo-shell](https://docs.mongodb.com/v3.4/mongo/). In this tutorial, we are connecting to the MongoDB server from inside the pod.
 
 ```bash
-$ kubectl get secrets -n demo mgo-misc-config-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mgo-misc-config-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mgo-misc-config-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mgo-misc-config-auth -o jsonpath='{.data.password}' | base64 -d
 zyp5hDfRlVOWOyk9
 
 $ kubectl exec -it mgo-misc-config-0 -n demo sh
 
-> mongo admin
+> mongosh admin
 
 > db.auth("root","zyp5hDfRlVOWOyk9")
 1

--- a/docs/guides/mongodb/failure-and-disaster-recovery/overview.md
+++ b/docs/guides/mongodb/failure-and-disaster-recovery/overview.md
@@ -128,15 +128,15 @@ The pod having `kubedb.com/role=primary` is the primary and `kubedb.com/role=sta
 Lets create a table in the primary.
 
 ```shell
-$ kubectl get secrets -n demo mg-ha-demo-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mg-ha-demo-auth -o jsonpath='{.data.username}' | base64 -d
 root⏎          
-$ kubectl get secrets -n demo mg-ha-demo-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mg-ha-demo-auth -o jsonpath='{.data.password}' | base64 -d
 JUIevJ)ISh!Srg4y⏎              
 # find the primary pod
 $ kubectl exec -it -n demo mg-ha-demo-0  -- bash
 Defaulted container "mongodb" out of: mongodb, replication-mode-detector, copy-config (init)
 # exec into the primary pod
-$ mongodb@mg-ha-demo-0:/$ mongo admin
+$ mongodb@mg-ha-demo-0:/$ mongosh admin
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin?compressors=disabled&gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("57604543-ec8b-478a-bca3-bdbcf4dda0b6") }
@@ -194,7 +194,7 @@ observe any visible differences between their states.
 ```shell
 kubectl exec -it -n demo mg-ha-demo-1  -- bash
 Defaulted container "mongodb" out of: mongodb, replication-mode-detector, copy-config (init)
-mongodb@mg-ha-demo-1:/$ mongo admin
+mongodb@mg-ha-demo-1:/$ mongosh admin
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin?compressors=disabled&gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("9ec7b2cc-8972-4f07-996f-f6c9573acc36") }
@@ -324,7 +324,7 @@ Now we know how failover is done, let's check if the new primary is working.
 ```shell
 $ `kubectl exec -it -n demo mg-ha-demo-1  -- bash
 Defaulted container "mongodb" out of: mongodb, replication-mode-detector, copy-config (init)
-mongodb@mg-ha-demo-1:/$ mongo admin
+mongodb@mg-ha-demo-1:/$ mongosh admin
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin?compressors=disabled&gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("9ec7b2cc-8972-4f07-996f-f6c9573acc36") }
@@ -377,7 +377,7 @@ Lets check if the standby `mg-ha-demo-0` got the updated data from new primary `
 ```shell
 $ kubectl exec -it -n demo mg-ha-demo-0  -- bash
 Defaulted container "mongodb" out of: mongodb, replication-mode-detector, copy-config (init)
-mongodb@mg-ha-demo-0:/$ mongo admin
+mongodb@mg-ha-demo-0:/$ mongosh admin
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin?compressors=disabled&gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("8c1a76f9-61cf-4105-b3b1-d82190640c87") }
@@ -420,7 +420,7 @@ You can validate the replica set status from the new primary `mg-ha-demo-0` by c
 ```shell
 $ kubectl exec -it -n demo mg-ha-demo-0  -- bash
 Defaulted container "mongodb" out of: mongodb, replication-mode-detector, copy-config (init)
-mongodb@mg-ha-demo-0:/$ mongo admin
+mongodb@mg-ha-demo-0:/$ mongosh admin
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin?compressors=disabled&gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("8c1a76f9-61cf-4105-b3b1-d82190640c87") }
@@ -623,7 +623,7 @@ Lets verify cluster state.
 ```shell
 $ kubectl exec -it -n demo mg-ha-demo-0  -- bash
 Defaulted container "mongodb" out of: mongodb, replication-mode-detector, copy-config (init)
-mongodb@mg-ha-demo-0:/$ mongo admin
+mongodb@mg-ha-demo-0:/$ mongosh admin
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin?compressors=disabled&gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("8c1a76f9-61cf-4105-b3b1-d82190640c87") }
@@ -682,7 +682,7 @@ Lets verify the cluster state now.
 ```shell
 $ kubectl exec -it -n demo mg-ha-demo-1  -- bash
 Defaulted container "mongodb" out of: mongodb, replication-mode-detector, copy-config (init)
-mongodb@mg-ha-demo-1:/$ mongo admin
+mongodb@mg-ha-demo-1:/$ mongosh admin
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/admin?compressors=disabled&gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("f99795f2-9fb1-4221-bf2c-916f0e92d152") }

--- a/docs/guides/mongodb/hidden-node/replicaset.md
+++ b/docs/guides/mongodb/hidden-node/replicaset.md
@@ -393,15 +393,15 @@ Now, you can connect to this database through [mongo-rs-hid](https://docs.mongod
 At first, insert data inside primary member `rs0:PRIMARY`.
 
 ```bash
-$ kubectl get secrets -n demo mongo-rs-hid-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mongo-rs-hid-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mongo-rs-hid-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mongo-rs-hid-auth -o jsonpath='{.data.password}' | base64 -d
 OX4yb!IFm;~yAHkD
 
 $ kubectl exec -it mongo-rs-hid-0 -n demo bash
 
-bash-4.4$ mongo admin -u root -p 'OX4yb!IFm;~yAHkD'
+bash-4.4$ mongosh admin -u root -p 'OX4yb!IFm;~yAHkD'
 Percona Server for MongoDB shell version v7.0.4-11
 connecting to: mongodb://127.0.0.1:27017/?compressors=disabled&gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("11890d64-37da-43dd-acb6-0f36a3678875") }
@@ -757,7 +757,7 @@ We will exec in `mongo-rs-hid-hidden-0`(which is a hidden node right now) to che
 
 ```bash
 $ kubectl exec -it mongo-rs-hid-hidden-0 -n demo bash
-bash-4.4$ mongo admin -u root -p 'OX4yb!IFm;~yAHkD'
+bash-4.4$ mongosh admin -u root -p 'OX4yb!IFm;~yAHkD'
 Percona Server for MongoDB server version: v7.0.4-11
 connecting to: mongodb://127.0.0.1:27017/admin
 MongoDB server version: 7.0.4
@@ -836,7 +836,7 @@ Now verify the automatic failover, Let's exec in `mongo-rs-hid-0` pod,
 
 ```bash
 $ kubectl exec -it mongo-rs-hid-0  -n demo bash
-bash-4.4:/$ mongo admin -u root -p 'OX4yb!IFm;~yAHkD'
+bash-4.4:/$ mongosh admin -u root -p 'OX4yb!IFm;~yAHkD'
 Percona Server for MongoDB server version: v7.0.4-11
 connecting to: mongodb://127.0.0.1:27017/admin
 MongoDB server version: 7.0.4

--- a/docs/guides/mongodb/hidden-node/sharding.md
+++ b/docs/guides/mongodb/hidden-node/sharding.md
@@ -301,14 +301,14 @@ If you want to use custom or existing secret please specify that when creating t
 - Username: Run following command to get _username_,
 
   ```bash
-  $ kubectl get secrets -n demo mongo-sh-hid-auth -o jsonpath='{.data.\username}' | base64 -d
+  $ kubectl get secrets -n demo mongo-sh-hid-auth -o jsonpath='{.data.username}' | base64 -d
   root
   ```
 
 - Password: Run the following command to get _password_,
 
   ```bash
-  $ kubectl get secrets -n demo mongo-sh-hid-auth -o jsonpath='{.data.\password}' | base64 -d
+  $ kubectl get secrets -n demo mongo-sh-hid-auth -o jsonpath='{.data.password}' | base64 -d
   6&UiN5;qq)Tnai=7
   ```
 
@@ -326,7 +326,7 @@ mongo-sh-hid-mongos-1   1/1     Running   0          6m20s
 
 $ kubectl exec -it mongo-sh-hid-mongos-0 -n demo bash
 
-mongodb@mongo-sh-mongos-0:/$ mongo admin -u root -p '6&UiN5;qq)Tnai=7'
+mongodb@mongo-sh-mongos-0:/$ mongosh admin -u root -p '6&UiN5;qq)Tnai=7'
 Percona Server for MongoDB shell version v7.0.4-11
 connecting to: mongodb://127.0.0.1:27017/?compressors=disabled&gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("e6979884-81b0-41c9-9745-50654f6fb39b") }
@@ -432,7 +432,7 @@ As `sh.status()` command only shows the general members, if we want to assure th
 ```bash
 kubectl exec -it -n demo pod/mongo-sh-hid-shard1-0 -- bash
 
-root@mongo-sh-hid-shard0-1:/ mongo admin -u root -p '6&UiN5;qq)Tnai=7'
+root@mongo-sh-hid-shard0-1:/ mongosh admin -u root -p '6&UiN5;qq)Tnai=7'
 Defaulted container "mongodb" out of: mongodb, copy-config (init)
 Percona Server for MongoDB shell version v7.0.4-11
 connecting to: mongodb://127.0.0.1:27017/?compressors=disabled&gssapiServiceName=mongodb

--- a/docs/guides/mongodb/initialization/using-script.md
+++ b/docs/guides/mongodb/initialization/using-script.md
@@ -372,15 +372,15 @@ type: Opaque
 Now, you can connect to this database through [mongo-shell](https://docs.mongodb.com/v3.4/mongo/). In this tutorial, we are connecting to the MongoDB server from inside the pod.
 
 ```bash
-$ kubectl get secrets -n demo mgo-init-script-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mgo-init-script-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mgo-init-script-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mgo-init-script-auth -o jsonpath='{.data.password}' | base64 -d
 oEwk7IGxCPM5OWo5
 
 $ kubectl exec -it mgo-init-script-0 -n demo sh
 
-> mongo admin
+> mongosh admin
 MongoDB shell version v3.4.10
 connecting to: mongodb://127.0.0.1:27017/admin
 MongoDB server version: 3.4.10

--- a/docs/guides/mongodb/pitr/pitr.md
+++ b/docs/guides/mongodb/pitr/pitr.md
@@ -313,7 +313,7 @@ $ kubectl exec -it -n demo mg-rs-0 bash
 kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
 Defaulted container "mongodb" out of: mongodb, replication-mode-detector, copy-config (init)
 mongodb@mg-rs-0:/$ 
-mongodb@mg-rs-0:/$ mongo -u root -p $MONGO_INITDB_ROOT_PASSWORD 
+mongodb@mg-rs-0:/$ mongosh -u root -p $MONGO_INITDB_ROOT_PASSWORD 
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/?compressors=disabled&gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("4a51b9fc-a26c-487b-848d-341cf5512c86") }
@@ -437,7 +437,7 @@ mg-rs-restored   4.4.26    Ready    5m47s
 **Validating data on Restored MongoDB**
 ```bash
 $ kubectl exec -it -n demo mg-rs-restored-0 bash
-mongodb@mg-rs-restored-0:/$ mongo -u root -p $MONGO_INITDB_ROOT_PASSWORD 
+mongodb@mg-rs-restored-0:/$ mongosh -u root -p $MONGO_INITDB_ROOT_PASSWORD 
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/?compressors=disabled&gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("50d3fc74-bffc-4c97-a1e6-a2ea63cb88e1") }

--- a/docs/guides/mongodb/quickstart/quickstart.md
+++ b/docs/guides/mongodb/quickstart/quickstart.md
@@ -504,7 +504,7 @@ Now, If you again exec into the `pod` and look for previous data, you will see t
 ```bash
 $ kubectl exec -it mgo-quickstart-0 -n demo bash
 
-mongodb@mgo-quickstart-0:/$ mongosh admin -u root -p CaM8v9LmmSGB~&hj
+mongodb@mgo-quickstart-0:/$ mongosh admin -u root -p 'CaM8v9LmmSGB~&hj'
 rs1:SECONDARY> use mydb
 switched to db mydb
 

--- a/docs/guides/mongodb/quickstart/quickstart.md
+++ b/docs/guides/mongodb/quickstart/quickstart.md
@@ -374,15 +374,15 @@ If you want to use custom or existing secret please specify that when creating t
 Now, you can connect to this database through [mongo-shell](https://docs.mongodb.com/v3.4/mongo/). In this tutorial, we are connecting to the MongoDB server from inside the pod.
 
 ```bash
-$ kubectl get secrets -n demo mgo-quickstart-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mgo-quickstart-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mgo-quickstart-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mgo-quickstart-auth -o jsonpath='{.data.password}' | base64 -d
 CaM8v9LmmSGB~&hj
 
 $ kubectl exec -it mgo-quickstart-0 -n demo sh
 
-> mongo admin
+> mongosh admin
 
 rs1:PRIMARY> db.auth("root","CaM8v9LmmSGB~&hj")
 1
@@ -504,7 +504,7 @@ Now, If you again exec into the `pod` and look for previous data, you will see t
 ```bash
 $ kubectl exec -it mgo-quickstart-0 -n demo bash
 
-mongodb@mgo-quickstart-0:/$ mongo admin -u root -p CaM8v9LmmSGB~&hj
+mongodb@mgo-quickstart-0:/$ mongosh admin -u root -p CaM8v9LmmSGB~&hj
 rs1:SECONDARY> use mydb
 switched to db mydb
 

--- a/docs/guides/mongodb/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/mongodb/reconfigure-tls/reconfigure-tls.md
@@ -196,13 +196,13 @@ Now, we can connect to this database through [mongo-shell](https://docs.mongodb.
 
 
 ```bash
-$ kubectl get secrets -n demo mg-rs-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mg-rs-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mg-rs-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mg-rs-auth -o jsonpath='{.data.password}' | base64 -d
 U6(h_pYrekLZ2OOd
 
-$ kubectl exec -it mg-rs-0 -n demo -- mongo admin -u root -p 'U6(h_pYrekLZ2OOd'
+$ kubectl exec -it mg-rs-0 -n demo -- mongosh admin -u root -p 'U6(h_pYrekLZ2OOd'
 rs0:PRIMARY> db.adminCommand({ getParameter:1, sslMode:1 })
 {
 	"sslMode" : "disabled",
@@ -444,7 +444,7 @@ subject=CN=root,OU=client,O=mongo
 Now, we can connect using `CN=root,OU=client,O=mongo` as root to connect to the mongo shell of the master pod,
 
 ```bash
-root@mgo-rs-tls-2:/$ mongo --tls --tlsCAFile /var/run/mongodb/tls/ca.crt --tlsCertificateKeyFile /var/run/mongodb/tls/client.pem admin --host localhost --authenticationMechanism MONGODB-X509 --authenticationDatabase='$external' -u "CN=root,OU=client,O=mongo" --quiet
+root@mgo-rs-tls-2:/$ mongosh --tls --tlsCAFile /var/run/mongodb/tls/ca.crt --tlsCertificateKeyFile /var/run/mongodb/tls/client.pem admin --host localhost --authenticationMechanism MONGODB-X509 --authenticationDatabase='$external' -u "CN=root,OU=client,O=mongo" --quiet
 rs0:PRIMARY>
 ```
 
@@ -965,7 +965,7 @@ Events:
 Now, Let's exec into the database primary node and find out that TLS is disabled or not.
 
 ```bash
-$ kubectl exec -it -n demo mg-rs-1 -- mongo admin -u root -p 'U6(h_pYrekLZ2OOd'
+$ kubectl exec -it -n demo mg-rs-1 -- mongosh admin -u root -p 'U6(h_pYrekLZ2OOd'
 rs0:PRIMARY> db.adminCommand({ getParameter:1, sslMode:1 })
 {
 	"sslMode" : "disabled",

--- a/docs/guides/mongodb/reconfigure/replicaset.md
+++ b/docs/guides/mongodb/reconfigure/replicaset.md
@@ -105,17 +105,17 @@ Now, we will check if the database has started with the custom configuration we 
 
 First we need to get the username and password to connect to a mongodb instance,
 ```bash
-$ kubectl get secrets -n demo mg-replicaset-auth -o jsonpath='{.data.\username}' | base64 -d                                                                       
+$ kubectl get secrets -n demo mg-replicaset-auth -o jsonpath='{.data.username}' | base64 -d                                                                       
 root
 
-$ kubectl get secrets -n demo mg-replicaset-auth -o jsonpath='{.data.\password}' | base64 -d                                                                         
+$ kubectl get secrets -n demo mg-replicaset-auth -o jsonpath='{.data.password}' | base64 -d                                                                         
 nrKuxni0wDSMrgwy
 ```
 
 Now let's connect to a mongodb instance and run a mongodb internal command to check the configuration we have provided.
 
 ```bash
-$ kubectl exec -n demo  mg-replicaset-0  -- mongo admin -u root -p nrKuxni0wDSMrgwy --eval "db._adminCommand( {getCmdLineOpts: 1})" --quiet                        
+$ kubectl exec -n demo  mg-replicaset-0  -- mongosh admin -u root -p nrKuxni0wDSMrgwy --eval "db._adminCommand( {getCmdLineOpts: 1})" --quiet                        
 {
 	"argv" : [
 		"mongod",
@@ -355,7 +355,7 @@ Events:
 Now let's connect to a mongodb instance and run a mongodb internal command to check the new configuration we have provided.
 
 ```bash
-$ kubectl exec -n demo  mg-replicaset-0  -- mongo admin -u root -p nrKuxni0wDSMrgwy --eval "db._adminCommand( {getCmdLineOpts: 1})" --quiet
+$ kubectl exec -n demo  mg-replicaset-0  -- mongosh admin -u root -p nrKuxni0wDSMrgwy --eval "db._adminCommand( {getCmdLineOpts: 1})" --quiet
 {
 	"argv" : [
 		"mongod",
@@ -582,7 +582,7 @@ Events:
 Now let's connect to a mongodb instance and run a mongodb internal command to check the new configuration we have provided.
 
 ```bash
-$ kubectl exec -n demo  mg-replicaset-0  -- mongo admin -u root -p nrKuxni0wDSMrgwy --eval "db._adminCommand( {getCmdLineOpts: 1})" --quiet
+$ kubectl exec -n demo  mg-replicaset-0  -- mongosh admin -u root -p nrKuxni0wDSMrgwy --eval "db._adminCommand( {getCmdLineOpts: 1})" --quiet
 {
 	"argv" : [
 		"mongod",

--- a/docs/guides/mongodb/reconfigure/sharding.md
+++ b/docs/guides/mongodb/reconfigure/sharding.md
@@ -116,17 +116,17 @@ Now, we will check if the database has started with the custom configuration we 
 
 First we need to get the username and password to connect to a mongodb instance,
 ```bash
-$ kubectl get secrets -n demo mg-sharding-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mg-sharding-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mg-sharding-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mg-sharding-auth -o jsonpath='{.data.password}' | base64 -d
 Dv8F55zVNiEkhHM6
 ```
 
 Now let's connect to a mongodb instance from each type of nodes and run a mongodb internal command to check the configuration we have provided.
 
 ```bash
-$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongo admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
+$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongosh admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
 {
 	"bindIp" : "*",
 	"ipv6" : true,
@@ -137,7 +137,7 @@ $ kubectl exec -n demo  mg-sharding-mongos-0  -- mongo admin -u root -p Dv8F55zV
 	}
 }
 
-$ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongo admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
+$ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongosh admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
 {
 	"bindIp" : "*",
 	"ipv6" : true,
@@ -148,7 +148,7 @@ $ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongo admin -u root -p Dv8F5
 	}
 }
 
-$ kubectl exec -n demo  mg-sharding-shard0-0  -- mongo admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
+$ kubectl exec -n demo  mg-sharding-shard0-0  -- mongosh admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
 {
 	"bindIp" : "*",
 	"ipv6" : true,
@@ -254,7 +254,7 @@ $ kubectl describe mongodbopsrequest -n demo mops-reconfigure-shard
 Now let's connect to a mongodb instance from each type of nodes and run a mongodb internal command to check the new configuration we have provided.
 
 ```bash
-$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongo admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
+$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongosh admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
   {
   	"bindIp" : "0.0.0.0",
   	"maxIncomingConnections" : 20000,
@@ -264,7 +264,7 @@ $ kubectl exec -n demo  mg-sharding-mongos-0  -- mongo admin -u root -p Dv8F55zV
   	}
   }
 
-$ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongo admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
+$ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongosh admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
   {
   	"bindIp" : "0.0.0.0",
   	"maxIncomingConnections" : 20000,
@@ -274,7 +274,7 @@ $ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongo admin -u root -p Dv8F5
   	}
   }
 
-$ kubectl exec -n demo  mg-sharding-shard0-0  -- mongo admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
+$ kubectl exec -n demo  mg-sharding-shard0-0  -- mongosh admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
   {
   	"bindIp" : "0.0.0.0",
   	"maxIncomingConnections" : 20000,
@@ -525,7 +525,7 @@ Events:
 Now let's connect to a mongodb instance from each type of nodes and run a mongodb internal command to check the new configuration we have provided.
 
 ```bash
-$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongo admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
+$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongosh admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
 {
 	"bindIp" : "*",
 	"ipv6" : true,
@@ -536,7 +536,7 @@ $ kubectl exec -n demo  mg-sharding-mongos-0  -- mongo admin -u root -p Dv8F55zV
 	}
 }
 
-$ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongo admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
+$ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongosh admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
 {
 	"bindIp" : "*",
 	"ipv6" : true,
@@ -547,7 +547,7 @@ $ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongo admin -u root -p Dv8F5
 	}
 }
 
-$ kubectl exec -n demo  mg-sharding-shard0-0  -- mongo admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
+$ kubectl exec -n demo  mg-sharding-shard0-0  -- mongosh admin -u root -p Dv8F55zVNiEkhHM6 --eval "db._adminCommand( {getCmdLineOpts: 1}).parsed.net" --quiet
 {
 	"bindIp" : "*",
 	"ipv6" : true,

--- a/docs/guides/mongodb/reconfigure/standalone.md
+++ b/docs/guides/mongodb/reconfigure/standalone.md
@@ -101,17 +101,17 @@ Now, we will check if the database has started with the custom configuration we 
 
 First we need to get the username and password to connect to a mongodb instance,
 ```bash
-$ kubectl get secrets -n demo mg-standalone-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mg-standalone-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mg-standalone-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mg-standalone-auth -o jsonpath='{.data.password}' | base64 -d
 m6lXjZugrC4VEpB8
 ```
 
 Now let's connect to a mongodb instance and run a mongodb internal command to check the configuration we have provided.
 
 ```bash
-$ kubectl exec -n demo  mg-standalone-0  -- mongo admin -u root -p m6lXjZugrC4VEpB8 --eval "db._adminCommand( {getCmdLineOpts: 1})" --quiet
+$ kubectl exec -n demo  mg-standalone-0  -- mongosh admin -u root -p m6lXjZugrC4VEpB8 --eval "db._adminCommand( {getCmdLineOpts: 1})" --quiet
 {
 	"argv" : [
 		"mongod",
@@ -334,7 +334,7 @@ Events:
 Now let's connect to a mongodb instance and run a mongodb internal command to check the new configuration we have provided.
 
 ```bash
-$ kubectl exec -n demo  mg-standalone-0  -- mongo admin -u root -p m6lXjZugrC4VEpB8 --eval "db._adminCommand( {getCmdLineOpts: 1})" --quiet
+$ kubectl exec -n demo  mg-standalone-0  -- mongosh admin -u root -p m6lXjZugrC4VEpB8 --eval "db._adminCommand( {getCmdLineOpts: 1})" --quiet
 {
 	"argv" : [
 		"mongod",
@@ -543,7 +543,7 @@ Events:
 Now let's connect to a mongodb instance and run a mongodb internal command to check the new configuration we have provided.
 
 ```bash
-$ kubectl exec -n demo  mg-standalone-0  -- mongo admin -u root -p m6lXjZugrC4VEpB8 --eval "db._adminCommand( {getCmdLineOpts: 1})" --quiet
+$ kubectl exec -n demo  mg-standalone-0  -- mongosh admin -u root -p m6lXjZugrC4VEpB8 --eval "db._adminCommand( {getCmdLineOpts: 1})" --quiet
 {
 	"argv" : [
 		"mongod",

--- a/docs/guides/mongodb/rotate-auth/rotateauth.md
+++ b/docs/guides/mongodb/rotate-auth/rotateauth.md
@@ -98,7 +98,7 @@ Now, you can exec into the pod `mgo-quickstart` and connect to database using `u
 ```shell
 $ kubectl exec -it -n demo mgo-quickstart-0 -- bash
 Defaulted container "mongodb" out of: mongodb, replication-mode-detector, copy-config (init)
-mongodb@mgo-quickstart-0:/$ mongo -u root -p $MONGO_INITDB_ROOT_PASSWORD 
+mongodb@mgo-quickstart-0:/$ mongosh -u root -p $MONGO_INITDB_ROOT_PASSWORD 
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/?compressors=disabled&gssapiServiceName=mongodb
 Implicit session: session { "id" : UUID("dcd7f912-93d0-4f24-843d-5e2cbecbb6e0") }

--- a/docs/guides/mongodb/scaling/horizontal-scaling/replicaset.md
+++ b/docs/guides/mongodb/scaling/horizontal-scaling/replicaset.md
@@ -91,7 +91,7 @@ Let's check the number of replicas this database has from the MongoDB object, nu
 $ kubectl get mongodb -n demo mg-replicaset -o json | jq '.spec.replicas'
 3
 
-$ kubectl get sts -n demo mg-replicaset -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo mg-replicaset -o json | jq '.spec.replicas'
 3
 ```
 
@@ -101,17 +101,17 @@ Also, we can verify the replicas of the replicaset from an internal mongodb comm
 
 First we need to get the username and password to connect to a mongodb instance,
 ```bash
-$ kubectl get secrets -n demo mg-replicaset-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mg-replicaset-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mg-replicaset-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mg-replicaset-auth -o jsonpath='{.data.password}' | base64 -d
 nrKuxni0wDSMrgwy
 ```
 
 Now let's connect to a mongodb instance and run a mongodb internal command to check the number of replicas,
 
 ```bash
-$ kubectl exec -n demo  mg-replicaset-0  -- mongo admin -u root -p nrKuxni0wDSMrgwy --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
+$ kubectl exec -n demo  mg-replicaset-0  -- mongosh admin -u root -p nrKuxni0wDSMrgwy --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
 [
 	{
 		"_id" : 0,
@@ -336,13 +336,13 @@ Now, we are going to verify the number of replicas this database has from the Mo
 $ kubectl get mongodb -n demo mg-replicaset -o json | jq '.spec.replicas'
 4
 
-$ kubectl get sts -n demo mg-replicaset -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo mg-replicaset -o json | jq '.spec.replicas'
 4
 ```
 
 Now let's connect to a mongodb instance and run a mongodb internal command to check the number of replicas,
 ```bash
-$ kubectl exec -n demo  mg-replicaset-0  -- mongo admin -u root -p nrKuxni0wDSMrgwy --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
+$ kubectl exec -n demo  mg-replicaset-0  -- mongosh admin -u root -p nrKuxni0wDSMrgwy --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
 [
 	{
 		"_id" : 0,
@@ -593,13 +593,13 @@ Now, we are going to verify the number of replicas this database has from the Mo
 $ kubectl get mongodb -n demo mg-replicaset -o json | jq '.spec.replicas' 
 3
 
-$ kubectl get sts -n demo mg-replicaset -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo mg-replicaset -o json | jq '.spec.replicas'
 3
 ```
 
 Now let's connect to a mongodb instance and run a mongodb internal command to check the number of replicas,
 ```bash
-$ kubectl exec -n demo  mg-replicaset-0  -- mongo admin -u root -p nrKuxni0wDSMrgwy --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet 
+$ kubectl exec -n demo  mg-replicaset-0  -- mongosh admin -u root -p nrKuxni0wDSMrgwy --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet 
 [
 	{
 		"_id" : 0,

--- a/docs/guides/mongodb/scaling/horizontal-scaling/sharding.md
+++ b/docs/guides/mongodb/scaling/horizontal-scaling/sharding.md
@@ -100,7 +100,7 @@ Let's check the number of shards this database from the MongoDB object and the n
 $ kubectl get mongodb -n demo mg-sharding -o json | jq '.spec.shardTopology.shard.shards'
 2
 
-$ kubectl get sts -n demo                                                                 
+$ kubectl get petset -n demo                                                                 
 NAME                    READY   AGE
 mg-sharding-configsvr   3/3     23m
 mg-sharding-mongos      2/2     22m
@@ -116,7 +116,7 @@ Now, Let's check the number of replicas each shard has from the MongoDB object a
 $ kubectl get mongodb -n demo mg-sharding -o json | jq '.spec.shardTopology.shard.replicas'
 3
 
-$ kubectl get sts -n demo mg-sharding-shard0 -o json | jq '.spec.replicas'  
+$ kubectl get petset -n demo mg-sharding-shard0 -o json | jq '.spec.replicas'  
 3
 ```
 
@@ -126,17 +126,17 @@ Also, we can verify the number of shard from an internal mongodb command by exec
 
 First we need to get the username and password to connect to a mongos instance,
 ```bash
-$ kubectl get secrets -n demo mg-sharding-auth -o jsonpath='{.data.\username}' | base64 -d 
+$ kubectl get secrets -n demo mg-sharding-auth -o jsonpath='{.data.username}' | base64 -d 
 root
 
-$ kubectl get secrets -n demo mg-sharding-auth -o jsonpath='{.data.\password}' | base64 -d  
+$ kubectl get secrets -n demo mg-sharding-auth -o jsonpath='{.data.password}' | base64 -d  
 xBC-EwMFivFCgUlK
 ```
 
 Now let's connect to a mongos instance and run a mongodb internal command to check the number of shards,
 
 ```bash
-$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongo admin -u root -p xBC-EwMFivFCgUlK --eval "sh.status()" --quiet  
+$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongosh admin -u root -p xBC-EwMFivFCgUlK --eval "sh.status()" --quiet  
 --- Sharding Status --- 
   sharding version: {
   	"_id" : 1,
@@ -168,7 +168,7 @@ Also, we can verify the number of replicas each shard has from an internal mongo
 Now let's connect to a shard instance and run a mongodb internal command to check the number of replicas,
 
 ```bash
-$ kubectl exec -n demo  mg-sharding-shard0-0  -- mongo admin -u root -p xBC-EwMFivFCgUlK --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
+$ kubectl exec -n demo  mg-sharding-shard0-0  -- mongosh admin -u root -p xBC-EwMFivFCgUlK --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
 [
 	{
 		"_id" : 0,
@@ -259,7 +259,7 @@ Let's check the number of replicas this database has from the MongoDB object, nu
 $ kubectl get mongodb -n demo mg-sharding -o json | jq '.spec.shardTopology.configServer.replicas'
 3
 
-$ kubectl get sts -n demo mg-sharding-configsvr -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo mg-sharding-configsvr -o json | jq '.spec.replicas'
 3
 ```
 
@@ -268,7 +268,7 @@ We can see from both command that the database has `3` replicas in the configSer
 Now let's connect to a mongodb instance and run a mongodb internal command to check the number of replicas,
 
 ```bash
-$ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongo admin -u root -p xBC-EwMFivFCgUlK --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
+$ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongosh admin -u root -p xBC-EwMFivFCgUlK --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
 [
 	{
 		"_id" : 0,
@@ -358,7 +358,7 @@ Let's check the number of replicas this database has from the MongoDB object, nu
 $ kubectl get mongodb -n demo mg-sharding -o json | jq '.spec.shardTopology.mongos.replicas'
 2
 
-$ kubectl get sts -n demo mg-sharding-mongos -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo mg-sharding-mongos -o json | jq '.spec.replicas'
 2
 ```
 
@@ -367,7 +367,7 @@ We can see from both command that the database has `2` replicas in the mongos.
 Now let's connect to a mongodb instance and run a mongodb internal command to check the number of replicas,
 
 ```bash
-$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongo admin -u root -p xBC-EwMFivFCgUlK --eval "sh.status()" --quiet
+$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongosh admin -u root -p xBC-EwMFivFCgUlK --eval "sh.status()" --quiet
 --- Sharding Status --- 
   sharding version: {
   	"_id" : 1,
@@ -593,7 +593,7 @@ Now, we are going to verify the number of shards this database has from the Mong
 $ kubectl get mongodb -n demo mg-sharding -o json | jq '.spec.shardTopology.shard.shards'         
 3
 
-$ kubectl get sts -n demo                                                                      
+$ kubectl get petset -n demo                                                                      
 NAME                    READY   AGE
 mg-sharding-configsvr   4/4     66m
 mg-sharding-mongos      3/3     64m
@@ -604,7 +604,7 @@ mg-sharding-shard2      4/4     12m
 
 Now let's connect to a mongos instance and run a mongodb internal command to check the number of shards,
 ```bash
-$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongo admin -u root -p xBC-EwMFivFCgUlK --eval "sh.status()" --quiet  
+$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongosh admin -u root -p xBC-EwMFivFCgUlK --eval "sh.status()" --quiet  
 --- Sharding Status --- 
   sharding version: {
   	"_id" : 1,
@@ -647,13 +647,13 @@ Now, we are going to verify the number of replicas each shard has from the Mongo
 $ kubectl get mongodb -n demo mg-sharding -o json | jq '.spec.shardTopology.shard.replicas'              
 4
 
-$ kubectl get sts -n demo mg-sharding-shard0 -o json | jq '.spec.replicas'          
+$ kubectl get petset -n demo mg-sharding-shard0 -o json | jq '.spec.replicas'          
 4
 ```
 
 Now let's connect to a shard instance and run a mongodb internal command to check the number of replicas,
 ```bash
-$ kubectl exec -n demo  mg-sharding-shard0-0  -- mongo admin -u root -p xBC-EwMFivFCgUlK --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
+$ kubectl exec -n demo  mg-sharding-shard0-0  -- mongosh admin -u root -p xBC-EwMFivFCgUlK --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
 [
 	{
 		"_id" : 0,
@@ -770,13 +770,13 @@ Now, we are going to verify the number of replicas this database has from the Mo
 $ kubectl get mongodb -n demo mg-sharding -o json | jq '.spec.shardTopology.configServer.replicas'
 4
 
-$ kubectl get sts -n demo mg-sharding-configsvr -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo mg-sharding-configsvr -o json | jq '.spec.replicas'
 4
 ```
 
 Now let's connect to a mongodb instance and run a mongodb internal command to check the number of replicas,
 ```bash
-$ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongo admin -u root -p xBC-EwMFivFCgUlK --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
+$ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongosh admin -u root -p xBC-EwMFivFCgUlK --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
 [
 	{
 		"_id" : 0,
@@ -893,13 +893,13 @@ Now, we are going to verify the number of replicas this database has from the Mo
 $ kubectl get mongodb -n demo mg-sharding -o json | jq '.spec.shardTopology.mongos.replicas'
 3
 
-$ kubectl get sts -n demo mg-sharding-mongos -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo mg-sharding-mongos -o json | jq '.spec.replicas'
 3
 ```
 
 Now let's connect to a mongodb instance and run a mongodb internal command to check the number of replicas,
 ```bash
-$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongo admin -u root -p xBC-EwMFivFCgUlK --eval "sh.status()" --quiet
+$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongosh admin -u root -p xBC-EwMFivFCgUlK --eval "sh.status()" --quiet
 --- Sharding Status --- 
   sharding version: {
   	"_id" : 1,
@@ -1136,7 +1136,7 @@ Now, we are going to verify the number of shards this database has from the Mong
 $ kubectl get mongodb -n demo mg-sharding -o json | jq '.spec.shardTopology.shard.shards'     
 2
 
-$ kubectl get sts -n demo                                                                      
+$ kubectl get petset -n demo                                                                      
 NAME                    READY   AGE
 mg-sharding-configsvr   3/3     77m
 mg-sharding-mongos      2/2     75m
@@ -1146,7 +1146,7 @@ mg-sharding-shard1      3/3     77m
 
 Now let's connect to a mongos instance and run a mongodb internal command to check the number of shards,
 ```bash
-$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongo admin -u root -p xBC-EwMFivFCgUlK --eval "sh.status()" --quiet  
+$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongosh admin -u root -p xBC-EwMFivFCgUlK --eval "sh.status()" --quiet  
 --- Sharding Status --- 
   sharding version: {
   	"_id" : 1,
@@ -1188,13 +1188,13 @@ Now, we are going to verify the number of replicas each shard has from the Mongo
 $ kubectl get mongodb -n demo mg-sharding -o json | jq '.spec.shardTopology.shard.replicas'
 3
 
-$ kubectl get sts -n demo mg-sharding-shard0 -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo mg-sharding-shard0 -o json | jq '.spec.replicas'
 3
 ```
 
 Now let's connect to a shard instance and run a mongodb internal command to check the number of replicas,
 ```bash
-$ kubectl exec -n demo  mg-sharding-shard0-0  -- mongo admin -u root -p xBC-EwMFivFCgUlK --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
+$ kubectl exec -n demo  mg-sharding-shard0-0  -- mongosh admin -u root -p xBC-EwMFivFCgUlK --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
 [
 	{
 		"_id" : 0,
@@ -1285,13 +1285,13 @@ Now, we are going to verify the number of replicas this database has from the Mo
 $ kubectl get mongodb -n demo mg-sharding -o json | jq '.spec.shardTopology.configServer.replicas'
 3
 
-$ kubectl get sts -n demo mg-sharding-configsvr -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo mg-sharding-configsvr -o json | jq '.spec.replicas'
 3
 ```
 
 Now let's connect to a mongodb instance and run a mongodb internal command to check the number of replicas,
 ```bash
-$ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongo admin -u root -p xBC-EwMFivFCgUlK --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
+$ kubectl exec -n demo  mg-sharding-configsvr-0  -- mongosh admin -u root -p xBC-EwMFivFCgUlK --eval "db.adminCommand( { replSetGetStatus : 1 } ).members" --quiet
 [
 	{
 		"_id" : 0,
@@ -1382,13 +1382,13 @@ Now, we are going to verify the number of replicas this database has from the Mo
 $ kubectl get mongodb -n demo mg-sharding -o json | jq '.spec.shardTopology.mongos.replicas'
 2
 
-$ kubectl get sts -n demo mg-sharding-mongos -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo mg-sharding-mongos -o json | jq '.spec.replicas'
 2
 ```
 
 Now let's connect to a mongodb instance and run a mongodb internal command to check the number of replicas,
 ```bash
-$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongo admin -u root -p xBC-EwMFivFCgUlK --eval "sh.status()" --quiet
+$ kubectl exec -n demo  mg-sharding-mongos-0  -- mongosh admin -u root -p xBC-EwMFivFCgUlK --eval "sh.status()" --quiet
 --- Sharding Status --- 
   sharding version: {
   	"_id" : 1,

--- a/docs/guides/mongodb/schema-manager/deploy-mongodbdatabase/index.md
+++ b/docs/guides/mongodb/schema-manager/deploy-mongodbdatabase/index.md
@@ -254,7 +254,7 @@ Here, we are going to connect to the database with the login credentials and ins
 
 ```bash
 $ kubectl exec -it -n demo mongodb-0 -c mongodb -- bash
-root@mongodb-0:/# mongo --authenticationDatabase=emptydb --username='v-kubernetes-demo-k8s-f7695915-1e-0NV83LXHuGMiittiObYE-1662635657' --password='u-kDmBcMITz9dLrZ7cAL' emptydb
+root@mongodb-0:/# mongosh --authenticationDatabase=emptydb --username='v-kubernetes-demo-k8s-f7695915-1e-0NV83LXHuGMiittiObYE-1662635657' --password='u-kDmBcMITz9dLrZ7cAL' emptydb
 MongoDB shell version v4.4.26
 ...
 
@@ -285,7 +285,7 @@ Here, we can see that the `STATUS` of the `schema-manager` is `Expired` because 
 
 ```bash
 $ kubectl exec -it -n demo mongodb-0 -c mongodb -- bash
-root@mongodb-0:/# mongo --authenticationDatabase=emptydb --username='v-kubernetes-demo-k8s-f7695915-1e-0NV83LXHuGMiittiObYE-1662635657' --password='u-kDmBcMITz9dLrZ7cAL' emptydb
+root@mongodb-0:/# mongosh --authenticationDatabase=emptydb --username='v-kubernetes-demo-k8s-f7695915-1e-0NV83LXHuGMiittiObYE-1662635657' --password='u-kDmBcMITz9dLrZ7cAL' emptydb
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/emptydb?authSource=emptydb&compressors=disabled&gssapiServiceName=mongodb
 Error: Authentication failed. :

--- a/docs/guides/mongodb/schema-manager/initializing-with-script/index.md
+++ b/docs/guides/mongodb/schema-manager/initializing-with-script/index.md
@@ -296,7 +296,7 @@ Here, we are going to connect to the database with the login credentials and ver
 
 ```bash
 $ kubectl exec -it -n demo mongodb-0 -c mongodb -- bash
-root@mongodb-0:/# mongo --authenticationDatabase=initdb --username='v-kubernetes-demo-k8s-f7695915-1e-6sXNTvVpPDtueRQWvoyH-1662641233' --password='-e4v396GFjjjMgPPuU7q' initdb
+root@mongodb-0:/# mongosh --authenticationDatabase=initdb --username='v-kubernetes-demo-k8s-f7695915-1e-6sXNTvVpPDtueRQWvoyH-1662641233' --password='-e4v396GFjjjMgPPuU7q' initdb
 MongoDB shell version v4.4.26
 ...
 
@@ -325,7 +325,7 @@ Here, we can see that the `STATUS` of the `schema-manager` is `Expired` because 
 
 ```bash
 $ kubectl exec -it -n demo mongodb-0 -c mongodb -- bash
-root@mongodb-0:/# mongo --authenticationDatabase=initdb --username='v-kubernetes-demo-k8s-f7695915-1e-6sXNTvVpPDtueRQWvoyH-1662641233' --password='-e4v396GFjjjMgPPuU7q' initdb
+root@mongodb-0:/# mongosh --authenticationDatabase=initdb --username='v-kubernetes-demo-k8s-f7695915-1e-6sXNTvVpPDtueRQWvoyH-1662641233' --password='-e4v396GFjjjMgPPuU7q' initdb
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/initdb?authSource=initdb&compressors=disabled&gssapiServiceName=mongodb
 Error: Authentication failed. :

--- a/docs/guides/mongodb/schema-manager/initializing-with-snapshot/index.md
+++ b/docs/guides/mongodb/schema-manager/initializing-with-snapshot/index.md
@@ -319,7 +319,7 @@ Here, we are going to connect to the database with the login credentials and ver
 
 ```bash
 $ kubectl exec -it -n demo mongodb-0 -c mongodb -- bash
-root@mongodb-0:/# mongo --authenticationDatabase=products --username='v-kubernetes-demo-k8s-f7695915-1e-2zXmduPS89LfvW6tr5Bw-1662639843' --password='6ykdBljJ7D8agXeoSp-f' products
+root@mongodb-0:/# mongosh --authenticationDatabase=products --username='v-kubernetes-demo-k8s-f7695915-1e-2zXmduPS89LfvW6tr5Bw-1662639843' --password='6ykdBljJ7D8agXeoSp-f' products
 MongoDB shell version v4.4.26
 ...
 
@@ -350,7 +350,7 @@ Here, we can see that the `STATUS` of the `schema-manager` is `Expired` because 
 
 ```bash
 $ kubectl exec -it -n demo mongodb-0 -c mongodb -- bash
-root@mongodb-0:/# mongo --authenticationDatabase=products --username='v-kubernetes-demo-k8s-f7695915-1e-2zXmduPS89LfvW6tr5Bw-1662639843' --password='6ykdBljJ7D8agXeoSp-f' products
+root@mongodb-0:/# mongosh --authenticationDatabase=products --username='v-kubernetes-demo-k8s-f7695915-1e-2zXmduPS89LfvW6tr5Bw-1662639843' --password='6ykdBljJ7D8agXeoSp-f' products
 MongoDB shell version v4.4.26
 connecting to: mongodb://127.0.0.1:27017/initdb?authSource=initdb&compressors=disabled&gssapiServiceName=mongodb
 Error: Authentication failed. :

--- a/docs/guides/mongodb/schema-manager/initializing-with-snapshot/index.md
+++ b/docs/guides/mongodb/schema-manager/initializing-with-snapshot/index.md
@@ -352,7 +352,7 @@ Here, we can see that the `STATUS` of the `schema-manager` is `Expired` because 
 $ kubectl exec -it -n demo mongodb-0 -c mongodb -- bash
 root@mongodb-0:/# mongosh --authenticationDatabase=products --username='v-kubernetes-demo-k8s-f7695915-1e-2zXmduPS89LfvW6tr5Bw-1662639843' --password='6ykdBljJ7D8agXeoSp-f' products
 MongoDB shell version v4.4.26
-connecting to: mongodb://127.0.0.1:27017/initdb?authSource=initdb&compressors=disabled&gssapiServiceName=mongodb
+connecting to: mongodb://127.0.0.1:27017/products?authSource=products&compressors=disabled&gssapiServiceName=mongodb
 Error: Authentication failed. :
 connect@src/mongo/shell/mongo.js:374:17
 @(connect):2:6

--- a/docs/guides/mongodb/tls/replicaset.md
+++ b/docs/guides/mongodb/tls/replicaset.md
@@ -178,7 +178,7 @@ subject=CN=root,O=kubedb
 Now, we can connect using `CN=root,O=kubedb` as root to connect to the mongo shell,
 
 ```bash
-root@mgo-rs-tls-0:/$ mongo --tls --tlsCAFile /var/run/mongodb/tls/ca.crt --tlsCertificateKeyFile /var/run/mongodb/tls/client.pem admin --host localhost --authenticationMechanism MONGODB-X509 --authenticationDatabase='$external' -u "CN=root,O=kubedb" --quiet
+root@mgo-rs-tls-0:/$ mongosh --tls --tlsCAFile /var/run/mongodb/tls/ca.crt --tlsCertificateKeyFile /var/run/mongodb/tls/client.pem admin --host localhost --authenticationMechanism MONGODB-X509 --authenticationDatabase='$external' -u "CN=root,O=kubedb" --quiet
 Welcome to the MongoDB shell.
 For interactive help, type "help".
 For more comprehensive documentation, see

--- a/docs/guides/mongodb/tls/sharding.md
+++ b/docs/guides/mongodb/tls/sharding.md
@@ -188,7 +188,7 @@ subject=CN=root,O=kubedb
 Now, we can connect using `CN=root,O=kubedb` as root to connect to the mongo shell,
 
 ```bash
-root@mongo-sh-tls-mongos-0:/# mongo --tls --tlsCAFile /var/run/mongodb/tls/ca.crt --tlsCertificateKeyFile /var/run/mongodb/tls/client.pem admin --host localhost --authenticationMechanism MONGODB-X509 --authenticationDatabase='$external' -u "CN=root,O=kubedb" --quiet
+root@mongo-sh-tls-mongos-0:/# mongosh --tls --tlsCAFile /var/run/mongodb/tls/ca.crt --tlsCertificateKeyFile /var/run/mongodb/tls/client.pem admin --host localhost --authenticationMechanism MONGODB-X509 --authenticationDatabase='$external' -u "CN=root,O=kubedb" --quiet
 Welcome to the MongoDB shell.
 For interactive help, type "help".
 For more comprehensive documentation, see

--- a/docs/guides/mongodb/tls/standalone.md
+++ b/docs/guides/mongodb/tls/standalone.md
@@ -174,7 +174,7 @@ subject=CN=root,O=kubedb
 Now, we can connect using `CN=root,O=kubedb` as root to connect to the mongo shell,
 
 ```bash
-mongodb@mgo-tls-0:/$ mongo --tls --tlsCAFile /var/run/mongodb/tls/ca.crt --tlsCertificateKeyFile /var/run/mongodb/tls/client.pem admin --host localhost --authenticationMechanism MONGODB-X509 --authenticationDatabase='$external' -u "CN=root,O=kubedb" --quiet
+mongodb@mgo-tls-0:/$ mongosh --tls --tlsCAFile /var/run/mongodb/tls/ca.crt --tlsCertificateKeyFile /var/run/mongodb/tls/client.pem admin --host localhost --authenticationMechanism MONGODB-X509 --authenticationDatabase='$external' -u "CN=root,O=kubedb" --quiet
 >
 ```
 

--- a/docs/guides/mongodb/update-version/replicaset.md
+++ b/docs/guides/mongodb/update-version/replicaset.md
@@ -246,7 +246,7 @@ Now, we are going to verify whether the `MongoDB` and the related `PetSets` and 
 $ kubectl get mg -n demo mg-replicaset -o=jsonpath='{.spec.version}{"\n"}'
 8.0.17
 
-$ kubectl get sts -n demo mg-replicaset -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+$ kubectl get petset -n demo mg-replicaset -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
 mongo:8.0.17
 
 $ kubectl get pods -n demo mg-replicaset-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'

--- a/docs/guides/mongodb/update-version/sharding.md
+++ b/docs/guides/mongodb/update-version/sharding.md
@@ -286,13 +286,13 @@ Now, we are going to verify whether the `MongoDB` and the related `PetSets` of `
 $ kubectl get mg -n demo mg-sharding -o=jsonpath='{.spec.version}{"\n"}'
 8.0.17
 
-$ kubectl get sts -n demo mg-sharding-configsvr -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+$ kubectl get petset -n demo mg-sharding-configsvr -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
 mongo:8.0.17
 
-$ kubectl get sts -n demo mg-sharding-shard0 -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+$ kubectl get petset -n demo mg-sharding-shard0 -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
 mongo:8.0.17
 
-$ kubectl get sts -n demo mg-sharding-mongos -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+$ kubectl get petset -n demo mg-sharding-mongos -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
 mongo:8.0.17
 
 $ kubectl get pods -n demo mg-sharding-configsvr-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'

--- a/docs/guides/mongodb/update-version/standalone.md
+++ b/docs/guides/mongodb/update-version/standalone.md
@@ -244,7 +244,7 @@ Now, we are going to verify whether the `MongoDB` and the related `PetSets` thei
 $ kubectl get mg -n demo mg-standalone -o=jsonpath='{.spec.version}{"\n"}'                                                                                          
 8.0.17
 
-$ kubectl get sts -n demo mg-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'                                                               
+$ kubectl get petset -n demo mg-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'                                                               
 mongo:8.0.17
 
 $ kubectl get pods -n demo mg-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'                                                                           

--- a/docs/guides/mongodb/vault-integration/kmip-encryption/index.md
+++ b/docs/guides/mongodb/vault-integration/kmip-encryption/index.md
@@ -210,15 +210,15 @@ We should see these logs which confirm that this `MongoDB` is setup with KMIP
 Now, we can connect to this database through [mongo-shell](https://docs.mongodb.com/v4.2/mongo/). In this tutorial, we are connecting to the MongoDB server from inside the pod.
 
 ```bash
-$ kubectl get secrets -n demo mg-kmip-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo mg-kmip-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo mg-kmip-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo mg-kmip-auth -o jsonpath='{.data.password}' | base64 -d
 bJI!1H!)V7!2U.wJ
 
 $ kubectl exec -it mg-kmip-0 -n demo -- bash
 
-> mongo admin
+> mongosh admin
 
 > db.auth("root","bJI!1H!)V7!2U.wJ")
 1

--- a/docs/guides/mongodb/volume-expansion/replicaset.md
+++ b/docs/guides/mongodb/volume-expansion/replicaset.md
@@ -100,7 +100,7 @@ mg-replicaset   4.4.26      Ready     10m
 Let's check volume size from petset, and from the persistent volume,
 
 ```bash
-$ kubectl get sts -n demo mg-replicaset -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo mg-replicaset -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1Gi"
 
 $ kubectl get pv -n demo                                                                                          
@@ -225,7 +225,7 @@ Events:
 Now, we are going to verify from the `Petset`, and the `Persistent Volumes` whether the volume of the database has expanded to meet the desired state, Let's check,
 
 ```bash
-$ kubectl get sts -n demo mg-replicaset -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo mg-replicaset -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "2Gi"
 
 $ kubectl get pv -n demo                                                                                          

--- a/docs/guides/mongodb/volume-expansion/sharding.md
+++ b/docs/guides/mongodb/volume-expansion/sharding.md
@@ -107,10 +107,10 @@ mg-sharding   4.4.26      Ready     2m45s
 Let's check volume size from petset, and from the persistent volume of shards and config servers,
 
 ```bash
-$ kubectl get sts -n demo mg-sharding-configsvr -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo mg-sharding-configsvr -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1Gi"
 
-$ kubectl get sts -n demo mg-sharding-shard0 -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo mg-sharding-shard0 -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "1Gi"
 
 $ kubectl get pv -n demo
@@ -250,10 +250,10 @@ Events:
 Now, we are going to verify from the `Petset`, and the `Persistent Volumes` whether the volume of the database has expanded to meet the desired state, Let's check,
 
 ```bash
-$ kubectl get sts -n demo mg-sharding-configsvr -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo mg-sharding-configsvr -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "2Gi"
 
-$ kubectl get sts -n demo mg-sharding-shard0 -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo mg-sharding-shard0 -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "2Gi"
 
 $ kubectl get pv -n demo


### PR DESCRIPTION
Fixes found by running the MongoDB guides on a live KubeDB cluster (MongoDB 8.0.17), confirmed against cluster behavior.

## Fixes
- **mongo -> mongosh (real, breaking)**: guides connect with the legacy `mongo` shell (`mongo admin -u root -p ...`, `mongo --tls ...`). The legacy `mongo` shell was removed in MongoDB 6.0; on the 8.0.17 image only `mongosh` exists (`mongo: not found`, exit 127). `mongosh` accepts the same syntax and works. Replaced across 26 files. Pod names like `mongo-sh-mongos-0` were left intact.
- **kubectl get sts -> kubectl get petset**: KubeDB manages a PetSet, not a StatefulSet.
- **stray-backslash secret reads**: `{.data.\username}`/`{.data.\password}` cleaned.

## Verified on cluster
- mgo-quickstart 8.0.17 Ready; auth secret basic-auth keys username/password (root); `mongosh admin -u root -p ...` authenticates (`mongo` does not exist).

No em-dashes introduced. Guides beyond the quickstart probe received only the above confirmed-pattern fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated MongoDB guide command examples across backups, clustering, TLS, failover/DR, scaling, storage autoscaling, reconfiguration, upgrades, quickstart, and more to use `mongosh` instead of the legacy `mongo`.
  * Corrected Kubernetes Secret JSONPath snippets used to extract connection credentials.

* **Bug Fixes**
  * Fixed guide verification commands to use current Kubernetes resource types (`PetSet` instead of `StatefulSet`) for storage, replica, and version checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->