### PR TITLE
docs(redis): fix secret-read commands found by executing the guides

### DIFF
--- a/docs/guides/redis/backup/kubestash/logical/index.md
+++ b/docs/guides/redis/backup/kubestash/logical/index.md
@@ -219,14 +219,14 @@ redis-cluster-shard2-1   1/1     Running   0          10m
 - Username: Run following command to get _username_,
 
   ```bash
-  $ kubectl get secrets -n demo redis-cluster-auth -o jsonpath='{.data.\username}' | base64 -d
+  $ kubectl get secrets -n demo redis-cluster-auth -o jsonpath='{.data.username}' | base64 -d
   default
   ```
 
 - Password: Run the following command to get _password_,
 
   ```bash
-  $ kubectl get secrets -n demo redis-cluster-auth -o jsonpath='{.data.\password}' | base64 -d
+  $ kubectl get secrets -n demo redis-cluster-auth -o jsonpath='{.data.password}' | base64 -d
   8UnSPM;(~cXWWs60
   ```
 Now, let’s exec into the pod and insert some data,

--- a/docs/guides/redis/backup/stash/auto-backup/index.md
+++ b/docs/guides/redis/backup/stash/auto-backup/index.md
@@ -155,7 +155,7 @@ redis.kubedb.com/sample-redis-1 created
 Now, let's insert some sample data into it.
 
 ```bash
-❯ export PASSWORD=$(kubectl get secrets -n demo-1 sample-redis-1-auth -o jsonpath='{.data.\password}' | base64 -d)
+❯ export PASSWORD=$(kubectl get secrets -n demo-1 sample-redis-1-auth -o jsonpath='{.data.password}' | base64 -d)
 ❯ kubectl exec -it -n demo-1 sample-redis-1-0 -- redis-cli -a $PASSWORD
 Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
 127.0.0.1:6379> set key1 value1
@@ -338,7 +338,7 @@ redis.kubedb.com/sample-redis-2 created
 Now, let's insert some sample data into it.
 
 ```bash
-❯ export PASSWORD=$(kubectl get secrets -n demo-2 sample-redis-2-auth -o jsonpath='{.data.\password}' | base64 -d)
+❯ export PASSWORD=$(kubectl get secrets -n demo-2 sample-redis-2-auth -o jsonpath='{.data.password}' | base64 -d)
 ❯ kubectl exec -it -n demo-2 sample-redis-2-0 -- redis-cli -a $PASSWORD
 Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
 127.0.0.1:6379> set key1 value1
@@ -515,7 +515,7 @@ redis.kubedb.com/sample-redis-3 created
 Now, let's insert some sample data into it.
 
 ```bash
-❯ export PASSWORD=$(kubectl get secrets -n demo-3 sample-redis-3-auth -o jsonpath='{.data.\password}' | base64 -d)
+❯ export PASSWORD=$(kubectl get secrets -n demo-3 sample-redis-3-auth -o jsonpath='{.data.password}' | base64 -d)
 ❯ kubectl exec -it -n demo-3 sample-redis-3-0 -- redis-cli -a $PASSWORD
 Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
 127.0.0.1:6379> set key1 value1

--- a/docs/guides/redis/backup/stash/standalone/index.md
+++ b/docs/guides/redis/backup/stash/standalone/index.md
@@ -133,7 +133,7 @@ Here, we are going to use `password` to authenticate and insert the sample data.
 At first, let's export the password as environment variables to make further commands re-usable.
 
 ```bash
-export PASSWORD=$(kubectl get secrets -n demo sample-redis-auth -o jsonpath='{.data.\password}' | base64 -d)
+export PASSWORD=$(kubectl get secrets -n demo sample-redis-auth -o jsonpath='{.data.password}' | base64 -d)
 ```
 
 Now, let's exec into the database pod and insert some sample data,

--- a/docs/guides/redis/clustering/redis-cluster.md
+++ b/docs/guides/redis/clustering/redis-cluster.md
@@ -219,14 +219,14 @@ status:
 - Username: Run following command to get _username_,
 
   ```bash
-  $ kubectl get secrets -n demo redis-cluster-auth -o jsonpath='{.data.\username}' | base64 -d
+  $ kubectl get secrets -n demo redis-cluster-auth -o jsonpath='{.data.username}' | base64 -d
   default
   ```
 
 - Password: Run the following command to get _password_,
 
   ```bash
-  $ kubectl get secrets -n demo redis-cluster-auth -o jsonpath='{.data.\password}' | base64 -d
+  $ kubectl get secrets -n demo redis-cluster-auth -o jsonpath='{.data.password}' | base64 -d
   AO8iK)s);o5kQVFs
   ```
 

--- a/docs/guides/redis/initialization/using-script.md
+++ b/docs/guides/redis/initialization/using-script.md
@@ -331,10 +331,10 @@ type: kubernetes.io/basic-auth
 Now, you can connect to this database through redis cli. In this tutorial, we are connecting to the Redis server from inside the pod.
 
 ```bash
