### PR TITLE
docs(ignite): fix incorrect commands and fields found by executing the guides

### DIFF
--- a/docs/examples/ignite/monitoring/builtin-prom-ignite.yaml
+++ b/docs/examples/ignite/monitoring/builtin-prom-ignite.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubedb.com/v1alpha2
 kind: Ignite
 metadata:
-  name: ignite-quickstart
+  name: builtin-prom-ignite
   namespace: demo
 spec:
   replicas: 3

--- a/docs/guides/ignite/custom-configuration/using-config-file.md
+++ b/docs/guides/ignite/custom-configuration/using-config-file.md
@@ -98,7 +98,7 @@ type: Opaque
 Now, create Ignite crd specifying `spec.configuration.secretName` field.
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/configuration/custom-ignite.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/custom-config/custom-ignite.yaml
 ignite.kubedb.com/custom-ignite created
 ```
 
@@ -139,8 +139,8 @@ Now, we will check if the database has started with the custom configuration we 
 We will connect to `custom-ignite-0` pod:
 
 ```bash
-$ kubectl exec -it -n demo ignite-quickstart-0 -c ignite -- bash
-[ignite@ignite-quickstart-0 config]$ cat /ignite/config/node-configuration.xml
+$ kubectl exec -it -n demo custom-ignite-0 -c ignite -- bash
+[ignite@custom-ignite-0 config]$ cat /ignite/config/node-configuration.xml
 
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"

--- a/docs/guides/ignite/custom-configuration/using-podtemplate.md
+++ b/docs/guides/ignite/custom-configuration/using-podtemplate.md
@@ -103,7 +103,7 @@ custom-ignite-0      1/1     Running   0          30s
 Now, check if the ignite has started with the custom configuration we have provided. First, we will exec in the pod. Then, we will check if the environment variable is set or not.
 
 ```bash
-$ kubectl exec -it custom-ignite-0 -n demo ignite -- sh
+$ kubectl exec -it -n demo custom-ignite-0 -c ignite -- sh
 $ echo $Ignite_Key
 KubeDB
 $ echo $Ignite_Value
@@ -437,7 +437,7 @@ spec:
   deletionPolicy: WipeOut
 ```
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/configuration/ignite-without-tolerations.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/custom-config/ignite-without-tolerations.yaml
 ignite.kubedb.com/ignite-without-tolerations created
 ```
 Now, wait a few minutes. KubeDB operator will create necessary petset, services, secret etc. If everything goes well, we will see that a pod with the name `ignite-without-tolerations-0` has been created and running.
@@ -562,7 +562,7 @@ spec:
 ```
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/configuration/with-tolerations.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/custom-config/with-tolerations.yaml
 ignite.kubedb.com/ignite-with-tolerations created
 ```
 Now, wait a few minutes. KubeDB operator will create necessary petset, services, secret etc. If everything goes well, we will see that a pod with the name `ignite-with-tolerations-0` has been created.

--- a/docs/guides/ignite/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/ignite/monitoring/using-builtin-prometheus.md
@@ -269,7 +269,7 @@ data:
 Let's create above `ConfigMap`,
 
 ```bash
-$ kubectl apply -f kubectl apply -f https://github.com/kubedb/docs/raw/v2024.8.21/docs/examples/monitoring/builtin-prometheus/prom-config.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/v2024.8.21/docs/examples/monitoring/builtin-prometheus/prom-config.yaml
 configmap/prometheus-config created
 ```
 

--- a/docs/guides/ignite/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/ignite/reconfigure-tls/reconfigure-tls.md
@@ -72,14 +72,15 @@ Now, wait until `ig` has status `Ready`. i.e,
 $ kubectl get ig -n demo
 NAME    VERSION    STATUS    AGE
 ig      2.17.0     Ready     10m
-
+```
 
 ```bash
-$ kubectl get secrets -n demo ig-admin-cred -o jsonpath='{.data.\username}' | base64 -d
-root
+$ kubectl get secrets -n demo ig-auth -o jsonpath='{.data.username}' | base64 -d
+ignite
 
-$ kubectl get secrets -n demo ig-admin-cred -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo ig-auth -o jsonpath='{.data.password}' | base64 -d
 U6(h_pYrekLZ2OOd
+```
 
 We can verify from the above output that TLS is disabled for this database.
 

