### PR TITLE
docs(druid): fix incorrect commands, secret keys, and broken example links found by executing the guides

### DIFF
--- a/docs/examples/druid/quickstart/druid-quickstart.yaml
+++ b/docs/examples/druid/quickstart/druid-quickstart.yaml
@@ -7,8 +7,8 @@ spec:
   version: 36.0.0
   deepStorage:
     type: s3
-  configuration:
-    secretName: deep-storage-config
+    configSecret:
+      name: deep-storage-config
   topology:
     routers:
       replicas: 1

--- a/docs/guides/druid/backup/application-level/index.md
+++ b/docs/guides/druid/backup/application-level/index.md
@@ -151,7 +151,7 @@ The database is `Ready`. Verify that KubeDB has created a `Secret` and a `Servic
 ```bash
 $ kubectl get secret -n demo -l=app.kubernetes.io/instance=sample-druid
 NAME                      TYPE                       DATA   AGE
-sample-druid-admin-cred   kubernetes.io/basic-auth   2      2m34s
+sample-druid-auth   kubernetes.io/basic-auth   2      2m34s
 sample-druid-config       Opaque                     11     2m34s
 
 $ kubectl get service -n demo -l=app.kubernetes.io/instance=sample-druid
@@ -162,7 +162,7 @@ sample-druid-pods           ClusterIP   None             <none>        8081/TCP,
 sample-druid-routers        ClusterIP   10.128.191.186   <none>        8888/TCP                                                2m53s
 ```
 
-Here, we have to use service `sample-druid-routers` and secret `sample-druid-admin-cred` to connect with the database. `KubeDB` creates an [AppBinding](/docs/guides/druid/concepts/appbinding.md) CR that holds the necessary information to connect with the database.
+Here, we have to use service `sample-druid-routers` and secret `sample-druid-auth` to connect with the database. `KubeDB` creates an [AppBinding](/docs/guides/druid/concepts/appbinding.md) CR that holds the necessary information to connect with the database.
 
 **Verify Internal Dependencies:**
 
@@ -234,7 +234,7 @@ spec:
       scheme: http
     url: http://sample-druid-coordinators-0.sample-druid-pods.demo.svc.cluster.local:8081,http://sample-druid-overlords-0.sample-druid-pods.demo.svc.cluster.local:8090,http://sample-druid-middlemanagers-0.sample-druid-pods.demo.svc.cluster.local:8091,http://sample-druid-historicals-0.sample-druid-pods.demo.svc.cluster.local:8083,http://sample-druid-brokers-0.sample-druid-pods.demo.svc.cluster.local:8082,http://sample-druid-routers-0.sample-druid-pods.demo.svc.cluster.local:8888
   secret:
-    name: sample-druid-admin-cred
+    name: sample-druid-auth
   type: kubedb.com/druid
   version: 36.0.0
 ```
@@ -261,14 +261,14 @@ Now hit the `http://localhost:8888` from any browser, and you will be prompted t
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo sample-druid-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo sample-druid-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo sample-druid-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo sample-druid-auth -o jsonpath='{.data.password}' | base64 -d
   DqG5E63NtklAkxqC
   ```
 
@@ -760,14 +760,14 @@ Then hit the `http://localhost:8888` from any browser, and you will be prompted 
 - Username:
 
   ```bash
-  $ kubectl get secret -n dev restored-druid-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n dev restored-druid-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n dev restored-druid-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n dev restored-druid-auth -o jsonpath='{.data.password}' | base64 -d
   DqG5E63NtklAkxqC
   ```
 After providing the credentials correctly, you should be able to access the web console like shown below. Now if you go to the `Datasources` section, you will see that our ingested datasource `wikipedia` exists in the list.

--- a/docs/guides/druid/backup/cross-ns-dependencies/index.md
+++ b/docs/guides/druid/backup/cross-ns-dependencies/index.md
@@ -166,7 +166,7 @@ The database is `Ready`. Verify that KubeDB has created a `Secret` and a `Servic
 ```bash
 $ kubectl get secret -n demo -l=app.kubernetes.io/instance=sample-druid
 NAME                      TYPE                       DATA   AGE
