### PR TITLE
docs(postgres): fix broken example-file references found by executing the guides

### DIFF
--- a/docs/guides/postgres/backup/kubestash/application-level/index.md
+++ b/docs/guides/postgres/backup/kubestash/application-level/index.md
@@ -430,7 +430,7 @@ spec:
 Let's create the `BackupConfiguration` CR that we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/kubestash/application-level/examples/backupconfiguration.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/backup/kubestash/application-level/examples/backupconfiguration.yaml
 backupconfiguration.core.kubestash.com/sample-postgres-backup created
 ```
 

--- a/docs/guides/postgres/backup/kubestash/logical/index.md
+++ b/docs/guides/postgres/backup/kubestash/logical/index.md
@@ -430,7 +430,7 @@ spec:
 Let's create the `BackupConfiguration` CR that we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/kubestash/logical/examples/backupconfiguration.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/backup/kubestash/logical/examples/backupconfiguration.yaml
 backupconfiguration.core.kubestash.com/sample-postgres-backup created
 ```
 

--- a/docs/guides/postgres/pitr/archiver.md
+++ b/docs/guides/postgres/pitr/archiver.md
@@ -105,7 +105,7 @@ spec:
     last: 2
 ```
 ```bash
-$ kubectl apply -f  https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/pitr/yamls/retention-policy.yaml 
+$ kubectl apply -f  https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/pitr/yamls/retentionPolicy.yaml 
 retentionpolicy.storage.kubestash.com/postgres-retention-policy created
 ```
 
@@ -172,9 +172,9 @@ stringData:
 ```
 
 ```bash 
- $ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/pirt/yamls/postgresarchiver.yaml
+ $ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/pitr/yamls/postgresarchiver.yaml
  postgresarchiver.archiver.kubedb.com/postgresarchiver-sample created
- $ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/pirt/yamls/encryptionSecret.yaml
+ $ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/pitr/yamls/encryptionSecret.yaml
 ```
 
 ## Ensure volumeSnapshotClass

--- a/docs/guides/postgres/quickstart/quickstart.md
+++ b/docs/guides/postgres/quickstart/quickstart.md
@@ -533,7 +533,7 @@ Say, the Postgres CR was deleted with `spec.deletionPolicy` to `Halt` and you wa
 
 You can do it by simpily re-deploying the original Postgres object:
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/postgres/quickstart/quick-postgres.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/postgres/quickstart/quick-postgres-v1.yaml
 postgres.kubedb.com/quick-postgres created
 ```
 ## Cleaning up

--- a/docs/guides/postgres/quickstart/rbac.md
+++ b/docs/guides/postgres/quickstart/rbac.md
@@ -67,7 +67,7 @@ spec:
 Create above Postgres object with following command
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/postgres/quickstart/quick-postgres.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/postgres/quickstart/quick-postgres-v1.yaml
 postgres.kubedb.com/quick-postgres created
 ```
 

--- a/docs/guides/postgres/remote-replica/remotereplica.md
+++ b/docs/guides/postgres/remote-replica/remotereplica.md
@@ -191,7 +191,7 @@ spec:
 ```
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/remote-replica/yamls/pg-ingress.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/postgres/remote-replica/yamls/pg-ingres.yaml
 ingress.networking.k8s.io/pg-singapore created
 $ kubectl get ingress -n demo
 NAME              CLASS   HOSTS                           ADDRESS          PORTS   AGE
@@ -360,7 +360,7 @@ kubectl delete -n demo pg/pg-singapore
 kubectl delete -n demo pg/pg-london
 kubectl delete secret -n demo pg-singapore-auth
 kubectl delete secret -n demo pg-london-auth
-kubectl delete ingres -n demo pg-singapore
+kubectl delete ingress -n demo pg-singapore
 kubectl delete ns demo
 ```
 

