### PR TITLE
docs(memcached): fix incorrect commands and fields found by executing the guides

### DIFF
--- a/docs/examples/memcached/monitoring/builtin-prom-memcd.yaml
+++ b/docs/examples/memcached/monitoring/builtin-prom-memcd.yaml
@@ -19,16 +19,4 @@ spec:
             cpu: 500m
             memory: 256Mi
   monitor:
-    agent: prometheus.io/operator
-    prometheus:
-      serviceMonitor:
-        labels:
-          release: prometheus
-      exporter:
-        resources:
-          requests:
-            memory: 512Mi
-            cpu: 200m
-          limits:
-            memory: 512Mi
-            cpu: 250m
+    agent: prometheus.io/builtin

--- a/docs/examples/memcached/restart/opsrequest-restart.yaml
+++ b/docs/examples/memcached/restart/opsrequest-restart.yaml
@@ -1,7 +1,7 @@
 apiVersion: ops.kubedb.com/v1alpha1
 kind: MemcachedOpsRequest
 metadata:
-  name: memcd-new
+  name: restart
   namespace: demo
 spec:
   type: Restart

--- a/docs/examples/memcached/scaling/memcached-horizontal.yaml
+++ b/docs/examples/memcached/scaling/memcached-horizontal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: memcd-quickstart
   namespace: demo
 spec:
-  replicas: 1
+  replicas: 3
   version: "1.6.40"
   podTemplate:
     spec:

--- a/docs/guides/memcached/autoscaler/compute/compute-autoscale.md
+++ b/docs/guides/memcached/autoscaler/compute/compute-autoscale.md
@@ -73,7 +73,7 @@ spec:
 Let's create the `Memcached` CRO we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/autoscaler/compute/mc-compute-autoscaler.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/auto-scaler/memcached.yaml
 Memcached.kubedb.com/mc-compute-autoscaler created
 ```
 
@@ -171,7 +171,7 @@ Here,
 Let's create the `MemcachedAutoscaler` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/autoscaling/compute/mc-compute-autoscaler.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/auto-scaler/memcached-autoscaler-compute.yaml
 Memcachedautoscaler.autoscaling.kubedb.com/rd-as created
 ```
 

--- a/docs/guides/memcached/autoscaler/compute/compute-autoscale.md
+++ b/docs/guides/memcached/autoscaler/compute/compute-autoscale.md
@@ -74,10 +74,10 @@ Let's create the `Memcached` CRO we have shown above,
 
 ```bash
 $ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/auto-scaler/memcached.yaml
-Memcached.kubedb.com/mc-compute-autoscaler created
+Memcached.kubedb.com/mc-autoscaler-compute created
 ```
 
-Now, wait until `mc-compute-autoscaler` has status `Ready`. i.e,
+Now, wait until `mc-autoscaler-compute` has status `Ready`. i.e,
 
 ```bash
 $ kubectl get mc -n demo
@@ -157,7 +157,7 @@ spec:
 
 Here,
 
-- `spec.databaseRef.name` specifies that we are performing compute resource autoscaling on `mc-compute-autoscaler` database.
+- `spec.databaseRef.name` specifies that we are performing compute resource autoscaling on `mc-autoscaler-compute` database.
 - `spec.compute.memcached.trigger` specifies that compute resource autoscaling is enabled for this database.
 - `spec.compute.memcached.podLifeTimeThreshold` specifies the minimum lifetime for at least one of the pod to initiate a vertical scaling.
 - `spec.compute.memcached.resourceDiffPercentage` specifies the minimum resource difference in percentage. The default is 10%.
@@ -172,7 +172,7 @@ Let's create the `MemcachedAutoscaler` CR we have shown above,
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/auto-scaler/memcached-autoscaler-compute.yaml
-Memcachedautoscaler.autoscaling.kubedb.com/rd-as created
+Memcachedautoscaler.autoscaling.kubedb.com/mc-autoscaler created
 ```
 
 #### Verify Autoscaling is set up successfully

--- a/docs/guides/memcached/custom-configuration/using-config-file.md
+++ b/docs/guides/memcached/custom-configuration/using-config-file.md
@@ -89,7 +89,7 @@ type: Opaque
 Now, create Memcached crd specifying `spec.configuration.secretName` field.
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/configuration/mc-custom.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/custom-config/custom-memcached.yaml
 memcached.kubedb.com/custom-memcached created
 ```
 

--- a/docs/guides/memcached/custom-configuration/using-podtemplate.md
+++ b/docs/guides/memcached/custom-configuration/using-podtemplate.md
@@ -437,7 +437,7 @@ spec:
   deletionPolicy: WipeOut
 ```
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/configuration/memcached-without-tolerations.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/custom-config/without-toleration.yaml
 memcached.kubedb.com/memcached-without-tolerations created
 ```
 Now, wait a few minutes. KubeDB operator will create necessary petset, services, secret etc. If everything goes well, we will see that a pod with the name `memcached-without-tolerations-0` has been created and running.
@@ -557,7 +557,7 @@ spec:
 ```
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/configuration/with-tolerations.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/custom-config/with-tolerations.yaml
 memcached.kubedb.com/memcached-with-tolerations created
 ```
 Now, wait a few minutes. KubeDB operator will create necessary petset, services, secret etc. If everything goes well, we will see that a pod with the name `memcached-with-tolerations-0` has been created.

--- a/docs/guides/memcached/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/memcached/monitoring/using-builtin-prometheus.md
@@ -64,19 +64,7 @@ spec:
             cpu: 500m
             memory: 256Mi
   monitor:
-    agent: prometheus.io/operator
-    prometheus:
-      serviceMonitor:
-        labels:
-          release: prometheus
-      exporter:
-        resources:
-          requests:
-            memory: 512Mi
-            cpu: 200m
-          limits:
-            memory: 512Mi
-            cpu: 250m
+    agent: prometheus.io/builtin
 ```
 
 Here,