-sample-druid-admin-cred   kubernetes.io/basic-auth   2      2m34s
+sample-druid-auth   kubernetes.io/basic-auth   2      2m34s
 sample-druid-config       Opaque                     11     2m34s
 
 $ kubectl get service -n demo -l=app.kubernetes.io/instance=sample-druid
@@ -177,7 +177,7 @@ sample-druid-pods           ClusterIP   None             <none>        8081/TCP,
 sample-druid-routers        ClusterIP   10.128.191.186   <none>        8888/TCP                                                2m53s
 ```
 
-Here, we have to use service `sample-druid-routers` and secret `sample-druid-admin-cred` to connect with the database. `KubeDB` creates an [AppBinding](/docs/guides/druid/concepts/appbinding.md) CR that holds the necessary information to connect with the database.
+Here, we have to use service `sample-druid-routers` and secret `sample-druid-auth` to connect with the database. `KubeDB` creates an [AppBinding](/docs/guides/druid/concepts/appbinding.md) CR that holds the necessary information to connect with the database.
 
 **Verify Internal Dependencies:**
 
@@ -256,7 +256,7 @@ spec:
       scheme: http
     url: http://sample-druid-coordinators-0.sample-druid-pods.demo.svc.cluster.local:8081,http://sample-druid-overlords-0.sample-druid-pods.demo.svc.cluster.local:8090,http://sample-druid-middlemanagers-0.sample-druid-pods.demo.svc.cluster.local:8091,http://sample-druid-historicals-0.sample-druid-pods.demo.svc.cluster.local:8083,http://sample-druid-brokers-0.sample-druid-pods.demo.svc.cluster.local:8082,http://sample-druid-routers-0.sample-druid-pods.demo.svc.cluster.local:8888
   secret:
-    name: sample-druid-admin-cred
+    name: sample-druid-auth
   type: kubedb.com/druid
   version: 36.0.0
 ```
@@ -283,14 +283,14 @@ Now hit the `http://localhost:8888` from any browser, and you will be prompted t
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo sample-druid-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo sample-druid-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo sample-druid-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo sample-druid-auth -o jsonpath='{.data.password}' | base64 -d
   DqG5E63NtklAkxqC
   ```
 
@@ -860,14 +860,14 @@ Then hit the `http://localhost:8888` from any browser, and you will be prompted 
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo restored-druid-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo restored-druid-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo restored-druid-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo restored-druid-auth -o jsonpath='{.data.password}' | base64 -d
   DqG5E63NtklAkxqC
   ```
 After providing the credentials correctly, you should be able to access the web console like shown below. Now if you go to the `Datasources` section, you will see that our ingested datasource `wikipedia` exists in the list.

--- a/docs/guides/druid/backup/logical/index.md
+++ b/docs/guides/druid/backup/logical/index.md
@@ -148,7 +148,7 @@ The database is `Ready`. Verify that KubeDB has created the necessary `Secrets` 
 ```bash
 $ kubectl get secret -n demo -l=app.kubernetes.io/instance=sample-druid 
 NAME                      TYPE                       DATA   AGE
-sample-druid-admin-cred   kubernetes.io/basic-auth   2      48s
+sample-druid-auth   kubernetes.io/basic-auth   2      48s
 
 $ kubectl get service -n demo -l=app.kubernetes.io/instance=sample-druid
 NAME                        TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                                 AGE
@@ -158,7 +158,7 @@ sample-druid-pods           ClusterIP   None             <none>        8081/TCP,
 sample-druid-routers        ClusterIP   10.128.95.51     <none>        8888/TCP                                                72s
 ```
 
-Here, we have to use service `sample-druid-routers` and secret `sample-druid-admin-cred` to connect with the database. `KubeDB` creates an [AppBinding](/docs/guides/druid/concepts/appbinding.md) CR that holds the necessary information to connect with the database.
+Here, we have to use service `sample-druid-routers` and secret `sample-druid-auth` to connect with the database. `KubeDB` creates an [AppBinding](/docs/guides/druid/concepts/appbinding.md) CR that holds the necessary information to connect with the database.
 
 **Verify AppBinding:**
 
@@ -216,7 +216,7 @@ spec:
       scheme: http
     url: http://sample-druid-coordinators-0.sample-druid-pods.demo.svc.cluster.local:8081,http://sample-druid-overlords-0.sample-druid-pods.demo.svc.cluster.local:8090,http://sample-druid-middlemanagers-0.sample-druid-pods.demo.svc.cluster.local:8091,http://sample-druid-historicals-0.sample-druid-pods.demo.svc.cluster.local:8083,http://sample-druid-brokers-0.sample-druid-pods.demo.svc.cluster.local:8082,http://sample-druid-routers-0.sample-druid-pods.demo.svc.cluster.local:8888
   secret:
-    name: sample-druid-admin-cred
+    name: sample-druid-auth
   type: kubedb.com/druid
   version: 36.0.0
 ```