--- a/docs/guides/ignite/reconfigure/reconfigure.md
+++ b/docs/guides/ignite/reconfigure/reconfigure.md
@@ -94,10 +94,10 @@ Now, we will check if the database has started with the custom configuration we 
 
 First we need to get the username and password to connect to a Ignite instance,
 ```bash
-$ kubectl get secrets -n demo ig-cluster-admin-cred -o jsonpath='{.data.\username}' | base64 -d
-admin
+$ kubectl get secrets -n demo ig-cluster-auth -o jsonpath='{.data.username}' | base64 -d
+ignite
 
-$ kubectl get secrets -n demo ig-cluster-admin-cred  -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo ig-cluster-auth  -o jsonpath='{.data.password}' | base64 -d
 m6lXjZugrC4VEpB8
 ```
 


### PR DESCRIPTION
Found by executing the Ignite guides on a live KubeDB v2026.6.19 cluster (docs HEAD v2026.6.19-31, IgniteVersion 2.17.0) and confirming each value against the source of truth (kubedb/apimachinery types and observed cluster behavior).

## Fixes

### reconfigure/reconfigure.md (verified live)
- The auth secret was read as `ig-cluster-admin-cred` with jsonpath `{.data.\username}` / `{.data.\password}`. The real secret is `ig-cluster-auth` with keys `username` / `password` (`kubectl get secret ig-cluster-admin-cred` returns NotFound; `kubectl get secret ig-cluster-auth -o jsonpath='{.data.username}' | base64 -d` returns `ignite`). Confirmed against `apimachinery` `Ignite.DefaultAuthSecretName()` (`<name>-auth`). Also corrected the shown username from `admin` to `ignite`.

### custom-configuration/using-config-file.md
- Corrected example path `docs/examples/ignite/configuration/custom-ignite.yaml` to `docs/examples/ignite/custom-config/custom-ignite.yaml` (the referenced file only exists under `custom-config/`).
- Corrected the exec pod name from `ignite-quickstart-0` to `custom-ignite-0` (the pod this guide creates).

### custom-configuration/using-podtemplate.md
- Corrected two example paths `configuration/ignite-without-tolerations.yaml` and `configuration/with-tolerations.yaml` to `custom-config/...` (files exist there).
- Fixed a malformed exec command `kubectl exec -it custom-ignite-0 -n demo ignite -- sh` to `kubectl exec -it -n demo custom-ignite-0 -c ignite -- sh`.

### monitoring/using-builtin-prometheus.md (verified live)
- Removed a duplicated `kubectl apply -f kubectl apply -f` in the ConfigMap create command.

### examples/ignite/monitoring/builtin-prom-ignite.yaml (verified live)
- Set `metadata.name` to `builtin-prom-ignite` (was `ignite-quickstart`). The guide refers to `builtin-prom-ignite` and its `builtin-prom-ignite-stats` service throughout; the stats service name follows the CR name (verified on cluster).

### reconfigure-tls/reconfigure-tls.md
- Same auth-secret bug as reconfigure: `ig-admin-cred` / `{.data.\username}` corrected to `ig-auth` / `{.data.username}`, and closed a malformed code fence in the pre-TLS section.

## Verification
Deployed and ran live: quickstart (sqlline connect + SQL), restart, vertical-scaling, and reconfigure OpsRequests (all Successful), and builtin-prometheus (stats service created). Version references (IgniteVersion 2.17.0) match the catalog on the cluster; no version reference needed changing.