--- a/docs/guides/postgres/rotate-authentication/rotateauth.md
+++ b/docs/guides/postgres/rotate-authentication/rotateauth.md
@@ -130,7 +130,7 @@ Here,
 
 Let's create the `PostgresOpsRequest` CR we have shown above,
 ```shell
- $ kubectl apply -f https://github.com/kubedb/docs/raw/{{ .version }}/docs/examples/postgres/rotate-auth/postgres-rotate-auth-generated.yaml
+ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{ .version }}/docs/examples/postgres/rotate-auth/rotate-auth-generated.yaml
  postgresopsrequest.ops.kubedb.com/pgops-rotate-auth-generated created
 ```
 Let's wait for `PostgresOpsrequest` to be `Successful`. Run the following command to watch `PostgresOpsrequest` CRO


### PR DESCRIPTION
Fixes found by executing the postgres guides against a live KubeDB v2026.6.19 cluster (docs version under test: v2026.6.19). Every change is a broken `kubectl apply/create -f ...` example reference or an invalid resource name: the path a user would run points to a file that does not exist on disk, or (in one case) to a resource type that does not exist. Each fix was verified against the actual files in this repo and, where the flow was runnable on the cluster, by running the corrected command.

### Fixes

- **quickstart/quickstart.md** (Resume step): applied `.../quickstart/quick-postgres.yaml`, which was deleted and replaced by `quick-postgres-v1.yaml` / `quick-postgres-v1alpha2.yaml`. Now points to `quick-postgres-v1.yaml`. Verified by halting the quickstart DB and resuming it with `quick-postgres-v1.yaml` (recreated from the retained PVC/secret).
- **quickstart/rbac.md**: same dangling `quick-postgres.yaml` reference. Now `quick-postgres-v1.yaml`. Verified the RBAC flow (Role/ServiceAccount/RoleBinding created, pod bound to the SA).
- **rotate-authentication/rotateauth.md**: applied `.../rotate-auth/postgres-rotate-auth-generated.yaml`; the file is `rotate-auth-generated.yaml`. Verified by running the corrected `RotateAuth` ops (operator-generated and user-defined flows both Successful, previous creds stored under `username.prev`/`password.prev`).
- **remote-replica/remotereplica.md** (line 194): applied `.../remote-replica/yamls/pg-ingress.yaml`; the file is `pg-ingres.yaml` (single "s"). Corrected to match the on-disk file.
- **remote-replica/remotereplica.md** (cleanup): `kubectl delete ingres ...` uses an invalid resource type; corrected to `ingress`. Confirmed on-cluster that `ingres` is not a known resource type.
- **pitr/archiver.md** (line 108): `.../pitr/yamls/retention-policy.yaml`; the file is `retentionPolicy.yaml` (camelCase).
- **pitr/archiver.md** (lines 175, 177): `.../pirt/yamls/postgresarchiver.yaml` and `.../pirt/yamls/encryptionSecret.yaml` use a `pirt` path typo; corrected to `pitr` (files exist under `pitr/yamls/`).
- **backup/kubestash/application-level/index.md** (line 433): `.../postgres/kubestash/application-level/examples/backupconfiguration.yaml` is missing the `backup/` path segment; the file lives at `.../postgres/backup/kubestash/application-level/examples/`. Sibling references in the same guide already use the correct path.
- **backup/kubestash/logical/index.md** (line 433): same missing `backup/` segment; corrected.

After the fixes, a full scan confirms every example/yaml reference in the postgres guide tree resolves to a file that exists.

### Coverage

Executed on the cluster (passed, no doc bug beyond the above): quickstart, rbac, clustering/ha_cluster, restart, scaling (vertical + horizontal), update-version, rotate-authentication, initialization, tls/configure, configuration (config-file + pgtune), synchronous, custom-versions, custom-rbac, reconfigure (configSecret + applyConfig + removeCustomConfig), cli. Guides needing infrastructure not present on the test cluster (volume-expansion, monitoring via prometheus-operator, backup end-to-end, pitr, autoscaler, gitops, distributed, disaster-recovery, storage-migration) were audited statically for the broken-reference class; that is where the pitr and backup fixes above came from.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected several PostgreSQL tutorial command examples so they point to the right manifest and example URLs.
  * Fixed broken or misspelled command references in backup, PITR, quickstart, remote replica, and authentication rotation guides.
  * Updated some examples to use the latest versioned manifest names and proper command syntax for creating and deleting resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->