@@ -243,14 +243,14 @@ Now hit the `http://localhost:8888` from any browser, and you will be prompted t
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo sample-druid-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo sample-druid-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo sample-druid-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo sample-druid-auth -o jsonpath='{.data.password}' | base64 -d
   DqG5E63NtklAkxqC
   ```
 
@@ -718,14 +718,14 @@ Then hit the `http://localhost:8888` from any browser, and you will be prompted 
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo sample-druid-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo sample-druid-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo sample-druid-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo sample-druid-auth -o jsonpath='{.data.password}' | base64 -d
   DqG5E63NtklAkxqC
   ```
 After providing the credentials correctly, you should be able to access the web console like shown below. Now if you go to the `Datasources` section, you will see that our ingested datasource `wikipedia` exists in the list. 

--- a/docs/guides/druid/backup/logical/index.md
+++ b/docs/guides/druid/backup/logical/index.md
@@ -708,7 +708,7 @@ restored-druid-pods           ClusterIP   None             <none>        8081/TC
 restored-druid-routers        ClusterIP   10.128.228.193   <none>        8888/TCP                                                10m
 ```
 ```bash
-kubectl port-forward -n demo svc/sample-druid-routers 8888
+kubectl port-forward -n demo svc/restored-druid-routers 8888
 Forwarding from 127.0.0.1:8888 -> 8888
 Forwarding from [::1]:8888 -> 8888
 ```
@@ -718,14 +718,14 @@ Then hit the `http://localhost:8888` from any browser, and you will be prompted 
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo sample-druid-auth -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo restored-druid-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo sample-druid-auth -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo restored-druid-auth -o jsonpath='{.data.password}' | base64 -d
   DqG5E63NtklAkxqC
   ```
 After providing the credentials correctly, you should be able to access the web console like shown below. Now if you go to the `Datasources` section, you will see that our ingested datasource `wikipedia` exists in the list. 

--- a/docs/guides/druid/clustering/guide/index.md
+++ b/docs/guides/druid/clustering/guide/index.md
@@ -107,7 +107,7 @@ spec:
 ```
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/clustering/guide/yamls/druid-with-monitoring.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/clustering/guide/yamls/druid-cluster.yaml
 druid.kubedb.com/druid-cluster created
 ```
 
@@ -180,7 +180,7 @@ Metadata:
   UID:               a2e12db2-6694-419f-ad07-2c906df5b611
 Spec:
   Auth Secret:
-    Name:  druid-cluster-admin-cred
+    Name:  druid-cluster-auth
   Deep Storage:
     Config Secret:
       Name:         deep-storage-config
@@ -552,7 +552,7 @@ Metadata:
   UID:               a2e12db2-6694-419f-ad07-2c906df5b611
 Spec:
   Auth Secret:
-    Name:  druid-cluster-admin-cred
+    Name:  druid-cluster-auth
   Deep Storage:
     Config Secret:
       Name:         deep-storage-config
@@ -884,14 +884,14 @@ Now hit the `http://localhost:8888` from any browser, and you will be prompted t
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo druid-cluster-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo druid-cluster-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo druid-cluster-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo druid-cluster-auth -o jsonpath='{.data.password}' | base64 -d
   LzJtVRX5E8MorFaf
   ```
 

--- a/docs/guides/druid/concepts/appbinding.md
+++ b/docs/guides/druid/concepts/appbinding.md
@@ -67,7 +67,7 @@ spec:
       scheme: http
     url: http://druid-quickstart-coordinators-0.druid-quickstart-pods.demo.svc.cluster.local:8081,http://druid-quickstart-overlords-0.druid-quickstart-pods.demo.svc.cluster.local:8090,http://druid-quickstart-middlemanagers-0.druid-quickstart-pods.demo.svc.cluster.local:8091,http://druid-quickstart-historicals-0.druid-quickstart-pods.demo.svc.cluster.local:8083,http://druid-quickstart-brokers-0.druid-quickstart-pods.demo.svc.cluster.local:8082,http://druid-quickstart-routers-0.druid-quickstart-pods.demo.svc.cluster.local:8888
   secret:
-    name: druid-quickstart-admin-cred
+    name: druid-quickstart-auth
   tlsSecret:
     name: druid-client-cert
   type: kubedb.com/druid

--- a/docs/guides/druid/configuration/config-file/index.md
+++ b/docs/guides/druid/configuration/config-file/index.md
@@ -169,7 +169,7 @@ spec:
 Now, create the Druid object by the following command:
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/configuration/config-file/yamls/druid-with-monitoring.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/configuration/config-file/yamls/druid-with-config.yaml
 druid.kubedb.com/druid-with-config created
 ```
 
