### PR TITLE
docs(percona-xtradb): fix incorrect commands and fields found by executing the guides

### DIFF
--- a/docs/guides/percona-xtradb/quickstart/overview/index.md
+++ b/docs/guides/percona-xtradb/quickstart/overview/index.md
@@ -267,7 +267,7 @@ w*yOU$b53dTbjsjJ
 We will exec into the pod `sample-pxc-0` and connet to the database using `username` and `password`.
 
 ```bash
-$ kubectl exec -it -n demo sample-pxc-0 -- perconaxtradb -u root --password='w*yOU$b53dTbjsjJ'
+$ kubectl exec -it -n demo sample-pxc-0 -- mysql -u root --password='w*yOU$b53dTbjsjJ'
 
 Server version: 8.4.3-3.1 Percona XtraDB Cluster (GPL), Release rel3, Revision cf742b4, WSREP version 26.1.4.3
 

--- a/docs/guides/percona-xtradb/rotateauth/rotateauth.md
+++ b/docs/guides/percona-xtradb/rotateauth/rotateauth.md
@@ -79,7 +79,7 @@ sample-pxc   8.4.3    Ready    43m
 The user can verify whether they are authorized by executing a query directly in the database. To do this, the user needs `username` and `password` in order to connect to the database. Below is an example showing how to retrieve the credentials from the secret.
 
 ````shell
-$ kubectl get PerconaXtraDB -n demo sample-pxc -ojson | jq .spec.authsecret.name
+$ kubectl get PerconaXtraDB -n demo sample-pxc -ojson | jq .spec.authSecret.name
 "sample-pxc-auth"
 $ kubectl get secrets -n demo sample-pxc-auth -o jsonpath='{.data.\username}' | base64 -d
 root⏎                                                                                                 
@@ -89,13 +89,12 @@ Q!IsZ7.NXM.ZIxvT⏎
 
 ### Connect with PerconaXtraDB database using credentials
 
-Now, you can connect to this database using `telnet`.
 Here, we will connect to PerconaXtraDB server from local-machine through port-forwarding.
-We will connect to `sample-pxc-0` pod from local-machine using port-frowarding and it must be running in separate terminal.
+We will connect to `sample-pxc-0` pod from local-machine using port-forwarding and it must be running in separate terminal.
 ```bash
-$ kubectl port-forward -n demo sample-pxc-0 11211
-Forwarding from 127.0.0.1:11211 -> 11211
-Forwarding from [::1]:11211 -> 11211
+$ kubectl port-forward -n demo sample-pxc-0 3306
+Forwarding from 127.0.0.1:3306 -> 3306
+Forwarding from [::1]:3306 -> 3306
 ```
 Now, you can exec into the pod `sample-pxc` and connect to database using `username` and `password`
 ```shell
@@ -159,7 +158,7 @@ Here,
 
 Let's create the `PerconaXtraDBOpsRequest` CR we have shown above,
 ```shell
- $ kubectl apply -f https://github.com/kubedb/docs/raw/{{ .version }}/docs/examples/perconaXtraDB/rotate-auth/PerconaXtraDB-rotate-auth-generated.yaml
+ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/percona-xtradb/rotateauth/yamls/PerconaXtraDB-rotate-auth-generated.yaml
  PerconaXtraDBopsrequest.ops.kubedb.com/pxops-rotate-auth-generated created
 ```
 Let's wait for `PerconaXtraDBOpsrequest` to be `Successful`. Run the following command to watch `PerconaXtraDBOpsrequest` CRO
@@ -258,7 +257,7 @@ Events:                    <none>
 
 **Verify Auth is rotated**
 ```shell
-$ kubectl get perconaxtradb -n demo sample-pxc -ojson | jq .spec.authsecret.name
+$ kubectl get perconaxtradb -n demo sample-pxc -ojson | jq .spec.authSecret.name
 "sample-pxc-auth"
 $ kubectl get secret -n demo sample-pxc-auth -o=jsonpath='{.data.username}' | base64 -d
 root⏎                         
@@ -308,12 +307,12 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing rotate authentication operation on `sample-pxc`cluster.
 - `spec.type` specifies that we are performing `RotateAuth` on PerconaXtraDB.
-- `spec.authentication.secretRef.name` specifies that we are using `quick-pcx-user-auth` as `spec.authsecret.name` for authentication.
+- `spec.authentication.secretRef.name` specifies that we are using `quick-pcx-user-auth` as `spec.authSecret.name` for authentication.
 
 Let's create the `PerconaXtraDBOpsRequest` CR we have shown above,
 
 ```shell
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{ .version }}/docs/examples/perconaXtraDB/rotate-auth/rotate-auth-user.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/percona-xtradb/rotateauth/yamls/rotate-auth-user.yaml
 PerconaXtraDBopsrequest.ops.kubedb.com/pxops-rotate-auth-user created
 ```
 Let’s wait for `PerconaXtraDBOpsRequest` to be Successful. Run the following command to watch `PerconaXtraDBOpsRequest` CRO:
@@ -503,7 +502,7 @@ Events:
 ```
 **Verify auth is rotate**
 ```shell
-$ kubectl get perconaxtradb -n demo sample-pxc -ojson | jq .spec.authsecret.name
+$ kubectl get perconaxtradb -n demo sample-pxc -ojson | jq .spec.authSecret.name
 "quick-pcx-user-auth "
 $ kubectl get secrets -n demo quick-pcx-user-auth -o jsonpath='{.data.\username}' | base64 -d
 root⏎                                                                                     
@@ -528,7 +527,7 @@ Or, you can delete one by one resource by their name by this tutorial, run:
 ```shell
 $ kubectl delete PerconaXtraDBopsrequest pxops-rotate-auth-generated pxops-rotate-auth-user -n demo
 PerconaXtraDBopsrequest.ops.kubedb.com "pxops-rotate-auth-generated" "pxops-rotate-auth-user" deleted
