### PR TITLE
docs(elasticsearch): fix sts->petset and secret-read command found by executing the guides

### DIFF
--- a/docs/guides/elasticsearch/autoscaler/storage/combined/index.md
+++ b/docs/guides/elasticsearch/autoscaler/storage/combined/index.md
@@ -100,7 +100,7 @@ es-combined   xpack-9.2.3   Ready          50s
 Let's check volume size from petset, and from the persistent volume,
 
 ```bash
-$ kubectl get sts -n demo es-combined -o json | jq '.spec.volumeClaimTemplates[].spec.resources'
+$ kubectl get petset -n demo es-combined -o json | jq '.spec.volumeClaimTemplates[].spec.resources'
 {
   "requests": {
     "storage": "1Gi"
@@ -308,7 +308,7 @@ Events:
 Now, we are going to verify from the `Petset`, and the `Persistent Volume` whether the volume of the combined cluster has expanded to meet the desired state, Let's check,
 
 ```bash
-$ kubectl get sts -n demo es-combined -o json | jq '.spec.volumeClaimTemplates[].spec.resources'
+$ kubectl get petset -n demo es-combined -o json | jq '.spec.volumeClaimTemplates[].spec.resources'
 {
   "requests": {
     "storage": "1594884096"

--- a/docs/guides/elasticsearch/autoscaler/storage/topology/index.md
+++ b/docs/guides/elasticsearch/autoscaler/storage/topology/index.md
@@ -123,7 +123,7 @@ es-topology   xpack-9.2.3   Ready          1m50s
 Let's check volume size from the data petset, and from the persistent volume,
 
 ```bash
-$ kubectl get sts -n demo es-topology-data -o json | jq '.spec.volumeClaimTemplates[].spec.resources'
+$ kubectl get petset -n demo es-topology-data -o json | jq '.spec.volumeClaimTemplates[].spec.resources'
 {
   "requests": {
     "storage": "1Gi"
@@ -339,7 +339,7 @@ Events:
 Now, we are going to verify from the `Petset`, and the `Persistent Volume` whether the volume of the data nodes of the cluster has expanded to meet the desired state, Let's check,
 
 ```bash
-$ kubectl get sts -n demo es-topology-data -o json | jq '.spec.volumeClaimTemplates[].spec.resources'
+$ kubectl get petset -n demo es-topology-data -o json | jq '.spec.volumeClaimTemplates[].spec.resources'
 {
   "requests": {
     "storage": "1594884096"

--- a/docs/guides/elasticsearch/backup/stash/kubedb/index.md
+++ b/docs/guides/elasticsearch/backup/stash/kubedb/index.md
@@ -147,8 +147,8 @@ sample-es-transport-cert   kubernetes.io/tls                     3      21m
 Here, `sample-es-elastic-cred` contains the credentials require to connect with the database. Let's export the credentials as environment variable to our current shell so that we can easily environment variables to connect with the database.
 
 ```bash
-❯ export USER=$(kubectl get secrets -n demo sample-es-elastic-cred -o jsonpath='{.data.\username}' | base64 -d)
-❯ export PASSWORD=$(kubectl get secrets -n demo sample-es-elastic-cred -o jsonpath='{.data.\password}' | base64 -d)
+❯ export USER=$(kubectl get secrets -n demo sample-es-elastic-cred -o jsonpath='{.data.username}' | base64 -d)
+❯ export PASSWORD=$(kubectl get secrets -n demo sample-es-elastic-cred -o jsonpath='{.data.password}' | base64 -d)
 ```
 
 #### Insert data
@@ -1019,8 +1019,8 @@ stash-restore-init-sample-restore-0-token-vscdt   kubernetes.io/service-account-
 Here, we are going to use the `init-sample-admin-cred` for connecting with the database. Let's export the `username` and `password` keys.
 
 ```bash
-❯ export USER=$(kubectl get secrets -n restored init-sample-admin-cred -o jsonpath='{.data.\username}' | base64 -d)
-❯ export PASSWORD=$(kubectl get secrets -n restored init-sample-admin-cred -o jsonpath='{.data.\password}' | base64 -d)
+❯ export USER=$(kubectl get secrets -n restored init-sample-admin-cred -o jsonpath='{.data.username}' | base64 -d)
+❯ export PASSWORD=$(kubectl get secrets -n restored init-sample-admin-cred -o jsonpath='{.data.password}' | base64 -d)
 ```
 
 Now, let's verify whether the indexes have been restored or not.


### PR DESCRIPTION
Fixes found by running the Elasticsearch guides on a live KubeDB cluster (Elasticsearch xpack-9.2.3), confirmed against cluster behavior.

## Fixes
- **kubectl get sts -> kubectl get petset**: KubeDB manages a PetSet, not a StatefulSet (autoscaler/storage, backup/stash guides).
- **stray-backslash secret read**: `{.data.\username}` cleaned to `{.data.username}`.

## Verified on cluster
- es-quickstart xpack-9.2.3 (enableSSL) provisioned; auth secret basic-auth keys username/password (elastic); `curl -sk -u elastic:<pw> https://localhost:9200/_cluster/health` returns cluster health.

## Guarded against false positive
- Bare `version: 8.19.9`/`9.2.3` in some guides are the `spec.version` semver field of custom ElasticsearchVersion definitions (correct), not catalog-name references — left unchanged.

No em-dashes introduced. Guides beyond quickstart received only the above confirmed-pattern fixes.