@@ -241,14 +241,14 @@ Now hit the `http://localhost:8888` from any browser, and you will be prompted t
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo druid-with-config-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo druid-with-config-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo druid-with-config-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo druid-with-config-auth -o jsonpath='{.data.password}' | base64 -d
   LzJtVRX5E8MorFaf
   ```
 

--- a/docs/guides/druid/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/druid/monitoring/using-builtin-prometheus.md
@@ -77,7 +77,7 @@ Here,
 Let's create the Druid crd we have shown above.
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/monitoring/yamls/druid-builtin-monitoring.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/monitoring/yamls/druid-monitoring-builtin.yaml
 druid.kubedb.com/druid-with-monitoring created
 ```
 

--- a/docs/guides/druid/monitoring/using-prometheus-operator.md
+++ b/docs/guides/druid/monitoring/using-prometheus-operator.md
@@ -187,7 +187,7 @@ Here,
 Let's create the druid object that we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/druid/monitoring/yamls/druid-with-monirtoring.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/monitoring/yamls/druid-with-monitoring.yaml
 druids.kubedb.com/druid-with-monitoring created
 ```
 

--- a/docs/guides/druid/quickstart/guide/index.md
+++ b/docs/guides/druid/quickstart/guide/index.md
@@ -279,7 +279,7 @@ Metadata:
   UID:               5a52ae03-1e4a-4262-9d04-384025c372db
 Spec:
   Auth Secret:
-    Name:  druid-quickstart-admin-cred
+    Name:  druid-quickstart-auth
   Deep Storage:
     Config Secret:
       Name:          deep-storage-config
@@ -610,7 +610,7 @@ NAME                                                  TYPE               VERSION
 appbinding.appcatalog.appscode.com/druid-quickstart   kubedb.com/druid   36.0.0    2m1s
 
 NAME                                 TYPE                       DATA   AGE
-secret/druid-quickstart-admin-cred   kubernetes.io/basic-auth   2      2m13s
+secret/druid-quickstart-auth   kubernetes.io/basic-auth   2      2m13s
 
 NAME                                                           AGE
 petset.apps.k8s.appscode.com/druid-quickstart-brokers          2m4s
@@ -663,14 +663,14 @@ Now hit the `http://localhost:8888` from any browser, and you will be prompted t
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo druid-quickstart-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo druid-quickstart-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo druid-quickstart-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo druid-quickstart-auth -o jsonpath='{.data.password}' | base64 -d
   LzJtVRX5E8MorFaf
   ```
 

--- a/docs/guides/druid/quickstart/guide/index.md
+++ b/docs/guides/druid/quickstart/guide/index.md
@@ -629,7 +629,7 @@ petset.apps.k8s.appscode.com/druid-quickstart-routers          2m1s
     - `{Druid-Name}-{routers}` - Like the previous one, this primary service is only created if `spec.topology.routers` is provided. It is used to connect the routers with external clients.
 - `AppBinding` - an [AppBinding](/docs/guides/kafka/concepts/appbinding.md) which hold to connect information for the Druid. Like other resources, it is named after the Druid instance.
 - `Secrets` - A secret is generated for each Druid cluster.
-    - `{Druid-Name}-{username}-cred` - the auth secrets which hold the `username` and `password` for the Druid users. Operator generates credentials for `admin` user and creates a secret for authentication.
+    - `{Druid-Name}-auth` - the auth secret which holds the `username` and `password` for the Druid users. Operator generates credentials for `admin` user and creates a secret for authentication.
 
 ## Connect with Druid Database
 We will use [port forwarding](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/) to connect with our routers of the Druid database. Then we will use `curl` to send `HTTP` requests to check cluster health to verify that our Druid database is working well. It is also possible to use `External-IP` to access druid nodes if you make `service` type of that node as `LoadBalancer`.

--- a/docs/guides/druid/reconfigure-tls/guide.md
+++ b/docs/guides/druid/reconfigure-tls/guide.md
@@ -157,14 +157,14 @@ Now hit the `http://localhost:8888` from any browser, and you will be prompted t
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo druid-cluster-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo druid-cluster-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo druid-cluster-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo druid-cluster-auth -o jsonpath='{.data.password}' | base64 -d
   LzJtVRX5E8MorFaf
   ```
 
@@ -217,7 +217,7 @@ spec:
 Let's apply the `YAML` file:
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/reconfigure-tls/yamls/druid-issuer.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/reconfigure-tls/yamls/druid-ca-issuer.yaml
 issuer.cert-manager.io/druid-ca-issuer created
 ```
 
