### PR TITLE
docs(oracle): fix incorrect commands and fields found by executing the guides

### DIFF
--- a/docs/examples/oracle/dataguard/dataguard.yaml
+++ b/docs/examples/oracle/dataguard/dataguard.yaml
@@ -11,6 +11,8 @@ spec:
     observer:
       podTemplate:
         spec:
+          imagePullSecrets:
+            - name: orclcred
           containers:
             - name: observer
               resources:
@@ -43,6 +45,8 @@ spec:
   mode: DataGuard
   podTemplate:
     spec:
+      imagePullSecrets:
+        - name: orclcred
       containers:
         - name: oracle
           resources:

--- a/docs/examples/oracle/quickstart/standalone.yaml
+++ b/docs/examples/oracle/quickstart/standalone.yaml
@@ -9,6 +9,8 @@ spec:
   mode: Standalone
   podTemplate:
     spec:
+      imagePullSecrets:
+        - name: orclcred
       containers:
         - name: oracle
           resources:

--- a/docs/examples/oracle/rotate-auth/standalone-rotate-auth-user.yaml
+++ b/docs/examples/oracle/rotate-auth/standalone-rotate-auth-user.yaml
@@ -1,0 +1,14 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: OracleOpsRequest
+metadata:
+  name: standalone-rotate-auth-user
+  namespace: demo
+spec:
+  type: RotateAuth
+  databaseRef:
+    name: oracle-sa-sample
+  authentication:
+    secretRef:
+      kind: Secret
+      name: oracle-user-auth
+  apply: IfReady

--- a/docs/guides/oracle/concepts/oracle.md
+++ b/docs/guides/oracle/concepts/oracle.md
@@ -180,12 +180,12 @@ spec:
 #### Core Parameters
 - `version`: Oracle database version (e.g., 21.3.0)
 - `mode`: Deployment mode (Standalone or DataGuard)
-- `edition`: Oracle edition (enterprise, standard)
+- `edition`: Oracle edition (enterprise)
 - `replicas`: Number of database instances
 
 #### DataGuard Specific Parameters
 - `protectionMode`: Defines the data protection mode (MaximumProtection, MaximumAvailability, MaximumPerformance)
-- `standbyType`: Type of standby database (PHYSICAL)
+- `standbyType`: Type of standby database (PHYSICAL, LOGICAL)
 - `syncMode`: Synchronization mode between primary and standby (SYNC, ASYNC)
 - `applyLagThreshold`: Maximum acceptable lag in applying changes
 - `transportLagThreshold`: Maximum acceptable transport lag

--- a/docs/guides/oracle/configuration/using-config-file.md
+++ b/docs/guides/oracle/configuration/using-config-file.md
@@ -40,12 +40,10 @@ Oracle allows configuring the database via a configuration file. When KubeDB pro
 To provide a custom configuration for an Oracle database, you set `spec.configuration`. There are three options, which can be combined:
 
 - **Secret** — point `spec.configuration.secretName` at a Kubernetes `Secret` whose key is **`oracle.cnf`**.
-- **Inline** — put one or more configuration files directly under `spec.configuration.inline`.
+- **Inline** — put the configuration directly under `spec.configuration.inline` in a single entry keyed **`oracle.cnf`**.
 - **Both** — supply a Secret *and* inline configuration. Inline values override the ones from the Secret.
 
-> Note: for Secret-based configuration, the Secret key **must** be `oracle.cnf`. Inline configuration keys can use any file name.
-
-When you provide inline configuration, you may include multiple files if needed. KubeDB applies inline files in lexicographical order by key name, so prefix file names with a priority number, such as `1-sga.cnf` and `2-backup-files.txt`, to control the processing order.
+> Note: for both Secret-based and inline configuration, the key **must** be `oracle.cnf`. `spec.configuration.inline` must contain exactly one entry, and it must be named `oracle.cnf`; any other name, or more than one entry, is rejected by the admission webhook.
 
 ## Custom Configuration via a Secret
 
@@ -154,7 +152,7 @@ metadata:
 spec:
   configuration:
     inline:
-      1-sga.cnf: |
+      oracle.cnf: |
         SGA_TARGET=1G
   podTemplate:
     spec:
@@ -177,7 +175,7 @@ spec:
 
 Here,
 
-- `spec.configuration.inline` holds one or more configuration files directly in the `Oracle` CR. Inline file names can be any valid key name and are processed in lexicographical order.
+- `spec.configuration.inline` holds the configuration directly in the `Oracle` CR. It must contain exactly one entry named `oracle.cnf`.
 
 ## Combining Secret and Inline Configuration
 
@@ -193,7 +191,7 @@ spec:
   configuration:
     secretName: oracle-custom-config
     inline:
-      1-sga.cnf: |
+      oracle.cnf: |
         SGA_TARGET=5G
   podTemplate:
     spec:

--- a/docs/guides/oracle/failover/overview.md
+++ b/docs/guides/oracle/failover/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Oracle Faoilover and Disaster Recovery
+title: Oracle Failover and Disaster Recovery
 menu:
   docs_{{ .version }}:
     identifier: guides-oracle-fdr-overview
@@ -178,7 +178,7 @@ $ kubectl apply -f oracle-dataguard.yaml
 
 ```shell
 $ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/oracle/dataguard/dataguard.yaml
-oracle.kubedb.com/oracle created
+oracle.kubedb.com/oracle-sample created
 
 ```
 Monitor status until all pods are ready:
