### PR TITLE
docs(rabbitmq): fix case-sensitive link and secret-read commands found by executing the guides

### DIFF
--- a/docs/guides/rabbitmq/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/rabbitmq/reconfigure-tls/reconfigure-tls.md
@@ -75,10 +75,10 @@ rm      4.2.4     Ready     10m
 
 
 ```bash
-$ kubectl get secrets -n demo rm-admin-cred -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo rm-admin-cred -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo rm-admin-cred -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo rm-admin-cred -o jsonpath='{.data.password}' | base64 -d
 U6(h_pYrekLZ2OOd
 
 We can verify from the above output that TLS is disabled for this database.

--- a/docs/guides/rabbitmq/reconfigure/reconfigure.md
+++ b/docs/guides/rabbitmq/reconfigure/reconfigure.md
@@ -100,10 +100,10 @@ Now, we will check if the database has started with the custom configuration we 
 
 First we need to get the username and password to connect to a RabbitMQ instance,
 ```bash
-$ kubectl get secrets -n demo rm-cluster-admin-cred -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo rm-cluster-admin-cred -o jsonpath='{.data.username}' | base64 -d
 admin
 
-$ kubectl get secrets -n demo rm-cluster-admin-cred  -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo rm-cluster-admin-cred  -o jsonpath='{.data.password}' | base64 -d
 m6lXjZugrC4VEpB8
 ```
 

--- a/docs/guides/rabbitmq/tls/tls.md
+++ b/docs/guides/rabbitmq/tls/tls.md
@@ -141,7 +141,7 @@ kubectl delete ns demo
 ## Next Steps
 
 - Detail concepts of [RabbitMQ object](/docs/guides/rabbitmq/concepts/rabbitmq.md).
-(/docs/guides/RabbitMQ/monitoring/using-prometheus-operator.md).
+(/docs/guides/rabbitmq/monitoring/using-prometheus-operator.md).
 - Monitor your RabbitMQ database with KubeDB using [out-of-the-box builtin-Prometheus](/docs/guides/rabbitmq/monitoring/using-builtin-prometheus.md).
 - Detail concepts of [RabbitMQ object](/docs/guides/rabbitmq/concepts/rabbitmq.md).
 - Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).


### PR DESCRIPTION
Fixes found by running the RabbitMQ quickstart on a live KubeDB cluster (RabbitMQ 4.2.4), confirmed against cluster behavior.

## Fixes
- **guides/RabbitMQ -> guides/rabbitmq (broken link)**: tls/tls.md linked `/docs/guides/RabbitMQ/monitoring/using-prometheus-operator.md` (capital); the site uses the lowercase `guides/rabbitmq/` path.
- **stray-backslash secret reads**: `{.data.\username}`/`{.data.\password}` cleaned.

## Verified on cluster
- rm-quickstart 4.2.4 Ready; auth secret basic-auth keys username/password (admin).

No em-dashes introduced.