@@ -606,14 +606,14 @@ After that you will be prompted to provide the credential of the druid database.
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo druid-cluster-tls-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo druid-cluster-tls-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo druid-cluster-tls-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo druid-cluster-tls-auth -o jsonpath='{.data.password}' | base64 -d
   LzJtVRX5E8MorFaf
   ```
 

--- a/docs/guides/druid/reconfigure/guide.md
+++ b/docs/guides/druid/reconfigure/guide.md
@@ -141,7 +141,7 @@ Then, we will create a new secret with this configuration file.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: config-secret
+  name: new-config
   namespace: demo
 stringData:
   middleManagers.properties: |-
@@ -151,7 +151,7 @@ stringData:
 ```
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/update-version/yamls/config-secret.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/reconfigure/yamls/config-secret.yaml
 secret/new-config created
 ```
 

--- a/docs/guides/druid/rotate-auth/guide.md
+++ b/docs/guides/druid/rotate-auth/guide.md
@@ -158,7 +158,7 @@ Here,
 
 Let's create the `DruidOpsRequest` CR we have shown above,
 ```shell
- $ kubectl apply -f kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/rotate-auth/yamls/Druid-rotate-auth-generated.yaml
+ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/rotate-auth/yamls/Druid-rotate-auth-generated.yaml
  Druidopsrequest.ops.kubedb.com/druidops-rotate-auth-generated created
 ```
 Let's wait for `DruidOpsrequest` to be `Successful`. Run the following command to watch `DruidOpsrequest` CRO
@@ -374,7 +374,7 @@ spec:
   authentication:
     secretRef:
       kind: Secret
-      name: sample-druid-auth-user
+      name: druid-quickstart-auth-user
   timeout: 5m
   apply: IfReady
 ```
@@ -417,7 +417,7 @@ Spec:
   Apply:  IfReady
   Authentication:
     Secret Ref:
-      Name:  sample-druid-auth-user
+      Name:  druid-quickstart-auth-user
   Database Ref:
     Name:   druid-quickstart
   Timeout:  5m

--- a/docs/guides/druid/rotate-auth/yamls/Druid-rotate-auth-user.yaml
+++ b/docs/guides/druid/rotate-auth/yamls/Druid-rotate-auth-user.yaml
@@ -10,6 +10,6 @@ spec:
   authentication:
     secretRef:
       kind: Secret
-      name: sample-druid-auth-user
+      name: druid-quickstart-auth-user
   timeout: 5m
   apply: IfReady

