### PR TITLE
docs(clickhouse): fix incorrect commands and fields found by executing the guides

### DIFF
--- a/docs/examples/clickhouse/rotate-auth/chops-rotate-auth-generated.yaml
+++ b/docs/examples/clickhouse/rotate-auth/chops-rotate-auth-generated.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   type: RotateAuth
   databaseRef:
-    name: clickhouse-prod
+    name: clickhouse
   timeout: 5m
   apply: IfReady

--- a/docs/examples/clickhouse/rotate-auth/chops-rotate-auth-user.yaml
+++ b/docs/examples/clickhouse/rotate-auth/chops-rotate-auth-user.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   type: RotateAuth
   databaseRef:
-    name: clickhouse-prod
+    name: clickhouse
   authentication:
     secretRef:
       kind: Secret

--- a/docs/guides/clickhouse/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/clickhouse/autoscaler/storage/storage-autoscale.md
@@ -59,7 +59,7 @@ Now, we are going to deploy a `ClickHouse` cluster using a supported version by 
 
 #### Deploy ClickHouse Cluster
 
-In this section, we are going to deploy a ClickHouse cluster with version `3.13.2`.  Then, in the next section we will set up autoscaling for this database using `ClickHouseAutoscaler` CRD. Below is the YAML of the `ClickHouse` CR that we are going to create,
+In this section, we are going to deploy a ClickHouse cluster with version `26.2.6`.  Then, in the next section we will set up autoscaling for this database using `ClickHouseAutoscaler` CRD. Below is the YAML of the `ClickHouse` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -115,7 +115,7 @@ spec:
 Let's create the `ClickHouse` CRO we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/examples/clickhouse/autoscaling/storage/clickhouse-autoscale.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/clickhouse/autoscaling/storage/clickhouse-autoscale.yaml
 clickhouse.kubedb.com/clickhouse-prod created
 ```
 

--- a/docs/guides/clickhouse/monitoring/using-prometheus-operator.md
+++ b/docs/guides/clickhouse/monitoring/using-prometheus-operator.md
@@ -254,7 +254,7 @@ Here,
 Let's create the clickhouse object that we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/clickhouse/monitoring/cas-with-monirtoring.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/clickhouse/monitoring/coreos-prom-clickhouse.yaml
 clickhouses.kubedb.com/clickhouse-prod created
 ```
 

--- a/docs/guides/clickhouse/reconfigure-tls/clickhouse.md
+++ b/docs/guides/clickhouse/reconfigure-tls/clickhouse.md
@@ -1097,7 +1097,7 @@ So, we can see from the above that, output that tls is disabled successfully.
 To cleanup the Kubernetes resources created by this tutorial, run:
 
 ```bash
-kubectl delete chops-add-tls chops-remove-tls chops-rotate chops-update-issuer
+kubectl delete chops -n demo chops-add-tls chops-remove-tls chops-rotate chops-update-issuer
 kubectl delete clickhouse -n demo clickhouse-prod
 kubectl delete issuer -n demo clickhouse-ca-issuer ch-new-issuer
 kubectl delete ns demo

--- a/docs/guides/clickhouse/reconfigure/reconfigure.md
+++ b/docs/guides/clickhouse/reconfigure/reconfigure.md
@@ -431,7 +431,7 @@ Let's create the `ClickHouseOpsRequest` CR we have shown above,
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/clickhouse/reconfigure/ch-reconfigure-ops-with-apply-config.yaml
-clickhouseopsrequest.ops.kubedb.com/chops-cluster-reconfiugre-with-config created
+clickhouseopsrequest.ops.kubedb.com/chops-cluster-reconfigure-with-config created
 ```
 
 #### Verify the new configuration is working
