### PR TITLE
docs(mssqlserver): fix sqlcmd path/flags and secret-name commands found by executing the guides

### DIFF
--- a/docs/guides/mssqlserver/backup/application-level/index.md
+++ b/docs/guides/mssqlserver/backup/application-level/index.md
@@ -260,7 +260,7 @@ kkvAFfl8sIxRO2i3⏎
 Now, Lets exec into the `Pod` to enter into `mssqlserver` shell and create a database and a table,
 
 ```bash
-$ kubectl exec -it -n demo sample-mssqlserver-0 -c mssql -- /opt/mssql-tools/bin/sqlcmd -S sample-mssqlserver -U sa -P "kkvAFfl8sIxRO2i3"
+$ kubectl exec -it -n demo sample-mssqlserver-0 -c mssql -- /opt/mssql-tools18/bin/sqlcmd -S sample-mssqlserver -U sa -P "kkvAFfl8sIxRO2i3" -No
 # list available databases
 1> SELECT name from sys.databases;
 2> GO
@@ -756,7 +756,7 @@ Ag9qi8zQiFew0xHo⏎
 Now, Lets exec into the `Pod` to enter into `mssqlserver` shell and verify restored data,
 
 ```bash
-$ kubectl exec -it -n dev sample-mssqlserver-0 -c mssql -- /opt/mssql-tools/bin/sqlcmd -S sample-mssqlserver -U sa -P "Ag9qi8zQiFew0xHo"
+$ kubectl exec -it -n dev sample-mssqlserver-0 -c mssql -- /opt/mssql-tools18/bin/sqlcmd -S sample-mssqlserver -U sa -P "Ag9qi8zQiFew0xHo" -No
 1> SELECT name from sys.databases;
 2> GO
 name                                                                                                                            

--- a/docs/guides/mssqlserver/backup/logical/index.md
+++ b/docs/guides/mssqlserver/backup/logical/index.md
@@ -257,7 +257,7 @@ kkvAFfl8sIxRO2i3⏎
 Now, Lets exec into the `Pod` to enter into `mssqlserver` shell and create a database and a table,
 
 ```bash
-$ kubectl exec -it -n demo sample-mssqlserver-0 -c mssql -- /opt/mssql-tools/bin/sqlcmd -S sample-mssqlserver -U sa -P "kkvAFfl8sIxRO2i3"
+$ kubectl exec -it -n demo sample-mssqlserver-0 -c mssql -- /opt/mssql-tools18/bin/sqlcmd -S sample-mssqlserver -U sa -P "kkvAFfl8sIxRO2i3" -No
 # list available databases
 1> SELECT name from sys.databases;
 2> GO
@@ -751,7 +751,7 @@ Ag9qi8zQiFew0xHo⏎
 Now, Lets exec into the `Pod` to enter into `mssqlserver` shell and verify restored data,
 
 ```bash
-$ kubectl exec -it -n demo restored-mssqlserver-0 -c mssql -- /opt/mssql-tools/bin/sqlcmd -S restored-mssqlserver -U sa -P "Ag9qi8zQiFew0xHo"
+$ kubectl exec -it -n demo restored-mssqlserver-0 -c mssql -- /opt/mssql-tools18/bin/sqlcmd -S restored-mssqlserver -U sa -P "Ag9qi8zQiFew0xHo" -No
 1> SELECT name from sys.databases;
 2> GO
 name                                                                                                                            

--- a/docs/guides/mssqlserver/clustering/ag_cluster.md
+++ b/docs/guides/mssqlserver/clustering/ag_cluster.md
@@ -422,7 +422,7 @@ mssql@mssqlserver-ag-cluster-0:/$
 
 You can connect to the database using the `sqlcmd` utility, which comes with the mssql-tools package on Linux. To check the installed version of sqlcmd, run the following command:
 ```bash
-mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd "-?"
+mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd "-?"
 Microsoft (R) SQL Server Command Line Tool
 Version 17.10.0001.1 Linux
 Copyright (C) 2017 Microsoft Corporation. All rights reserved.
@@ -459,7 +459,7 @@ usage: sqlcmd            [-U login id]          [-P password]
 Now, connect to the database using username and password, check the name of the created availability group, replicas of the availability group and see if databases are added to the availability group.
 ```bash
 $ kubectl exec -it -n demo mssqlserver-ag-cluster-0 -c mssql -- bash
-mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "wFKDGnWgFP5Rdv92"
+mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "wFKDGnWgFP5Rdv92" -No
 1> select name from sys.databases
 2> go
 name                                                  