--- a/docs/guides/druid/scaling/horizontal-scaling/guide.md
+++ b/docs/guides/druid/scaling/horizontal-scaling/guide.md
@@ -120,7 +120,7 @@ spec:
 Let's create the `Druid` CR we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/druid/scaling/horizontal-scaling/yamls/druid-topology.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/scaling/horizontal-scaling/yamls/druid-cluster.yaml
 druid.kubedb.com/druid-cluster created
 ```
 
@@ -180,14 +180,14 @@ Now hit the `http://localhost:8888` from any browser, and you will be prompted t
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo druid-cluster-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo druid-cluster-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo druid-cluster-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo druid-cluster-auth -o jsonpath='{.data.password}' | base64 -d
   LzJtVRX5E8MorFaf
   ```
 
@@ -452,7 +452,7 @@ Here,
 Let's create the `DruidOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/druid/scaling/horizontal-scaling/druid-hscale-down-topology.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/scaling/horizontal-scaling/yamls/druid-hscale-down.yaml
 druidopsrequest.ops.kubedb.com/druid-hscale-down created
 ```
 

--- a/docs/guides/druid/scaling/vertical-scaling/guide.md
+++ b/docs/guides/druid/scaling/vertical-scaling/guide.md
@@ -119,7 +119,7 @@ spec:
 Let's create the `Druid` CR we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/druid/scaling/vertical-scaling/yamls/druid-cluster.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/scaling/vertical-scaling/yamls/druid-cluster.yaml
 druid.kubedb.com/druid-cluster created
 ```
 

--- a/docs/guides/druid/tls/guide.md
+++ b/docs/guides/druid/tls/guide.md
@@ -267,14 +267,14 @@ After that you will be prompted to provide the credential of the druid database.
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo druid-cluster-tls-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo druid-cluster-tls-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo druid-cluster-tls-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo druid-cluster-tls-auth -o jsonpath='{.data.password}' | base64 -d
   LzJtVRX5E8MorFaf
   ```
 

--- a/docs/guides/druid/update-version/guide.md
+++ b/docs/guides/druid/update-version/guide.md
@@ -150,14 +150,14 @@ Now hit the `http://localhost:8888` from any browser, and you will be prompted t
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo druid-cluster-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo druid-cluster-auth -o jsonpath='{.data.username}' | base64 -d
   admin
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo druid-cluster-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo druid-cluster-auth -o jsonpath='{.data.password}' | base64 -d
   LzJtVRX5E8MorFaf
   ```
 
@@ -203,7 +203,7 @@ Here,
 Let's create the `DruidOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/update-version/yamls/druid-hscale-up.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/update-version/yamls/update-version-ops.yaml
 druidopsrequest.ops.kubedb.com/druid-update-version created
 ```
 

--- a/docs/guides/druid/volume-expansion/guide.md
+++ b/docs/guides/druid/volume-expansion/guide.md
@@ -150,7 +150,7 @@ spec:
 Let's create the `Druid` CR we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/volume-expansion/yamls/druid-topology.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/volume-expansion/yamls/druid-cluster.yaml
 druid.kubedb.com/druid-cluster created
 ```
 