@@ -441,9 +441,9 @@ If everything goes well, `KubeDB` Ops-manager operator will merge this new confi
 Let's wait for `ClickHouseOpsRequest` to be `Successful`.  Run the following command to watch `ClickHouseOpsRequest` CR,
 
 ```bash
-➤ kubectl get chops -n demo chops-cluster-reconfiugre-with-config 
+➤ kubectl get chops -n demo chops-cluster-reconfigure-with-config 
 NAME                                    TYPE          STATUS       AGE
-chops-cluster-reconfiugre-with-config   Reconfigure   Successful   12m
+chops-cluster-reconfigure-with-config   Reconfigure   Successful   12m
 ```
 
 We can see from the above output that the `ClickHouseOpsRequest` has succeeded. If we describe the `ClickHouseOpsRequest` we will get an overview of the steps that were followed to reconfigure the cluster.
@@ -451,8 +451,8 @@ We can see from the above output that the `ClickHouseOpsRequest` has succeeded. 
 
 
 ```bash
-➤ kubectl describe chops -n demo chops-cluster-reconfiugre-with-config 
-Name:         chops-cluster-reconfiugre-with-config
+➤ kubectl describe chops -n demo chops-cluster-reconfigure-with-config 
+Name:         chops-cluster-reconfigure-with-config
 Namespace:    demo
 Labels:       <none>
 Annotations:  <none>
@@ -562,9 +562,9 @@ Status:
 Events:
   Type     Reason                                                                               Age   From                         Message
   ----     ------                                                                               ----  ----                         -------
-  Normal   Starting                                                                             13m   KubeDB Ops-manager Operator  Start processing for ClickHouseOpsRequest: demo/chops-cluster-reconfiugre-with-config
+  Normal   Starting                                                                             13m   KubeDB Ops-manager Operator  Start processing for ClickHouseOpsRequest: demo/chops-cluster-reconfigure-with-config
   Normal   Starting                                                                             13m   KubeDB Ops-manager Operator  Pausing ClickHouse databse: demo/clickhouse-prod
-  Normal   Successful                                                                           13m   KubeDB Ops-manager Operator  Successfully paused ClickHouse database: demo/clickhouse-prod for ClickHouseOpsRequest: chops-cluster-reconfiugre-with-config
+  Normal   Successful                                                                           13m   KubeDB Ops-manager Operator  Successfully paused ClickHouse database: demo/clickhouse-prod for ClickHouseOpsRequest: chops-cluster-reconfigure-with-config
   Warning  reconcile; ConditionStatus:True                                                      13m   KubeDB Ops-manager Operator  reconcile; ConditionStatus:True
   Warning  reconcile; ConditionStatus:True                                                      13m   KubeDB Ops-manager Operator  reconcile; ConditionStatus:True
   Warning  reconcile; ConditionStatus:True                                                      13m   KubeDB Ops-manager Operator  reconcile; ConditionStatus:True
@@ -580,7 +580,7 @@ Events:
   Warning  evict pod; ConditionStatus:True; PodName:clickhouse-prod-appscode-cluster-shard-1-1  11m   KubeDB Ops-manager Operator  evict pod; ConditionStatus:True; PodName:clickhouse-prod-appscode-cluster-shard-1-1
   Normal   RestartNodes                                                                         10m   KubeDB Ops-manager Operator  Successfully restarted all nodes
   Normal   Starting                                                                             10m   KubeDB Ops-manager Operator  Resuming ClickHouse database: demo/clickhouse-prod
-  Normal   Successful                                                                           10m   KubeDB Ops-manager Operator  Successfully resumed ClickHouse database: demo/clickhouse-prod for ClickHouseOpsRequest: chops-cluster-reconfiugre-with-config
+  Normal   Successful                                                                           10m   KubeDB Ops-manager Operator  Successfully resumed ClickHouse database: demo/clickhouse-prod for ClickHouseOpsRequest: chops-cluster-reconfigure-with-config
 ```
 
 Now let's exec into one of the instance to check the new configuration we have provided.

--- a/docs/guides/clickhouse/restart/restart.md
+++ b/docs/guides/clickhouse/restart/restart.md
@@ -98,14 +98,14 @@ clickhouse.kubedb.com/clickhouse-prod created
 apiVersion: ops.kubedb.com/v1alpha1
 kind: ClickHouseOpsRequest
 metadata:
-  name: restart
+  name: clickhouse-restart
   namespace: demo
 spec:
   type: Restart
   databaseRef:
     name: clickhouse-prod