@@ -514,7 +514,7 @@ From the output above, we can see that mssqlserver-ag-cluster-0 is the primary n
 
 ```bash
 $ kubectl exec -it mssqlserver-ag-cluster-0 -c mssql -n demo -- bash
-mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "wFKDGnWgFP5Rdv92"
+mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "wFKDGnWgFP5Rdv92" -No
 1> SELECT database_name FROM sys.availability_databases_cluster
 2> go
 database_name                                                                                                                   
@@ -547,7 +547,7 @@ Access the secondary node (Node 2) to verify that the data is present.
 
 ```bash
 $ kubectl exec -it mssqlserver-ag-cluster-1 -c mssql -n demo -- bash
-mssql@mssqlserver-ag-cluster-1:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "wFKDGnWgFP5Rdv92"
+mssql@mssqlserver-ag-cluster-1:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "wFKDGnWgFP5Rdv92" -No
 1> SELECT database_name FROM sys.availability_databases_cluster
 2> go
 database_name                                                                                                                   
@@ -574,7 +574,7 @@ ID    NAME                             AGE
 Now access the secondary node (Node 3) to verify that the data is present.
 ```bash
 $ kubectl exec -it mssqlserver-ag-cluster-2 -c mssql -n demo -- bash
-mssql@mssqlserver-ag-cluster-2:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "wFKDGnWgFP5Rdv92"
+mssql@mssqlserver-ag-cluster-2:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "wFKDGnWgFP5Rdv92" -No
 1> SELECT database_name FROM sys.availability_databases_cluster
 2> go
 database_name                                                                                                                   

--- a/docs/guides/mssqlserver/clustering/standalone.md
+++ b/docs/guides/mssqlserver/clustering/standalone.md
@@ -376,7 +376,7 @@ mssql@mssqlserver-standalone-0:/$
 
 You can connect to the database using the `sqlcmd` utility, which comes with the mssql-tools package on Linux. To check the installed version of sqlcmd, run the following command:
 ```bash
-mssql@mssqlserver-standalone-0:/$ /opt/mssql-tools/bin/sqlcmd "-?"
+mssql@mssqlserver-standalone-0:/$ /opt/mssql-tools18/bin/sqlcmd "-?"
 Microsoft (R) SQL Server Command Line Tool
 Version 17.10.0001.1 Linux
 Copyright (C) 2017 Microsoft Corporation. All rights reserved.
@@ -412,7 +412,7 @@ usage: sqlcmd            [-U login id]          [-P password]
 
 Now, connect to the database using username and password
 ```bash
-mssql@mssqlserver-standalone-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "axgXHj4oRIVQ1ocK"
+mssql@mssqlserver-standalone-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "axgXHj4oRIVQ1ocK" -No
 1> select name from sys.databases
 2> go
 name                                                  

--- a/docs/guides/mssqlserver/configuration/using-config-file.md
+++ b/docs/guides/mssqlserver/configuration/using-config-file.md
@@ -208,7 +208,7 @@ tlsprotocols = 1.2
 forceencryption = 1
 [memory]
 memorylimitmb = 2304
-mssql@mssql-custom-config-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P AqRe6WIuqwKXLaWc
+mssql@mssql-custom-config-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P AqRe6WIuqwKXLaWc -No
 1> SELECT encrypt_option FROM sys.dm_exec_connections WHERE session_id = @@SPID;
 2> go
 encrypt_option                          

--- a/docs/guides/mssqlserver/configuration/using-podtemplate.md
+++ b/docs/guides/mssqlserver/configuration/using-podtemplate.md
@@ -200,7 +200,7 @@ $ kubectl get secrets -n demo custom-config-podtemplate-auth -o jsonpath='{.data
 3K7lJibYg3y6ICXc
 
 $ kubectl exec -it custom-config-podtemplate-0 -n demo -c mssql -- bash
-mssql@custom-config-podtemplate-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 3K7lJibYg3y6ICXc
+mssql@custom-config-podtemplate-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 3K7lJibYg3y6ICXc -No
 1> SELECT physical_memory_kb / 1024 AS physical_memory_mb FROM sys.dm_os_sys_info;
 2> go
 physical_memory_mb  

--- a/docs/guides/mssqlserver/failover/guide.md
+++ b/docs/guides/mssqlserver/failover/guide.md
@@ -226,7 +226,7 @@ sa⏎
 $ kubectl get secret -n demo mssqlserver-ag-cluster-auth -o jsonpath='{.data.\password}' | base64 -d
 tZQpzrowQQ20xbCf⏎         
 $ kubectl exec -it -n demo mssqlserver-ag-cluster-0 -c mssql -- bash
-mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf"
+mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf" -No
 1> select name from sys.databases
 2> go
 name                                                                                                                            
@@ -271,7 +271,7 @@ Verify the table creation in secondary's.
 
 ```shell
 $ kubectl exec -it -n demo mssqlserver-ag-cluster-1 -c mssql -- bash