@@ -224,7 +224,7 @@ During `Online` VolumeExpansion KubeDB expands volume without pausing database o
 Let's create the `DruidOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/volume-expansion/yamls/druid-volume-expansion-topology.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/druid/volume-expansion/yamls/volume-expansion-ops.yaml
 druidopsrequest.ops.kubedb.com/dr-volume-exp created
 ```
 


### PR DESCRIPTION
Fixes found by executing the Druid guides against a KubeDB v2026.6.19 cluster (DruidVersion 36.0.0). Each fix was confirmed against the source of truth (apimachinery druid types/helpers) or observed cluster behavior.

## Quickstart example deep-storage field
- `docs/examples/druid/quickstart/druid-quickstart.yaml` used `spec.configuration.secretName`, which is not a Druid field. Applying it drops the deep-storage secret link (`kubectl apply --dry-run=server ... -o jsonpath='{.spec.deepStorage}'` -> `{"type":"s3"}`, no configSecret), so the quickstart download would deploy a Druid that never provisions.
- Now uses `spec.deepStorage.configSecret.name` (matches the inline YAML in the guide and `DeepStorageSpec.ConfigSecret` in apimachinery/apis/kubedb/v1alpha2/druid_types.go). Verified: quickstart deploys Ready and `curl .../status/health` returns `true`.

## Auth secret name: `<db>-admin-cred` -> `<db>-auth`
- The generated auth secret is `<druid-name>-auth` (apimachinery druid_helpers.go `GetAuthSecretName`). Live cluster: `druid-quickstart-admin-cred` -> NotFound, `druid-quickstart-auth` -> returns admin/password; the AppBinding also references `<name>-auth`.
- Corrected the `-admin-cred` reads/outputs across quickstart, update-version, scaling/horizontal-scaling, clustering, configuration/config-file, reconfigure-tls, tls, concepts/appbinding, and the three backup guides (application-level, logical, cross-ns-dependencies). Covers `druid-quickstart-`, `druid-cluster-`, `druid-cluster-tls-`, `druid-with-config-`, `sample-druid-`, `restored-druid-`.

## Broken example-download links (kubectl create/apply -f https://...)
Each referenced a non-existent file; corrected targets validated with `kubectl apply --dry-run=server` (created object name matches the guide's claimed output):
- clustering/guide: `druid-with-monitoring.yaml` -> `clustering/guide/yamls/druid-cluster.yaml`
- configuration/config-file: `druid-with-monitoring.yaml` -> `config-file/yamls/druid-with-config.yaml`
- monitoring/using-builtin-prometheus: `druid-builtin-monitoring.yaml` -> `monitoring/yamls/druid-monitoring-builtin.yaml`
- monitoring/using-prometheus-operator: `docs/examples/druid/monitoring/yamls/druid-with-monirtoring.yaml` (also a typo) -> `docs/guides/druid/monitoring/yamls/druid-with-monitoring.yaml`
- reconfigure-tls/guide: `druid-issuer.yaml` -> `reconfigure-tls/yamls/druid-ca-issuer.yaml`
- reconfigure/guide: `update-version/yamls/config-secret.yaml` (404) -> `reconfigure/yamls/config-secret.yaml`
- update-version/guide: `druid-hscale-up.yaml` (wrong file) -> `update-version/yamls/update-version-ops.yaml`
- volume-expansion/guide: `druid-topology.yaml` -> `volume-expansion/yamls/druid-cluster.yaml`; `druid-volume-expansion-topology.yaml` -> `volume-expansion/yamls/volume-expansion-ops.yaml`
- scaling/horizontal-scaling/guide: `docs/examples/druid/.../druid-topology.yaml` -> `.../scaling/horizontal-scaling/yamls/druid-cluster.yaml`; `docs/examples/druid/.../druid-hscale-down-topology.yaml` -> `.../yamls/druid-hscale-down.yaml`
- scaling/vertical-scaling/guide: `docs/examples/druid/.../yamls/druid-cluster.yaml` -> `docs/guides/druid/scaling/vertical-scaling/yamls/druid-cluster.yaml`

## rotate-auth guide
Ran the RotateAuth (operator-generated) ops against a live Druid: DruidOpsRequest Successful, and the auth secret gained `username.prev`/`password.prev` as documented.
- Removed a duplicated command fragment: `kubectl apply -f kubectl apply -f https://...` -> single `kubectl apply -f https://...`.
- Fixed the user-secret name mismatch: the guide creates secret `druid-quickstart-auth-user`, but the RotateAuth `authentication.secretRef.name` (inline YAML and `yamls/Druid-rotate-auth-user.yaml`) referenced `sample-druid-auth-user`, which does not exist. Now references `druid-quickstart-auth-user`.

## reconfigure guide
The inline config Secret was named `config-secret`, but the guide output, the download file, and the Reconfigure ops all use `new-config`. A copy-paste user would create the wrong secret. Fixed the inline name to `new-config`.

## Note (not fixed)
`reconfigure/guide.md` references `docs/examples/druid/reconfigure/druid-reconfigure-apply-topology.yaml` for the second (applyConfig) Reconfigure ops, but no such example file exists in the repo. The inline YAML for that ops is present in the guide, so it was left for a maintainer to add the example file or repoint the link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Druid quickstarts and guides to use the correct authentication Secret names across UI access, backup/restore, credential rotation, scaling, TLS verification, monitoring, and version upgrades.
  * Refreshed example commands, kubectl snippets, and displayed output values to match the updated Secret references.
  * Corrected and aligned Druid manifest examples and tutorial URLs so commands point to the right files.
  * Adjusted a quickstart manifest to use the updated deep storage secret configuration format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->