-  timeout: 3m
-  apply: Always
+  timeout: 10m
+  apply: IfReady
 ```
 
 - `spec.type` specifies the Type of the ops Request

--- a/docs/guides/clickhouse/rotate-auth/rotateauth.md
+++ b/docs/guides/clickhouse/rotate-auth/rotateauth.md
@@ -503,7 +503,7 @@ To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
 $ kubectl delete clickhouseopsrequests -n demo chops-rotate-auth-generated chops-rotate-auth-user
-$ kubectl delete clickhouse -n demo clickhouse-prod
+$ kubectl delete clickhouse -n demo clickhouse
 $ kubectl delete secret -n demo clickhouse-user-auth
 $ kubectl delete ns demo
 ```

--- a/docs/guides/clickhouse/scaling/horizontal-scaling/cluster.md
+++ b/docs/guides/clickhouse/scaling/horizontal-scaling/cluster.md
@@ -154,7 +154,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing horizontal scaling operation on `clickhouse-prod` cluster.
 - `spec.type` specifies that we are performing `HorizontalScaling` on clickhouse.
-- `spec.horizontalScaling.cluster[index].replicas` specifies the desired replicas after scaling for clickhouse cluster.
+- `spec.horizontalScaling.replicas` specifies the desired replicas after scaling for clickhouse cluster.
 
 Let's create the `ClickHouseOpsRequest` CR we have shown above,
 
@@ -343,7 +343,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing horizontal scaling down operation on `clickhouse-prod` cluster.
 - `spec.type` specifies that we are performing `HorizontalScaling` on clickhouse.
-- `spec.horizontalScaling.cluster[index].replicas` specifies the desired replicas after scaling for the clickhouse nodes.
+- `spec.horizontalScaling.replicas` specifies the desired replicas after scaling for the clickhouse nodes.
 
 Let's create the `ClickHouseOpsRequest` CR we have shown above,
 

--- a/docs/guides/clickhouse/scaling/vertical-scaling/cluster.md
+++ b/docs/guides/clickhouse/scaling/vertical-scaling/cluster.md
@@ -167,7 +167,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `clickhouse-prod` cluster.
 - `spec.type` specifies that we are performing `VerticalScaling` on clickhouse.
-- `spec.VerticalScaling.cluster[index].node` specifies the desired resources after scaling.
+- `spec.verticalScaling.node` specifies the desired resources after scaling.
 
 Let's create the `ClickHouseOpsRequest` CR we have shown above,
 

--- a/docs/guides/clickhouse/scaling/vertical-scaling/standalone.md
+++ b/docs/guides/clickhouse/scaling/vertical-scaling/standalone.md
@@ -135,7 +135,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `clickhouse-prod` cluster.
 - `spec.type` specifies that we are performing `VerticalScaling` on clickhouse.
-- `spec.verticalScaling.standalone` specifies the desired resources after scaling.
+- `spec.verticalScaling.node` specifies the desired resources after scaling.
 
 Let's create the `ClickHouseOpsRequest` CR we have shown above,
 

--- a/docs/guides/clickhouse/tls/cluster.md
+++ b/docs/guides/clickhouse/tls/cluster.md
@@ -158,7 +158,7 @@ spec:
 ### Deploy ClickHouse Topology Cluster with TLS/SSL
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/clickhouse/tls/clickhouse-prod-tls.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/clickhouse/tls/clickhouse-cluster-tls.yaml
 clickhouse.kubedb.com/clickhouse-prod-tls created
 ```
 

--- a/docs/guides/clickhouse/update-version/update-version.md
+++ b/docs/guides/clickhouse/update-version/update-version.md
@@ -34,7 +34,7 @@ $ kubectl create ns demo
 namespace/demo created
 ```
 