-$ kubectl delete secret -n sample-pxc-auth
+$ kubectl delete secret -n demo sample-pxc-auth
 secret "sample-pxc-auth" deleted
 $ kubectl delete secret -n demo   quick-pcx-user-auth 
 secret "quick-pcx-user-auth " deleted

--- a/docs/guides/percona-xtradb/tls/configure/index.md
+++ b/docs/guides/percona-xtradb/tls/configure/index.md
@@ -31,7 +31,7 @@ section_menu_id: guides
   namespace/demo created
   ```
 
-> Note: YAML files used in this tutorial are stored in [docs/guides/percona-xtradb/tls/configure/examples](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/guides/mysql/tls/configure/yamls) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+> Note: YAML files used in this tutorial are stored in [docs/guides/percona-xtradb/tls/configure/examples](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/guides/percona-xtradb/tls/configure/examples) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
 
 ### Deploy PerconaXtraDB database with TLS/SSL configuration
 
@@ -370,7 +370,7 @@ From the above output, you can see that only using client certificate we can acc
 To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
-$ kubectl delete  perconaxtradb demo  sample-pxc
+$ kubectl delete perconaxtradb -n demo sample-pxc
 perconaxtradb.kubedb.com "sample-pxc" deleted
 $ kubectl delete ns demo
 namespace "demo" deleted


### PR DESCRIPTION
While executing the PerconaXtraDB guides against a live KubeDB v2026.6.19 cluster, the following broken commands and fields were found and fixed. Each fix was confirmed against cluster behavior or the source of truth.

## quickstart/overview
- Connect step used `kubectl exec ... -- perconaxtradb -u root ...`, but no `perconaxtradb` client binary exists in the container (`exec: "perconaxtradb": executable file not found in $PATH`). The working client is `mysql`. Changed to `mysql -u root`. Verified live: `mysql` connects and returns results; `perconaxtradb` fails.

## rotateauth
- `jq .spec.authsecret.name` returned `null` (jq is case sensitive). The CR field is `authSecret`. Fixed all three `jq` occurrences and one prose reference to `.spec.authSecret.name`. Verified live: `.spec.authsecret.name` -> null, `.spec.authSecret.name` -> "sample-pxc-auth".
- Two apply URLs used the wrong template `{{ .version }}` and a non-existent path `docs/examples/perconaXtraDB/rotate-auth/`. Corrected to `{{< param "info.version" >}}` and the real path `docs/guides/percona-xtradb/rotateauth/yamls/` (matching the files that actually ship there).
- Cleanup command `kubectl delete secret -n sample-pxc-auth` was missing the namespace value (it treated the secret name as the namespace). Fixed to `kubectl delete secret -n demo sample-pxc-auth`.
- The "Connect ... using `telnet`" paragraph with `kubectl port-forward -n demo sample-pxc-0 11211` was leftover from the Memcached guide. PerconaXtraDB speaks MySQL on port 3306. Removed the telnet sentence, changed the port to 3306, and fixed a "port-frowarding" typo.

The full RotateAuth (operator generated) OpsRequest was run live and completed Successful; post-rotate `mysql` login with the rotated password works, and `username.prev`/`password.prev` keys are present.

## tls/configure
- Cleanup command `kubectl delete  perconaxtradb demo  sample-pxc` was missing `-n` (it treated `demo` as a resource name). Fixed to `kubectl delete perconaxtradb -n demo sample-pxc`.
- The "YAML files ... stored in" Note linked to `docs/guides/mysql/tls/configure/yamls` (wrong database and directory). Fixed to `docs/guides/percona-xtradb/tls/configure/examples`.

Guides deployed/exercised live: quickstart, clustering (Galera, wsrep_cluster_size=3), rotateauth (RotateAuth OpsRequest Successful). Other guides were reviewed against source and cluster behavior; volume-expansion, autoscaler, and Prometheus-operator monitoring are blocked by environment gaps (no expandable StorageClass, no VPA/metrics-server, no Prometheus operator) and were not part of these fixes.