-mssql@mssqlserver-ag-cluster-1:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf"
+mssql@mssqlserver-ag-cluster-1:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf" -No
 1> select name from sys.databases
 2> go
 name                                                                                                                            
@@ -346,7 +346,7 @@ Now we know how failover is done, let's check if the new primary `mssqlserver-ag
 
 ```shell
 $ kubectl exec -it -n demo mssqlserver-ag-cluster-2 -c mssql -- bash
-mssql@mssqlserver-ag-cluster-2:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf"
+mssql@mssqlserver-ag-cluster-2:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf" -No
 1> use agdb1
 2> go
 Changed database context to 'agdb1'.
@@ -386,7 +386,7 @@ Let's check if the secondary(`mssqlserver-ag-cluster-0`) got the updated data fr
 
 ```shell
 $ kubectl exec -it -n demo mssqlserver-ag-cluster-0 -c mssql -- bash
-mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf"
+mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf" -No
 1> use agdb1
 2> go
 Changed database context to 'agdb1'.
@@ -430,7 +430,7 @@ Let's validate the cluster state from new primary(`mssqlserver-ag-cluster-0`).
 
 ```shell
 $ kubectl exec -it -n demo mssqlserver-ag-cluster-0 -c mssql -- bash
-mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf"
+mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf" -No
 1> use agdb1
 2> go
 Changed database context to 'agdb1'.
@@ -467,7 +467,7 @@ mssqlserver-ag-cluster-2 secondary
 Let's verify cluster state.
 ```shell
 $ kubectl exec -it -n demo mssqlserver-ag-cluster-0 -c mssql -- bash
-mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf" 
+mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf" -No 
 1> use agdb1
 2> go
 Changed database context to 'agdb1'.
@@ -512,7 +512,7 @@ Let's verify the cluster state now.
 
 ```shell
 $  kubectl exec -it -n demo mssqlserver-ag-cluster-0 -c mssql -- bash
-mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf" 
+mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "tZQpzrowQQ20xbCf" -No 
 1> use agdb1
 2> go
 1> SELECT * FROM sys.dm_hadr_availability_replica_states;

--- a/docs/guides/mssqlserver/pitr/archiver.md
+++ b/docs/guides/mssqlserver/pitr/archiver.md
@@ -353,7 +353,7 @@ sa⏎
 $ kubectl get secret -n demo  sample-mssqlserver-ag-auth -o jsonpath='{.data.password}'| base64 -d
 XhGrsDvJ7ATrPp7n⏎
 
-$ kubectl exec -it -n demo sample-mssqlserver-ag-0 -c mssql -- /opt/mssql-tools/bin/sqlcmd -S sample-mssqlserver-ag -U sa -P "XhGrsDvJ7ATrPp7n"
+$ kubectl exec -it -n demo sample-mssqlserver-ag-0 -c mssql -- /opt/mssql-tools18/bin/sqlcmd -S sample-mssqlserver-ag -U sa -P "XhGrsDvJ7ATrPp7n" -No
 1> SELECT name from sys.databases;
 2> GO
 name                                                                                                                            
@@ -431,7 +431,7 @@ Point-In-Time Recovery allows you to restore a `Microsoft SQL Server` database t
 Let’s say accidentally drops the table `equipment`.
 
 ```bash
-$ kubectl exec -it -n demo sample-mssqlserver-ag-0 -c mssql -- /opt/mssql-tools/bin/sqlcmd -S sample-mssqlserver-ag -U sa -P "XhGrsDvJ7ATrPp7n"
+$ kubectl exec -it -n demo sample-mssqlserver-ag-0 -c mssql -- /opt/mssql-tools18/bin/sqlcmd -S sample-mssqlserver-ag -U sa -P "XhGrsDvJ7ATrPp7n" -No
 1> use demo
 2> DROP table equipment;
 3> GO
@@ -547,7 +547,7 @@ sa⏎
 $ kubectl get secret -n demo  restored-mssqlserver-ag-auth -o jsonpath='{.data.password}'| base64 -d
 Q2YKiGgqr5ju62NL⏎
 