-$ kubectl get secrets -n demo rd-init-script-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo rd-init-script-auth -o jsonpath='{.data.username}' | base64 -d
 default
 
-$ kubectl get secrets -n demo rd-init-script-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo rd-init-script-auth -o jsonpath='{.data.password}' | base64 -d
 I4LN__V2nh9lvwar
 
 $ kubectl exec -it rd-init-script-0 -n demo -- bash

--- a/docs/guides/redis/reconfigure/redis.md
+++ b/docs/guides/redis/reconfigure/redis.md
@@ -100,10 +100,10 @@ Now, we will check if the database has started with the custom configuration we 
 
 First we need to get the username and password to connect to a redis instance,
 ```bash
-$ kubectl get secrets -n demo sample-redis-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo sample-redis-auth -o jsonpath='{.data.username}' | base64 -d
 default
 
-$ kubectl get secrets -n demo sample-redis-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo sample-redis-auth -o jsonpath='{.data.password}' | base64 -d
 0PI1tYTyzp;YaXOh
 ```
 

--- a/docs/guides/redis/reconfigure/valkey.md
+++ b/docs/guides/redis/reconfigure/valkey.md
@@ -100,10 +100,10 @@ Now, we will check if the database has started with the custom configuration we 
 
 First we need to get the username and password to connect to a Valkey instance,
 ```bash
-$ kubectl get secrets -n demo sample-redis-auth -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo sample-redis-auth -o jsonpath='{.data.username}' | base64 -d
 default
 
-$ kubectl get secrets -n demo sample-redis-auth -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo sample-redis-auth -o jsonpath='{.data.password}' | base64 -d
 0PI1tYTyzp;YaXOh
 ```
 

--- a/docs/guides/redis/sentinel/redis-sentinel.md
+++ b/docs/guides/redis/sentinel/redis-sentinel.md
@@ -257,14 +257,14 @@ status:
 - Username: Run following command to get _username_,
 
   ```bash
-  $ kubectl get secrets -n demo rd-demo-auth -o jsonpath='{.data.\username}' | base64 -d
+  $ kubectl get secrets -n demo rd-demo-auth -o jsonpath='{.data.username}' | base64 -d
   default
   ```
 
 - Password: Run the following command to get _password_,
 
   ```bash
-  $ kubectl get secrets -n demo rd-demo-auth -o jsonpath='{.data.\password}' | base64 -d
+  $ kubectl get secrets -n demo rd-demo-auth -o jsonpath='{.data.password}' | base64 -d
   5VjZ7iYaoo8YRp!p
   ```
 Now, you can connect to this redis database using the service using the credentials.
@@ -277,14 +277,14 @@ Now, you can connect to this redis database using the service using the credenti
 - Username: Run following command to get _username_,
 
   ```bash
-  $ kubectl get secrets -n demo sen-demo-auth -o jsonpath='{.data.\username}' | base64 -d
+  $ kubectl get secrets -n demo sen-demo-auth -o jsonpath='{.data.username}' | base64 -d
   root
   ```
 
 - Password: Run the following command to get _password_,
 
   ```bash
-  $ kubectl get secrets -n demo sen-demo-auth -o jsonpath='{.data.\password}' | base64 -d
+  $ kubectl get secrets -n demo sen-demo-auth -o jsonpath='{.data.password}' | base64 -d
   Gw_sd;~Vrsj9kJSL
   ```
 


### PR DESCRIPTION
Fixes found by running the Redis guides on a live KubeDB cluster (Redis 8.2.2), confirmed against cluster behavior.

## Fixes
- **stray-backslash secret reads**: `jsonpath='{.data.\username}'` / `'{.data.\password}'` cleaned to `{.data.username}` / `{.data.password}` (8 files).

## Verified on cluster
- redis-quickstart 8.2.2 Ready; auth secret basic-auth (username=default). Doc flow works exactly: `redis-cli` -> `ping`=PONG, `SET mykey "Hello"`=OK, `GET mykey`="Hello". `redis-cli` client is present/correct (unchanged).

No em-dashes introduced. Guides beyond quickstart received only the above confirmed-pattern fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Redis and Valkey tutorial commands for retrieving credentials from Kubernetes secrets.
  * Fixed username and password extraction examples so the JSONPath expressions match the actual secret keys.
  * Clarified connection information steps across backup, clustering, initialization, reconfigure, and Sentinel guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->