@@ -119,7 +107,11 @@ Labels:            app.kubernetes.io/component=database
                    app.kubernetes.io/managed-by=kubedb.com
                    app.kubernetes.io/name=memcacheds.kubedb.com
                    kubedb.com/role=stats
-Annotations:       monitoring.appscode.com/agent: prometheus.io/operator
+Annotations:       monitoring.appscode.com/agent: prometheus.io/builtin
+                   prometheus.io/path: /metrics
+                   prometheus.io/port: 56790
+                   prometheus.io/scheme: http
+                   prometheus.io/scrape: true
 Selector:          app.kubernetes.io/instance=builtin-prom-memcd,app.kubernetes.io/managed-by=kubedb.com,app.kubernetes.io/name=memcacheds.kubedb.com
 Type:              ClusterIP
 IP Family Policy:  SingleStack

--- a/docs/guides/memcached/quickstart/quickstart.md
+++ b/docs/guides/memcached/quickstart/quickstart.md
@@ -122,7 +122,7 @@ KubeDB operator watches for `Memcached` objects using Kubernetes api. When a `Me
 ```bash
 $ kubectl get mc -n demo
 NAME               VERSION    STATUS    AGE
-memcd-quickstart   1.6.40     Running   2m
+memcd-quickstart   1.6.40     Ready     2m
 
 $ kubectl describe mc -n demo memcd-quickstart
 Name:         memcd-quickstart
@@ -233,7 +233,7 @@ memcd-quickstart        ClusterIP   10.96.115.90   <none>        11211/TCP   9m7
 memcd-quickstart-pods   ClusterIP   None           <none>        11211/TCP   9m7s
 ```
 
-KubeDB operator sets the `status.phase` to `Running` once the database is successfully created. Run the following command to see the modified Memcached object:
+KubeDB operator sets the `status.phase` to `Ready` once the database is successfully created. Run the following command to see the modified Memcached object:
 
 ```yaml
 $ kubectl get mc -n demo memcd-quickstart -o yaml
@@ -322,6 +322,20 @@ status:
 ```
 ## Connect with Memcached database
 
+By default, KubeDB enables authentication for Memcached. The credentials are stored in the auth secret named `{Memcached crd name}-auth`. You need these credentials to connect to the server.
+
+Retrieve the credentials from the auth secret. They are stored in the `authData` key in the `username:password` format.
+
+```bash
+$ kubectl get memcached -n demo memcd-quickstart -o=jsonpath='{.spec.authSecret.name}'
+memcd-quickstart-auth
+
+$ kubectl get secret -n demo memcd-quickstart-auth -o=jsonpath='{.data.authData}' | base64 -d
+user:tysiujogcmzapyhz
+```
+
+Here, `username` is `user` and `password` is `tysiujogcmzapyhz`.
+
 Now, you can connect to this database using `telnet`.
 Here, we will connect to Memcached server from local-machine through port-forwarding.
 
@@ -340,6 +354,14 @@ Forwarding from [::1]:11211 -> 11211
 Trying 127.0.0.1...
 Connected to 127.0.0.1.
 Escape character is '^]'.
+
+# Authenticate first. Without this, the server returns `CLIENT_ERROR unauthenticated`.
+# The value is the `username` and `password` separated by a space, and the byte
+# count (21 here) is the length of that value.
+set auth 0 0 21
+user tysiujogcmzapyhz
+# Output:
+STORED
 
 # Save data Command:
 set my_key 0 2592000 1

--- a/docs/guides/memcached/reconfigure/reconfigure.md
+++ b/docs/guides/memcached/reconfigure/reconfigure.md
@@ -84,7 +84,7 @@ spec:
 Let's create the `Memcached` CR we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/reconfigure/sample-memcached-config.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/reconfigure/memcached-config.yaml
 memcached.kubedb.com/memcd-quickstart created
 ```
 