-$ kubectl exec -it -n demo restored-mssqlserver-ag-0 -c mssql -- /opt/mssql-tools/bin/sqlcmd -S restored-mssqlserver-ag -U sa -P "Q2YKiGgqr5ju62NL"
+$ kubectl exec -it -n demo restored-mssqlserver-ag-0 -c mssql -- /opt/mssql-tools18/bin/sqlcmd -S restored-mssqlserver-ag -U sa -P "Q2YKiGgqr5ju62NL" -No
 1> SELECT name from sys.databases;
 2> GO
 name                                                                                                                            

--- a/docs/guides/mssqlserver/quickstart/quickstart.md
+++ b/docs/guides/mssqlserver/quickstart/quickstart.md
@@ -49,13 +49,13 @@ When you have installed KubeDB, it has created `MSSQLServerVersion` CR for all s
 
 ```bash
 $ kubectl get msversion
-NAME        VERSION   DB_IMAGE                                                DEPRECATED   AGE
-2022-cu12   2022      mcr.microsoft.com/mssql/server:2022-CU12-ubuntu-22.04                7d19h
-2022-cu14   2022      mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04                7d19h
-2022-cu16   2022      mcr.microsoft.com/mssql/server:2022-CU16-ubuntu-22.04                7d19h
-2022-cu19   2022      mcr.microsoft.com/mssql/server:2022-CU19-ubuntu-22.04                7d19h
-2022-cu22   2022      mcr.microsoft.com/mssql/server:2022-CU22-ubuntu-22.04                7d19h
-2025-cu0    2025      mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04                 7d19h
+NAME        VERSION     DB_IMAGE                                                DEPRECATED   AGE
+2022-cu12   2022-cu12   mcr.microsoft.com/mssql/server:2022-CU12-ubuntu-22.04                7d19h
+2022-cu14   2022-cu14   mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04                7d19h
+2022-cu16   2022-cu16   mcr.microsoft.com/mssql/server:2022-CU16-ubuntu-22.04                7d19h
+2022-cu19   2022-cu19   mcr.microsoft.com/mssql/server:2022-CU19-ubuntu-22.04                7d19h
+2022-cu22   2022-cu22   mcr.microsoft.com/mssql/server:2022-CU22-ubuntu-22.04                7d19h
+2025-cu0    2025-cu0    mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04                 7d19h
 
 ```
 
@@ -380,7 +380,7 @@ mssql@mssqlserver-quickstart-0:/$
 
 You can connect to the database using the `sqlcmd` utility, which comes with the mssql-tools package on Linux. To check the installed version of sqlcmd, run the following command:
 ```bash
-mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools/bin/sqlcmd "-?"
+mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools18/bin/sqlcmd "-?"
 Microsoft (R) SQL Server Command Line Tool
 Version 17.10.0001.1 Linux
 Copyright (C) 2017 Microsoft Corporation. All rights reserved.
@@ -416,7 +416,7 @@ usage: sqlcmd            [-U login id]          [-P password]
 
 Now, connect to the database using username and password 
 ```bash
-mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "axgXHj4oRIVQ1ocK"
+mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "axgXHj4oRIVQ1ocK" -No
 1> select name from sys.databases
 2> go
 name                                                  

--- a/docs/guides/mssqlserver/reconfigure-tls/ag_cluster.md
+++ b/docs/guides/mssqlserver/reconfigure-tls/ag_cluster.md
@@ -157,12 +157,12 @@ $ kubectl exec -it -n demo mssql-ag-cluster-0 -c mssql -- bash
 mssql@mssql-ag-cluster-0:/$ cat /var/opt/mssql/mssql.conf
 [language]
 lcid = 1033
-mssql@mssql-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "Q9kDWVQMnawLcnZq" -N
+mssql@mssql-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "Q9kDWVQMnawLcnZq" -N
 Sqlcmd: Error: Microsoft ODBC Driver 17 for SQL Server : SSL Provider: [error:0A000086:SSL routines::certificate verify failed:self-signed certificate].
 Sqlcmd: Error: Microsoft ODBC Driver 17 for SQL Server : Client unable to establish connection.
 
 So Now, we have to connect with -C [Trust Server Certificate]
-mssql@mssql-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "Q9kDWVQMnawLcnZq" -N -C
+mssql@mssql-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "Q9kDWVQMnawLcnZq" -N -C
 1> 
 ```
 
@@ -376,7 +376,7 @@ forceencryption = 1
 tlscert = /var/opt/mssql/tls/server.crt
 tlskey = /var/opt/mssql/tls/server.key
 tlsprotocols = 1.2,1.1,1.0
-mssql@mssql-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Q9kDWVQMnawLcnZq -N
+mssql@mssql-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P Q9kDWVQMnawLcnZq -N
 1> 
 ```
 
