### PR TITLE
docs(kafka): fix case-sensitive guides/Kafka 404 path found by executing the guide

### DIFF
--- a/docs/guides/kafka/quickstart/kafka/index.md
+++ b/docs/guides/kafka/quickstart/kafka/index.md
@@ -102,7 +102,7 @@ spec:
 ```
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/Kafka/quickstart/kafka/yamls/kafka-v1.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/kafka/quickstart/kafka/yamls/kafka-v1.yaml
 kafka.kubedb.com/kafka-quickstart created
 ```
 
@@ -127,7 +127,7 @@ spec:
 ```
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/Kafka/quickstart/kafka/yamls/kafka-v1alpha2.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/kafka/quickstart/kafka/yamls/kafka-v1alpha2.yaml
 kafka.kubedb.com/kafka-quickstart created
 ```
 


### PR DESCRIPTION
Fix found by running the Kafka quickstart on a live KubeDB cluster (Kafka 4.2.0, 3-node KRaft), confirmed against cluster behavior.

## Fix
- **guides/Kafka -> guides/kafka (404)**: the quickstart apply URLs used `.../docs/guides/Kafka/quickstart/kafka/yamls/kafka-v1.yaml` with a capital `Kafka`. GitHub raw is case-sensitive and the real directory is lowercase `kafka` (confirmed the lowercase file exists), so the URLs 404. Fixed to `guides/kafka/`.

## Verified on cluster
- kafka-quickstart 4.2.0 (replicas 3) Ready; 3 pods 1/1; auth secret basic-auth keys username/password (admin).

No em-dashes introduced.