@@ -175,7 +175,7 @@ Here,
 Let's create the `MemcachedOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/reconfigure/ops-request-reconfigure.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/reconfigure/config-secret-reconfigure.yaml
 memcachedopsrequest.ops.kubedb.com/memcd-reconfig created
 ```
 
@@ -341,7 +341,7 @@ Here,
 Let's create the `MemcachedOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/reconfigure/ops-request-reconfigure.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/reconfigure/apply-config-reconfigure.yaml
 memcachedopsrequest.ops.kubedb.com/memcd-reconfig created
 ```
 

--- a/docs/guides/memcached/tls/tls.md
+++ b/docs/guides/memcached/tls/tls.md
@@ -89,7 +89,7 @@ spec:
 Apply the `YAML` file:
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/tls/issuer.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/tls/memcached-ca-issuer.yaml
 issuer.cert-manager.io/memcached-ca-issuer created
 ```
 


### PR DESCRIPTION
Executed every Memcached guide under `docs/docs/guides/memcached/` on a live KubeDB v2026.6.19 cluster (kubectl dba v0.52.0) and fixed the bugs the runs surfaced. Correct values were confirmed against the source of truth (kubedb/apimachinery, the in-repo example manifests) or observed cluster behavior.

## Fixes

### Broken example-file references (raw GitHub URLs that 404)
Each was cross-checked against the actual file in `docs/examples/memcached/`:

- `custom-configuration/using-config-file.md`: `configuration/mc-custom.yaml` -> `custom-config/custom-memcached.yaml`
- `custom-configuration/using-podtemplate.md`: `configuration/memcached-without-tolerations.yaml` -> `custom-config/without-toleration.yaml`; `configuration/with-tolerations.yaml` -> `custom-config/with-tolerations.yaml`
- `reconfigure/reconfigure.md`: `reconfigure/sample-memcached-config.yaml` -> `reconfigure/memcached-config.yaml`; the configSecret step `reconfigure/ops-request-reconfigure.yaml` -> `reconfigure/config-secret-reconfigure.yaml`; the applyConfig step `reconfigure/ops-request-reconfigure.yaml` -> `reconfigure/apply-config-reconfigure.yaml`
- `tls/tls.md`: `tls/issuer.yaml` -> `tls/memcached-ca-issuer.yaml`
- `autoscaler/compute/compute-autoscale.md`: `autoscaler/compute/mc-compute-autoscaler.yaml` -> `auto-scaler/memcached.yaml`; `autoscaling/compute/mc-compute-autoscaler.yaml` -> `auto-scaler/memcached-autoscaler-compute.yaml`

Verified: the corrected manifests apply on the cluster (config-file, reconfigure, and tls guides were run end to end; the autoscaler manifests pass `kubectl apply --dry-run=server`).

### Horizontal scaling example started at 1 replica (ops fails)
`docs/examples/memcached/scaling/memcached-horizontal.yaml` had `replicas: 1`, while the guide narrates deploying with 3 and scaling to 5. Applying it and running the documented HorizontalScaling ops fails: the validating webhook denies `can not update from 1 replica to 5 replica` (apimachinery/pkg/webhooks/kubedb/v1/memcached.go `validateReplica`). Changed the example to `replicas: 3`, matching the guide. Verified live: 3 -> 5 scaling completes Successfully.

### Restart ops example name did not match the guide
`docs/examples/memcached/restart/opsrequest-restart.yaml` created an ops named `memcd-new`, but the guide's apply output, `kubectl get`, and cleanup all use `restart`. Renamed the ops to `restart`. Verified live: the Restart ops completes Successfully.

### Builtin Prometheus guide used the operator agent
`monitoring/using-builtin-prometheus.md` and `docs/examples/memcached/monitoring/builtin-prom-memcd.yaml` set `monitor.agent: prometheus.io/operator` (with an operator-only serviceMonitor block), contradicting the guide's own text and requiring a Prometheus operator. Set it to `agent: prometheus.io/builtin`, matching the reference redis/postgres builtin examples. Verified live: the stats service then carries the documented `prometheus.io/scrape/path/port` annotations and serves exporter metrics. Updated the describe output annotations accordingly.

### Quickstart connection steps missing authentication
KubeDB now enables SASL auth for Memcached by default (pod arg `--auth-file`). The quickstart's telnet set/get returns `CLIENT_ERROR unauthenticated` as written. Added the credential retrieval (`authData` key of the `-auth` secret, in `username:password` form) and the authentication command before set/get, matching the flow already documented in the rotate-auth and tls guides. Verified live. Also corrected the quickstart STATUS column and prose from `Running` to `Ready` (current `status.phase`).

## Guides executed
quickstart, cli, custom-configuration (config-file, podtemplate), custom-rbac, reconfigure, restart, update-version, scaling (horizontal, vertical), rotate-auth, tls, monitoring (builtin) all run live and pass with these fixes. monitoring (prometheus-operator), private-registry, and autoscaler/compute were validated via `--dry-run=server` only, as the cluster lacks the Prometheus operator, a private registry, and VPA/metrics-server respectively.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Memcached examples and tutorials to point to revised manifest URLs and filenames across quickstart, custom configuration, restart, scaling, reconfigure, and TLS guides.
  * Refreshed monitoring guidance to use built-in Prometheus configuration (including updated annotations and removed operator-specific blocks).
  * Clarified quickstart flow for authenticated access, including credential retrieval and a “Ready” status wording update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->