@@ -965,13 +965,13 @@ $ kubectl exec -it -n demo mssql-ag-cluster-1 -c mssql -- bash
 mssql@mssql-ag-cluster-1:/$ cat /var/opt/mssql/mssql.conf
 [language]
 lcid = 1033
-mssql@mssql-ag-cluster-1:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Q9kDWVQMnawLcnZq -N
+mssql@mssql-ag-cluster-1:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P Q9kDWVQMnawLcnZq -N
 Sqlcmd: Error: Microsoft ODBC Driver 17 for SQL Server : SSL Provider: [error:0A000086:SSL routines::certificate verify failed:self-signed certificate].
 Sqlcmd: Error: Microsoft ODBC Driver 17 for SQL Server : Client unable to establish connection.
 
 
 So Now, we have to connect with -C [Trust Server Certificate]
-mssql@mssql-ag-cluster-1:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Q9kDWVQMnawLcnZq -N -C
+mssql@mssql-ag-cluster-1:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P Q9kDWVQMnawLcnZq -N -C
 1> 
 ```
 

--- a/docs/guides/mssqlserver/reconfigure-tls/standalone.md
+++ b/docs/guides/mssqlserver/reconfigure-tls/standalone.md
@@ -288,13 +288,13 @@ $ kubectl exec -it -n demo ms-standalone-0 -c mssql -- bash
 mssql@ms-standalone-0:/$ cat /var/opt/mssql/mssql.conf
 [language]
 lcid = 1033
-mssql@ms-standalone-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "b1HLv9EV4CaSalX6" -N
+mssql@ms-standalone-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "b1HLv9EV4CaSalX6" -N
 Sqlcmd: Error: Microsoft ODBC Driver 17 for SQL Server : SSL Provider: [error:0A000086:SSL routines::certificate verify failed:self-signed certificate].
 Sqlcmd: Error: Microsoft ODBC Driver 17 for SQL Server : Client unable to establish connection.
 
 
 So Now, we have to connect with -C [Trust Server Certificate]
-mssql@ms-standalone-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "b1HLv9EV4CaSalX6" -N -C
+mssql@ms-standalone-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "b1HLv9EV4CaSalX6" -N -C
 1> 
 ```
 
@@ -482,7 +482,7 @@ forceencryption = 1
 tlscert = /var/opt/mssql/tls/server.crt
 tlskey = /var/opt/mssql/tls/server.key
 tlsprotocols = 1.2,1.1,1.0
-mssql@ms-standalone-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P l2mGQRMETAS96QRb -N
+mssql@ms-standalone-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P l2mGQRMETAS96QRb -N
 1> 
 ```
 
@@ -981,12 +981,12 @@ $ kubectl exec -it -n demo ms-standalone-0 -c mssql -- bash
 mssql@ms-standalone-0:/$ cat /var/opt/mssql/mssql.conf
 [language]
 lcid = 1033
-mssql@ms-standalone-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P b1HLv9EV4CaSalX6 -N
+mssql@ms-standalone-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P b1HLv9EV4CaSalX6 -N
 Sqlcmd: Error: Microsoft ODBC Driver 17 for SQL Server : SSL Provider: [error:0A000086:SSL routines::certificate verify failed:self-signed certificate].
 Sqlcmd: Error: Microsoft ODBC Driver 17 for SQL Server : Client unable to establish connection.
 
 So Now, we have to connect with -C [Trust Server Certificate]
-mssql@ms-standalone-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P b1HLv9EV4CaSalX6 -N -C
+mssql@ms-standalone-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P b1HLv9EV4CaSalX6 -N -C
 1> 
 ```
 

--- a/docs/guides/mssqlserver/reconfigure/ag_cluster.md
+++ b/docs/guides/mssqlserver/reconfigure/ag_cluster.md
@@ -177,7 +177,7 @@ mssql@mssqlserver-ag-cluster-0:/$ cat /var/opt/mssql/mssql.conf
 lcid = 1033
 [memory]
 memorylimitmb = 2048
-mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P gkBGX7RE0ap4yjHt
+mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P gkBGX7RE0ap4yjHt -No
 1> SELECT physical_memory_kb / 1024 AS physical_memory_mb FROM sys.dm_os_sys_info;
 2> go
 physical_memory_mb  