@@ -462,8 +462,8 @@ SQL> SELECT * FROM kathak;
    ID NAME		    AGE
 ----- -------------------- ----
     1 Radha		     25
-    3 Gopal		     28
-    2 Mohan		     30
+    2 Gopal		     28
+    3 Mohan		     30
 
 SQL> exit
 Disconnected from Oracle Database 21c Enterprise Edition Release 21.0.0.0.0 - Production

--- a/docs/guides/oracle/rotate-authentication/rotateauth.md
+++ b/docs/guides/oracle/rotate-authentication/rotateauth.md
@@ -230,7 +230,7 @@ spec:
 ```
 
 ```bash
-$ kubectl create -f standalone-rotate-auth-user.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/oracle/rotate-auth/standalone-rotate-auth-user.yaml
 oracleopsrequest.ops.kubedb.com/standalone-rotate-auth-user created
 ```
 

--- a/docs/guides/oracle/volume-expansion/volume-expansion.md
+++ b/docs/guides/oracle/volume-expansion/volume-expansion.md
@@ -28,7 +28,7 @@ This guide will show you how to use `KubeDB` Ops-manager operator to expand the 
 $ kubectl get storageclass
 NAME                   PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
 local-path (default)   rancher.io/local-path   Delete          WaitForFirstConsumer   false                  12d
-longhorn (default)     driver.longhorn.io      Delete          Immediate              true                   12d
+longhorn               driver.longhorn.io      Delete          Immediate              true                   12d
 ```
 
 > **Note:** `local-path` has `ALLOWVOLUMEEXPANSION: false`, so it cannot be used for volume expansion. Use a storage class such as `longhorn` that supports it.


### PR DESCRIPTION
This PR fixes bugs found by executing the Oracle guides against a KubeDB v2026.6.19 cluster. Oracle itself cannot be provisioned in the test environment (the operator authenticates to container-registry.oracle.com to resolve the image digest and gets 401 without Oracle credentials, so no PetSet is ever created), so every CR was validated with `kubectl apply --dry-run=server` and every field, secret key, enum, and example-file reference was confirmed against the source of truth (apimachinery API types and webhooks, the oracle operator, and the live catalog).

## Fixes

1. **examples/oracle/quickstart/standalone.yaml**: added the missing `imagePullSecrets: [orclcred]` under `podTemplate.spec`. The guide instructs creating the `orclcred` secret and its inline YAML includes it, but the downloadable file omitted it. The operator resolves the image digest using the spec's imagePullSecrets (oracle/pkg/utils/util.go -> petset.go `authn.ImageWithDigest`), so without it provisioning fails with a registry 401 (observed live).

2. **examples/oracle/dataguard/dataguard.yaml**: added the missing `imagePullSecrets: [orclcred]` to both the observer and the main `podTemplate.spec`, matching the failover guide's inline manifest. Same root cause as (1).

3. **guides/oracle/configuration/using-config-file.md**: the guide claimed inline config supports "any file name", "multiple files", and lexicographical ordering, and used the key `1-sga.cnf`. The admission webhook (apimachinery oracle.go) requires `spec.configuration.inline` to contain exactly one entry named `oracle.cnf`. Corrected the prose and both inline example keys to `oracle.cnf`. Verified live: `1-sga.cnf` is rejected, `oracle.cnf` is accepted.

4. **guides/oracle/concepts/oracle.md**: `edition` listed `(enterprise, standard)`, but the enum only allows `enterprise` (oracle_types.go; dry-run rejects `standard`). Also completed `standbyType` to `(PHYSICAL, LOGICAL)` per the enum.

5. **guides/oracle/volume-expansion/volume-expansion.md**: the sample `kubectl get storageclass` output marked both `local-path` and `longhorn` as `(default)`, which is impossible. Removed `(default)` from `longhorn`.

6. **guides/oracle/failover/overview.md**: fixed the front-matter title typo `Faoilover` -> `Failover`; corrected the `kubectl create -f .../dataguard/dataguard.yaml` output from `oracle.kubedb.com/oracle created` to `oracle.kubedb.com/oracle-sample created` (the manifest name is `oracle-sample`); and fixed a swapped id/name mapping in a SQL verify block (`3 Gopal`/`2 Mohan` -> `2 Gopal`/`3 Mohan`, matching the data inserted earlier in the guide).

7. **guides/oracle/rotate-authentication/rotateauth.md** + **examples/oracle/rotate-auth/standalone-rotate-auth-user.yaml**: the "user created credentials" step ran `kubectl create -f standalone-rotate-auth-user.yaml`, a file that did not exist. Added the missing example file (the exact OracleOpsRequest shown inline) and updated the command to the github-raw URL form used elsewhere in the guide. The new file passes server dry-run.

All guides under docs/guides/oracle were audited. Guides with no issues: initialization, restart, scaling/vertical-scaling, volume-expansion/overview, reconfigure, rotate-authentication/overview, monitoring, tls, concepts/opsrequest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Oracle guides and sample manifests to reflect current setup and usage, including image pull secret configuration and authentication rotation examples.
  * Clarified Oracle configuration rules, including supported config file naming and how inline settings are handled.
  * Refined Oracle failover and volume expansion examples for accuracy, and corrected a few Oracle guide labels and sample outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->