-> **Note:** YAML files used in this tutorial are stored in [docs/examples/clickhouse](/docs/examples/clickhouse) directory of [kubedb/docs](https://github.com/kube/docs) repository.
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/clickhouse](/docs/examples/clickhouse) directory of [kubedb/docs](https://github.com/kubedb/docs) repository.
 
 ## Prepare ClickHouse
 


### PR DESCRIPTION
## What

Fixes found by running every ClickHouse guide under `docs/guides/clickhouse/` on a live KubeDB v2026.6.19 cluster (docs HEAD v2026.6.19-31) and comparing actual behavior to the docs. Each fix was confirmed against the source of truth (the KubeDB API types / example manifests) or observed cluster behavior.

## Fixes

1. **restart/restart.md**: the inline `ClickHouseOpsRequest` YAML named the ops `restart` with `timeout: 3m`, `apply: Always`, but the example file and every follow-on command use `clickhouse-restart` / `10m` / `IfReady`. Synced the inline YAML to match. Verified: ops `clickhouse-restart` reaches `Successful`.

2. **rotate-auth**: example ops files `chops-rotate-auth-generated.yaml` and `chops-rotate-auth-user.yaml` set `databaseRef.name: clickhouse-prod`, but the deployed CR is `clickhouse`. Applying them was rejected by the webhook (`spec.databaseRef demo/clickhouse-prod, is invalid or not found`). Changed to `clickhouse`, and fixed the cleanup command to delete `clickhouse` (not `clickhouse-prod`). Verified: both rotate paths succeed and connect with the new credentials.

3. **reconfigure/reconfigure.md**: follow-on `kubectl get/describe chops` commands used the misspelled name `chops-cluster-reconfiugre-with-config` (the example file and cleanup use the correct spelling). Fixed all occurrences. Verified: reconfigure with secret (150000) and with applyConfig (180000) both succeed.

4. **reconfigure-tls/clickhouse.md**: the cleanup command `kubectl delete chops-add-tls chops-remove-tls chops-rotate chops-update-issuer` was missing the resource type and namespace (fails with `the server doesn't have a resource type "chops-add-tls"`). Fixed to `kubectl delete chops -n demo ...`. Verified: add-TLS and remove-TLS ops succeed.

5. **tls/cluster.md**: the create command referenced `tls/clickhouse-prod-tls.yaml`, which does not exist. The actual file is `tls/clickhouse-cluster-tls.yaml`. Fixed. Verified: cluster provisions with TLS and port 9440 serves the cert.

6. **update-version/update-version.md**: broken link `https://github.com/kube/docs` corrected to `https://github.com/kubedb/docs`. Verified: version update 25.12.3 to 26.2.6 succeeds.

7. **scaling/horizontal-scaling/cluster.md**: prose referenced `spec.horizontalScaling.cluster[index].replicas`; the API field is `spec.horizontalScaling.replicas`. Fixed both occurrences. Verified: scale up (2 to 4) and down (4 to 3) succeed.

8. **scaling/vertical-scaling/cluster.md** and **standalone.md**: prose referenced `spec.VerticalScaling.cluster[index].node` and `spec.verticalScaling.standalone`; the API field is `spec.verticalScaling.node`. Fixed. Verified: both vertical scaling ops succeed.

9. **monitoring/using-prometheus-operator.md**: create command referenced `monitoring/cas-with-monirtoring.yaml` (a nonexistent Cassandra copy-paste name). Corrected to `monitoring/coreos-prom-clickhouse.yaml`.

10. **autoscaler/storage/storage-autoscale.md**: create URL had an extra path segment (`docs/guides/examples/...` instead of `docs/examples/...`), and the prose said version `3.13.2` while the manifest and catalog use `26.2.6`. Both fixed.

## Verification

Fixes 1-8 were re-executed end to end on the cluster. Fixes 9-10 are broken-file-reference / version corrections confirmed against `docs/examples/clickhouse/` and the ClickHouse catalog; the autoscaler and Prometheus-operator flows could not be run fully because the cluster lacks metrics-server, VPA, a Prometheus operator, and a volume-expansion storage class.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several ClickHouse guides and examples to use the correct resource names, manifest links, and cleanup commands.
  * Clarified scaling instructions for both horizontal and vertical scaling.
  * Corrected TLS, restart, monitoring, rotate-auth, reconfigure, and version-update walkthroughs for consistency.
  * Refreshed tutorial version references and example URLs so the docs match the latest recommended workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->