@@ -363,7 +363,7 @@ mssql@mssqlserver-ag-cluster-0:/$ cat /var/opt/mssql/mssql.conf
 lcid = 1033
 [memory]
 memorylimitmb = 2560
-mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P gkBGX7RE0ap4yjHt
+mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P gkBGX7RE0ap4yjHt -No
 1> SELECT physical_memory_kb / 1024 AS physical_memory_mb FROM sys.dm_os_sys_info;
 2> go
 physical_memory_mb  
@@ -544,7 +544,7 @@ mssql@mssqlserver-ag-cluster-0:/$  cat /var/opt/mssql/mssql.conf
 lcid = 1033
 [memory]
 memorylimitmb = 3072
-mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P gkBGX7RE0ap4yjHt
+mssql@mssqlserver-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P gkBGX7RE0ap4yjHt -No
 1> SELECT physical_memory_kb / 1024 AS physical_memory_mb FROM sys.dm_os_sys_info;
 2> go
 physical_memory_mb  

--- a/docs/guides/mssqlserver/reconfigure/standalone.md
+++ b/docs/guides/mssqlserver/reconfigure/standalone.md
@@ -171,7 +171,7 @@ mssql@ms-standalone-0:/$ cat /var/opt/mssql/mssql.conf
 lcid = 1033
 [memory]
 memorylimitmb = 2048
-mssql@ms-standalone-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P SERtEyH1RMMEsvE0
+mssql@ms-standalone-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P SERtEyH1RMMEsvE0 -No
 1> SELECT physical_memory_kb / 1024 AS physical_memory_mb FROM sys.dm_os_sys_info;
 2> go
 physical_memory_mb  
@@ -344,7 +344,7 @@ mssql@ms-standalone-0:/$ cat /var/opt/mssql/mssql.conf
 lcid = 1033
 [memory]
 memorylimitmb = 2560
-mssql@ms-standalone-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P SERtEyH1RMMEsvE0
+mssql@ms-standalone-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P SERtEyH1RMMEsvE0 -No
 1> SELECT physical_memory_kb / 1024 AS physical_memory_mb FROM sys.dm_os_sys_info;
 2> go
 physical_memory_mb  
@@ -511,7 +511,7 @@ mssql@ms-standalone-0:/$ cat /var/opt/mssql/mssql.conf
 lcid = 1033
 [memory]
 memorylimitmb = 3072
-mssql@ms-standalone-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P SERtEyH1RMMEsvE0
+mssql@ms-standalone-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P SERtEyH1RMMEsvE0 -No
 1> SELECT physical_memory_kb / 1024 AS physical_memory_mb FROM sys.dm_os_sys_info;
 2> go
 physical_memory_mb  

--- a/docs/guides/mssqlserver/rotate-auth/rotateauth.md
+++ b/docs/guides/mssqlserver/rotate-auth/rotateauth.md
@@ -143,7 +143,7 @@ $ kubectl get secret -n demo mssqlserver-quickstart-auth -o jsonpath='{.data.pas
 Now, you can exec into the pod `mssqlserver-quickstart-0` and connect to database using `username` and `password`
 ```bash
 $ kubectl exec -it -n demo mssqlserver-quickstart-0 -c mssql -- bash
-mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "9ycCSYznZpZRxs9U"
+mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "9ycCSYznZpZRxs9U" -No
 1> select name from sys.databases
 2> go
 name                                                  
@@ -302,7 +302,7 @@ Let's verify if we can connect to the database using the new credentials.
 
 ```shell
 $ kubectl exec -it -n demo mssqlserver-quickstart-0 -c mssql -- bash
-mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "zTBVvzgoEb2qUe3X"
+mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "zTBVvzgoEb2qUe3X" -No
 1> select name from sys.databases
 2> go
 name                                                                                                                            
@@ -331,7 +331,7 @@ $ kubectl get secret -n demo mssqlserver-quickstart-auth -o go-template='{{ inde
 Let's confirm that the previous credentials no longer work.
 ```shell
 kubectl exec -it -n demo mssqlserver-quickstart-0 -c mssql -- bash
-mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "9ycCSYznZpZRxs9U"
+mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "9ycCSYznZpZRxs9U" -No
 Sqlcmd: Error: Microsoft ODBC Driver 17 for SQL Server : Login failed for user 'sa'..
 mssql@mssqlserver-quickstart-0:/$ 
 
@@ -496,7 +496,7 @@ Mssqlserver2⏎
 Let's verify if we can connect to the database using the new credentials.
 ```shell
 $ kubectl exec -it -n demo mssqlserver-quickstart-0 -c mssql -- bash
-mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "Mssqlserver2"
+mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "Mssqlserver2" -No
 1> SELECT name FROM sys.databases 
 2> go
 name                                                                                                                            
@@ -514,13 +514,13 @@ Also, there will be two more new keys in the secret that stores the previous cre
 ```shell
 $ kubectl get secret -n demo mssqlserver-quickstart-auth -o go-template='{{ index .data "username.prev" }}' | base64 -d
 sa⏎                                                                                         
-$ kubectl get secret -n demo quick-mssqlserver-user-auth -o go-template='{{ index .data "password.prev" }}' | base64 -d
+$ kubectl get secret -n demo mssqlserver-quickstart-auth -o go-template='{{ index .data "password.prev" }}' | base64 -d
 zTBVvzgoEb2qUe3X⏎ 
 ```
 Let's confirm that the previous credentials no longer work.
 ```shell
 kubectl exec -it -n demo mssqlserver-quickstart-0 -c mssql -- bash
-mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "zTBVvzgoEb2qUe3X"
+mssql@mssqlserver-quickstart-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "zTBVvzgoEb2qUe3X" -No
 Sqlcmd: Error: Microsoft ODBC Driver 17 for SQL Server : Login failed for user 'sa'..
 mssql@mssqlserver-quickstart-0:/$ 
 
@@ -535,10 +535,10 @@ Or, you can delete one by one resource by their name by this tutorial, run:
 ```shell
 $ kubectl delete MSSQLServeropsrequest msops-rotate-auth-generated msops-rotate-auth-user -n demo
 MSSQLServeropsrequest.ops.kubedb.com "msops-rotate-auth-generated" "msops-rotate-auth-user" deleted
-$ kubectl delete secret -n demoquick-mssqlserver-user-auth
-secret "quick-mssqlserver-user-auth" deleted
-$ kubectl delete secret -n demo   mssqlserver-quickstart-auth 
-secret "mssqlserver-quickstart-auth " deleted
+$ kubectl delete secret -n demo mssqlserver-quickstart-auth-user
+secret "mssqlserver-quickstart-auth-user" deleted
+$ kubectl delete secret -n demo mssqlserver-quickstart-auth
+secret "mssqlserver-quickstart-auth" deleted
 
 ```
 

--- a/docs/guides/mssqlserver/scaling/horizontal-scaling/mssqlserver.md
+++ b/docs/guides/mssqlserver/scaling/horizontal-scaling/mssqlserver.md
@@ -186,7 +186,7 @@ $ kubectl get secrets -n demo mssql-ag-cluster-auth -o jsonpath='{.data.\passwor
 Now, connect to the database using username and password, check the name of the created availability group, replicas of the availability group and see if databases are added to the availability group.
 ```bash
 $ kubectl exec -it -n demo mssql-ag-cluster-0 -c mssql -- bash
-mssql@mssql-ag-cluster-2:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "123KKxgOXuOkP206"
+mssql@mssql-ag-cluster-2:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "123KKxgOXuOkP206" -No
 1> select name from sys.databases
 2> go
 name                                                  
@@ -450,7 +450,7 @@ I1024 15:10:24.650632       1 health.go:51] 1:1A (4294967322)
 Now, connect to the database, check updated configurations of the availability group cluster. 
 ```bash
 $ kubectl exec -it -n demo mssql-ag-cluster-2 -c mssql -- bash
-mssql@mssql-ag-cluster-2:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "123KKxgOXuOkP206"
+mssql@mssql-ag-cluster-2:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "123KKxgOXuOkP206" -No
 1> SELECT name FROM sys.availability_groups
 2> go
 name                                                                                                                            
@@ -680,7 +680,7 @@ pod/mssql-ag-cluster-1   2/2     Running   0          38m
 Now, connect to the database, check updated configurations of the availability group cluster.
 ```bash
 $ kubectl exec -it -n demo mssql-ag-cluster-0 -c mssql -- bash
-mssql@mssql-ag-cluster-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "123KKxgOXuOkP206"
+mssql@mssql-ag-cluster-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "123KKxgOXuOkP206" -No
 1> SELECT name FROM sys.availability_groups
 2> go
 name                                                                                                                            

--- a/docs/guides/mssqlserver/tls/ag_cluster.md
+++ b/docs/guides/mssqlserver/tls/ag_cluster.md
@@ -207,7 +207,7 @@ Ng1DaJSNjZkgXXFX
 
 ```bash
 $ kubectl exec -it -n demo mssql-ag-tls-0 -c mssql -- bash
-mssql@mssql-ag-tls-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Ng1DaJSNjZkgXXFX -N 
+mssql@mssql-ag-tls-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P Ng1DaJSNjZkgXXFX -N 
 1> select name from sys.databases
 2> go
 name                                                  

--- a/docs/guides/mssqlserver/tls/standalone.md
+++ b/docs/guides/mssqlserver/tls/standalone.md
@@ -201,7 +201,7 @@ C2vU3HOCWY0hQHaj
 
 ```bash
 $ kubectl exec -it -n demo mssql-standalone-tls-0 -c mssql -- bash
-mssql@mssql-standalone-tls-0:/$ /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "C2vU3HOCWY0hQHaj" -N
+mssql@mssql-standalone-tls-0:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "C2vU3HOCWY0hQHaj" -N
 1> select name from sys.databases
 2> go
 name                                                                                                                            


### PR DESCRIPTION
These fixes come from executing the MSSQLServer guides on a live KubeDB v2026.6.19 cluster (docs HEAD v2026.6.19-31) as a new user would, and correcting what actually breaks. Every value is confirmed against observed cluster behavior or the guide's own definitions.

## 1. sqlcmd path and TLS flag wrong for the 2025-cu0 image (17 files)

The example YAMLs deploy `version: "2025-cu0"`, but the connection commands still use the old SQL Server 2022 (v17) client. On the 2025-cu0 image:

- `/opt/mssql-tools/bin/sqlcmd` does not exist. Only `/opt/mssql-tools18/bin/sqlcmd` (v18.4) is present. The old path fails with `stat /opt/mssql-tools/bin/sqlcmd: no such file or directory`.
- sqlcmd v18 defaults to mandatory encryption, so the plain command `sqlcmd -S localhost -U sa -P "<pw>"` fails against the self-signed KubeDB cert with `SSL Provider: certificate verify failed:self-signed certificate`. Adding `-No` (trust server certificate) succeeds and returns the documented rows. `-No` is the same convention already used by the initialization, dag_cluster and arbiter guides.

Fix applied across all 17 guide files that connect to SQL Server:
- `/opt/mssql-tools/bin/sqlcmd` to `/opt/mssql-tools18/bin/sqlcmd` (51 lines).
- appended `-No` to the plain `-U sa -P <pw>` invocations that carried no encrypt/trust flag (36 lines). Lines that already show `-N` (intentional "encryption fails" demo) or `-N -C` / `-C` were left as path-only fixes.

Verified live on the quickstart pod:
`/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "<pw>" -No -Q "select name from sys.databases"` returns the documented 5 rows (master, tempdb, model, msdb, kubedb_system). Also re-verified end to end while executing the rotate-auth RotateAuth OpsRequest (new credentials connect, previous credentials rejected).

## 2. quickstart: stale `kubectl get msversion` output

The "Find Available Versions" table showed the VERSION column as `2022` / `2025`. Live output shows VERSION equal to NAME (`2022-cu12`, `2025-cu0`, etc.). Updated the sample table to match.

## 3. rotate-auth: cleanup and verify commands reference a never-created secret

The guide creates the user secret `mssqlserver-quickstart-auth-user`, but the cleanup and one verify command referenced `quick-mssqlserver-user-auth`, which is never created, and one command glued the namespace to the name (`kubectl delete secret -n demoquick-mssqlserver-user-auth`, which errors). Corrected to the guide's own secret names:
- read `password.prev` from `mssqlserver-quickstart-auth`.
- `kubectl delete secret -n demo mssqlserver-quickstart-auth-user` and `kubectl delete secret -n demo mssqlserver-quickstart-auth`.

## Coverage / notes

- Executed live: quickstart (full lifecycle, connection, appbinding, DoNotTerminate) and rotate-auth (RotateAuth OpsRequest end to end).
- Not executed due to environment gaps: monitoring (no Prometheus operator), volume-expansion and autoscaler (no allowVolumeExpansion StorageClass / no metrics-server / no VPA). Multi-replica AG, backup, pitr and other heavy guides were not each stood up individually, but the image-level sqlcmd fix applies uniformly to their connection commands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated multiple SQL Server guides to use the newer `sqlcmd` command path.
  * Added connection flags in several examples for more consistent command behavior.
  * Refreshed example outputs and verification steps in TLS, failover, scaling, backup, restore, reconfigure, and auth rotation walkthroughs.
  * Corrected a few setup and cleanup instructions, including secret names and version listings in the quickstart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->