### PR TITLE
docs(singlestore): fix wrong auth-secret name, stray-backslash secret reads, and aggregator pod name

### DIFF
--- a/docs/guides/singlestore/backup/kubestash/application-level/index.md
+++ b/docs/guides/singlestore/backup/kubestash/application-level/index.md
@@ -157,7 +157,7 @@ The database is `Ready`. Verify that KubeDB has created a `Secret` and a `Servic
 ```bash
 $ kubectl get secret -n demo -l=app.kubernetes.io/instance=sample-singlestore
 NAME                           TYPE                       DATA   AGE
-sample-singlestore-root-cred   kubernetes.io/basic-auth   2      4m58s
+sample-singlestore-auth   kubernetes.io/basic-auth   2      4m58s
 
 $ kubectl get service -n demo -l=app.kubernetes.io/instance=sample-singlestore
 NAME                       TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
@@ -166,7 +166,7 @@ sample-singlestore-pods   ClusterIP   None             <none>        3306/TCP   
 
 ```
 
-Here, we have to use service `sample-singlestore` and secret `sample-singlestore-root-cred` to connect with the database. `KubeDB` creates an [AppBinding](/docs/guides/singlestore/concepts/appbinding.md) CR that holds the necessary information to connect with the database.
+Here, we have to use service `sample-singlestore` and secret `sample-singlestore-auth` to connect with the database. `KubeDB` creates an [AppBinding](/docs/guides/singlestore/concepts/appbinding.md) CR that holds the necessary information to connect with the database.
 
 **Verify AppBinding:**
 
@@ -233,7 +233,7 @@ spec:
         restoreTask:
           name: ""
   secret:
-    name: sample-singlestore-root-cred
+    name: sample-singlestore-auth
   type: kubedb.com/singlestore
   version: 8.9.3
 
@@ -263,10 +263,10 @@ sample-singlestore-leaf-2         2/2     Running   0          15m
 And copy the username and password of the `root` user to access into `memsql` shell.
 
 ```bash
-$ kubectl get secret -n demo  sample-singlestore-root-cred -o jsonpath='{.data.username}'| base64 -d
+$ kubectl get secret -n demo  sample-singlestore-auth -o jsonpath='{.data.username}'| base64 -d
 root⏎           
 
-kubectl get secret -n demo  sample-singlestore-root-cred -o jsonpath='{.data.password}'| base64 -d
+kubectl get secret -n demo  sample-singlestore-auth -o jsonpath='{.data.password}'| base64 -d
 xEJv73q3w_m1~H.G⏎ 
 ```
 
@@ -765,10 +765,10 @@ sample-singlestore-leaf-2         2/2     Running   0          15m
 And copy the username and password of the `root` user to access into `mysql` shell.
 
 ```bash
-$ kubectl get secret -n demo  sample-singlestore-root-cred -o jsonpath='{.data.username}'| base64 -d
+$ kubectl get secret -n demo  sample-singlestore-auth -o jsonpath='{.data.username}'| base64 -d
 root⏎           
 
-kubectl get secret -n demo  sample-singlestore-root-cred -o jsonpath='{.data.password}'| base64 -d
+kubectl get secret -n demo  sample-singlestore-auth -o jsonpath='{.data.password}'| base64 -d
 xEJv73q3w_m1~H.G⏎ 
 ```
 

--- a/docs/guides/singlestore/backup/kubestash/logical/index.md
+++ b/docs/guides/singlestore/backup/kubestash/logical/index.md
@@ -157,7 +157,7 @@ The database is `Ready`. Verify that KubeDB has created a `Secret` and a `Servic
 ```bash
 $ kubectl get secret -n demo -l=app.kubernetes.io/instance=sdb-sample
 NAME                   TYPE                       DATA   AGE
-sdb-sample-root-cred   kubernetes.io/basic-auth   2      4m58s
+sdb-sample-auth   kubernetes.io/basic-auth   2      4m58s
 
 $ kubectl get service -n demo -l=app.kubernetes.io/instance=sdb-sample
 NAME              TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
@@ -166,7 +166,7 @@ sdb-sample-pods   ClusterIP   None             <none>        3306/TCP           
 
 ```
 
-Here, we have to use service `sdb-sample` and secret `sdb-sample-root-cred` to connect with the database. `KubeDB` creates an [AppBinding](/docs/guides/mysql/concepts/appbinding/index.md) CR that holds the necessary information to connect with the database.
+Here, we have to use service `sdb-sample` and secret `sdb-sample-auth` to connect with the database. `KubeDB` creates an [AppBinding](/docs/guides/mysql/concepts/appbinding/index.md) CR that holds the necessary information to connect with the database.
 
 **Verify AppBinding:**
 
@@ -233,7 +233,7 @@ spec:
         restoreTask:
           name: ""
   secret:
-    name: sdb-sample-root-cred
+    name: sdb-sample-auth
   type: kubedb.com/singlestore
   version: 8.9.3
 
@@ -263,10 +263,10 @@ sdb-sample-leaf-2         2/2     Running   0          15m
 And copy the username and password of the `root` user to access into `memsql` shell.
 
 ```bash
-$ kubectl get secret -n demo  sdb-sample-root-cred -o jsonpath='{.data.username}'| base64 -d
+$ kubectl get secret -n demo  sdb-sample-auth -o jsonpath='{.data.username}'| base64 -d
 root⏎           
 
-kubectl get secret -n demo  sdb-sample-root-cred -o jsonpath='{.data.password}'| base64 -d
+kubectl get secret -n demo  sdb-sample-auth -o jsonpath='{.data.password}'| base64 -d
 xEJv73q3w_m1~H.G⏎ 
 ```
 
@@ -792,10 +792,10 @@ restored-singlestore-leaf-2         2/2     Running   0          34m
 And then copy the user name and password of the `root` user to access into `memsql` shell.
 
 ```bash
-$ kubectl get secret -n demo  restored-singlestore-root-cred -o jsonpath='{.data.username}'| base64 -d
+$ kubectl get secret -n demo  restored-singlestore-auth -o jsonpath='{.data.username}'| base64 -d
 root⏎           
 
-kubectl get secret -n demo  restored-singlestore-root-cred -o jsonpath='{.data.password}'| base64 -d
+kubectl get secret -n demo  restored-singlestore-auth -o jsonpath='{.data.password}'| base64 -d
 QMm1hi0T*7QFz_yh⏎ 
 ```
 

--- a/docs/guides/singlestore/clustering/singlestore-clustering/index.md
+++ b/docs/guides/singlestore/clustering/singlestore-clustering/index.md
@@ -165,7 +165,7 @@ metadata:
   uid: 22b254e0-d185-413c-888f-ca4c2524e909
 spec:
   authSecret:
-    name: sample-sdb-root-cred
+    name: sample-sdb-auth
   deletionPolicy: WipeOut
   healthChecker:
     failureThreshold: 1
@@ -355,28 +355,28 @@ status:
 
 ## Connect with SingleStore database
 
-KubeDB operator has created a new Secret called `sample-sdb-root-cred` *(format: {singlestore-object-name}-root-cred)* for storing the password for `singlestore` superuser. This secret contains a `username` key which contains the *username* for SingleStore superuser and a `password` key which contains the *password* for SingleStore superuser.
+KubeDB operator has created a new Secret called `sample-sdb-auth` *(format: {singlestore-object-name}-auth)* for storing the password for `singlestore` superuser. This secret contains a `username` key which contains the *username* for SingleStore superuser and a `password` key which contains the *password* for SingleStore superuser.
 
 If you want to use an existing secret please specify that when creating the SingleStore object using `spec.authSecret.name`. While creating this secret manually, make sure the secret contains these two keys containing data `username` and `password` and also make sure of using `root` as value of `username`. For more details see [here](/docs/guides/mysql/concepts/database/index.md#specdatabasesecret).
 
-Now, we need `username` and `password` to connect to this database from `kubectl exec` command. In this example  `sample-sdb-root-cred` secret holds username and password
+Now, we need `username` and `password` to connect to this database from `kubectl exec` command. In this example  `sample-sdb-auth` secret holds username and password
 
 ```bash
-$ kubectl get pod -n demo sample-sdb-master-aggregator-0 -oyaml | grep podIP
+$ kubectl get pod -n demo sample-sdb-aggregator-0 -oyaml | grep podIP
   podIP: 10.244.0.14
-$ kubectl get secrets -n demo sample-sdb-root-cred -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo sample-sdb-auth -o jsonpath='{.data.username}' | base64 -d
   root
-$ kubectl get secrets -n demo sample-sdb-root-cred -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo sample-sdb-auth -o jsonpath='{.data.password}' | base64 -d
   J0h_BUdJB8mDO31u
 ```
-we will exec into the pod `sample-sdb-master-aggregator-0` and connect to the database using username and password
+we will exec into the pod `sample-sdb-aggregator-0` and connect to the database using username and password
 
 ```bash
 $ kubectl exec -it -n demo sample-sdb-aggregator-0 -- bash
 Defaulting container name to singlestore.
 Use 'kubectl describe pod/sample-sdb-aggregator-0 -n demo' to see all of the containers in this pod.
 
-[memsql@sample-sdb-master-aggregator-0 /]$ memsql -uroot -p"J0h_BUdJB8mDO31u"
+[memsql@sample-sdb-aggregator-0 /]$ memsql -uroot -p"J0h_BUdJB8mDO31u"
 singlestore-client: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 1114

--- a/docs/guides/singlestore/concepts/appbinding.md
+++ b/docs/guides/singlestore/concepts/appbinding.md
@@ -77,7 +77,7 @@ spec:
         restoreTask:
           name: ""
   secret:
-    name: sdb-root-cred
+    name: sdb-auth
   type: kubedb.com/singlestore
   version: 8.9.3
 ```

--- a/docs/guides/singlestore/configuration/podtemplating/index.md
+++ b/docs/guides/singlestore/configuration/podtemplating/index.md
@@ -596,8 +596,8 @@ Containers:
       cpu:     500m
       memory:  2Gi
     Environment:
-      ROOT_USERNAME:        <set to the key 'username' in secret 'sdb-without-tolerations-root-cred'>  Optional: false
-      ROOT_PASSWORD:        <set to the key 'password' in secret 'sdb-without-tolerations-root-cred'>  Optional: false
+      ROOT_USERNAME:        <set to the key 'username' in secret 'sdb-without-tolerations-auth'>  Optional: false
+      ROOT_PASSWORD:        <set to the key 'password' in secret 'sdb-without-tolerations-auth'>  Optional: false
       SINGLESTORE_LICENSE:  <set to the key 'password' in secret 'license-secret'>                     Optional: false
       LICENSE_KEY:          <set to the key 'password' in secret 'license-secret'>                     Optional: false
       HOST_IP:               (v1:status.hostIP)

--- a/docs/guides/singlestore/initialization/using-script/index.md
+++ b/docs/guides/singlestore/initialization/using-script/index.md
@@ -150,7 +150,7 @@ metadata:
   uid: ccfe9d0e-6f13-4187-b652-4e157a21568e
 spec:
   authSecret:
-    name: sdb-sample-root-cred
+    name: sdb-sample-auth
   deletionPolicy: WipeOut
   healthChecker:
     failureThreshold: 1

--- a/docs/guides/singlestore/quickstart/quickstart.md
+++ b/docs/guides/singlestore/quickstart/quickstart.md
@@ -164,7 +164,7 @@ data-sdb-quickstart-aggregator-0          Bound    pvc-75057e3d-e1d7-4770-905b-6
 $ kubectl get pv -n demo
 NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                          STORAGECLASS   VOLUMEATTRIBUTESCLASS   REASON   AGE
 pvc-4f45c51b-47d4-4254-8275-782bf3588667   10Gi       RWO            Delete           Bound    demo/data-sdb-quickstart-leaf-0                standard       <unset>                          87s
-pvc-75057e3d-e1d7-4770-905b-6049f2edbcde   1Gi        RWO            Delete           Bound    demo/data-sdb-quickstart-master-aggregator-0   standard       <unset>                          91s
+pvc-75057e3d-e1d7-4770-905b-6049f2edbcde   1Gi        RWO            Delete           Bound    demo/data-sdb-quickstart-aggregator-0   standard       <unset>                          91s
 pvc-769e68f4-80a9-4e3e-b2bc-e974534b9dee   10Gi       RWO            Delete           Bound    demo/data-sdb-quickstart-leaf-1                standard       <unset>                          80s
 $ kubectl get service -n demo
 NAME                  TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)                         AGE
@@ -194,7 +194,7 @@ metadata:
   uid: 29d6a814-e801-45b5-8217-b59fc77d84e5
 spec:
   authSecret:
-    name: sdb-quickstart-root-cred
+    name: sdb-quickstart-auth
   healthChecker:
     failureThreshold: 1
     periodSeconds: 10
@@ -397,28 +397,28 @@ status:
 
 ## Connect with SingleStore database
 
-KubeDB operator has created a new Secret called `sdb-quickstart-root-cred` *(format: {singlestore-object-name}-root-cred)* for storing the password for `singlestore` superuser. This secret contains a `username` key which contains the *username* for SingleStore superuser and a `password` key which contains the *password* for SingleStore superuser.
+KubeDB operator has created a new Secret called `sdb-quickstart-auth` *(format: {singlestore-object-name}-auth)* for storing the password for `singlestore` superuser. This secret contains a `username` key which contains the *username* for SingleStore superuser and a `password` key which contains the *password* for SingleStore superuser.
 
 If you want to use an existing secret please specify that when creating the SingleStore object using `spec.authSecret.name`. While creating this secret manually, make sure the secret contains these two keys containing data `username` and `password` and also make sure of using `root` as value of `username`. For more details see [here](/docs/guides/mysql/concepts/database/index.md#specdatabasesecret).
 
-Now, we need `username` and `password` to connect to this database from `kubectl exec` command. In this example  `sdb-quickstart-root-cred` secret holds username and password
+Now, we need `username` and `password` to connect to this database from `kubectl exec` command. In this example  `sdb-quickstart-auth` secret holds username and password
 
 ```bash
-$ kubectl get pod -n demo sdb-quickstart-master-aggregator-0 -oyaml | grep podIP
+$ kubectl get pod -n demo sdb-quickstart-aggregator-0 -oyaml | grep podIP
   podIP: 10.244.0.14
-$ kubectl get secrets -n demo sdb-quickstart-root-cred -o jsonpath='{.data.\username}' | base64 -d
+$ kubectl get secrets -n demo sdb-quickstart-auth -o jsonpath='{.data.username}' | base64 -d
   root
-$ kubectl get secrets -n demo sdb-quickstart-root-cred -o jsonpath='{.data.\password}' | base64 -d
+$ kubectl get secrets -n demo sdb-quickstart-auth -o jsonpath='{.data.password}' | base64 -d
   J0h_BUdJB8mDO31u
 ```
-we will exec into the pod `sdb-quickstart-master-aggregator-0` and connect to the database using username and password
+we will exec into the pod `sdb-quickstart-aggregator-0` and connect to the database using username and password
 
 ```bash
 $ kubectl exec -it -n demo sdb-quickstart-aggregator-0 -- bash
   Defaulting container name to singlestore.
   Use 'kubectl describe pod/sdb-quickstart-aggregator-0 -n demo' to see all of the containers in this pod.
   
-  [memsql@sdb-quickstart-master-aggregator-0 /]$ memsql -uroot -p"J0h_BUdJB8mDO31u"
+  [memsql@sdb-quickstart-aggregator-0 /]$ memsql -uroot -p"J0h_BUdJB8mDO31u"
   singlestore-client: [Warning] Using a password on the command line interface can be insecure.
   Welcome to the MySQL monitor.  Commands end with ; or \g.
   Your MySQL connection id is 1114
@@ -501,12 +501,12 @@ Now, run the following command to get all singlestore resources in `demo` namesp
 ```bash
 $ kubectl get petset,svc,secret,pvc -n demo
 NAME                              TYPE                       DATA   AGE
-secret/sdb-quickstart-root-cred   kubernetes.io/basic-auth   2      3m35s
+secret/sdb-quickstart-auth   kubernetes.io/basic-auth   2      3m35s
 
 NAME                                                            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
 persistentvolumeclaim/data-sdb-quickstart-leaf-0                Bound    pvc-389f40a8-09bc-4724-aa52-94705d56ff77   1Gi        RWO            standard       <unset>                 3m18s
 persistentvolumeclaim/data-sdb-quickstart-leaf-1                Bound    pvc-8dfbf04e-41a8-4cdd-ba14-7ad42d8701bb   1Gi        RWO            standard       <unset>                 3m11s
-persistentvolumeclaim/data-sdb-quickstart-master-aggregator-0   Bound    pvc-c4f7d255-7307-4455-b195-70c71b81706f   1Gi        RWO            standard       <unset>                 3m29s
+persistentvolumeclaim/data-sdb-quickstart-aggregator-0   Bound    pvc-c4f7d255-7307-4455-b195-70c71b81706f   1Gi        RWO            standard       <unset>                 3m29s
 
 ```
 
@@ -532,7 +532,7 @@ Now, run the following command to get all singlestore resources in `demo` namesp
 ```bash
 $ kubectl get petset,svc,secret,pvc -n demo
 NAME                              TYPE                       DATA   AGE
-secret/sdb-quickstart-root-cred   kubernetes.io/basic-auth   2      17m
+secret/sdb-quickstart-auth   kubernetes.io/basic-auth   2      17m
 
 ```
 

--- a/docs/guides/singlestore/tls/configure/index.md
+++ b/docs/guides/singlestore/tls/configure/index.md
@@ -204,7 +204,7 @@ Let's check the tls-secrets have created,
 ```bash
 $ kubectl get secret -n demo | grep sdb-tls
 sdb-tls-client-cert   kubernetes.io/tls          3      5m41s
-sdb-tls-root-cred     kubernetes.io/basic-auth   2      5m41s
+sdb-tls-auth     kubernetes.io/basic-auth   2      5m41s
 sdb-tls-server-cert   kubernetes.io/tls 
 ```
 


### PR DESCRIPTION
These fixes were found by executing the SingleStore guides on a live KubeDB v2026.6.19 cluster and confirming the correct values against the source repos (`kubedb/apimachinery`, `kubedb/singlestore`) and observed cluster state.

## Fixes

1. Wrong credential secret name: `-root-cred` -> `-auth`
   - The docs call the operator-created credential secret `<name>-root-cred`. The operator actually creates `<name>-auth` (basic-auth, keys `username`/`password`).
   - Confirmed by source `apimachinery/apis/kubedb/v1alpha2/singlestore_helpers.go` (`GetAuthSecretName()` -> `<name>-auth`), by the AppBinding reference (`singlestore/pkg/controller/appbinding.go` `getAuthSecretRef`), by the pod `ROOT_USERNAME/ROOT_PASSWORD` env (valueFrom `sdb-quickstart-auth`), and by the cluster (only `sdb-quickstart-auth` exists).
   - Files: quickstart, clustering, initialization/using-script, configuration/podtemplating, concepts/appbinding, tls/configure, backup/kubestash/logical, backup/kubestash/application-level.

2. Stray backslash in secret-read commands
   - `jsonpath='{.data.\username}'` / `{.data.\password}'` return garbage. Corrected to `{.data.username}` / `{.data.password}`.
   - Verified on cluster: corrected command returns `root` and the real password.
   - Files: quickstart, clustering.

3. Wrong aggregator pod/PVC name: `-master-aggregator-` -> `-aggregator-`
   - Docs reference pod/PVC `<name>-master-aggregator-0`. Actual name is `<name>-aggregator-0` (petset `<name>-aggregator`).
   - Verified on cluster: pods `sdb-quickstart-aggregator-0`, `sdb-quickstart-leaf-0/1`.
   - Files: quickstart, clustering.

## Verification

Deployed the quickstart on the cluster; the operator created `sdb-quickstart-auth`; the corrected `kubectl get secret ... -o jsonpath='{.data.username}' | base64 -d` returned `root` and the password, and the pod name matched `sdb-quickstart-aggregator-0`. Secret-name and AppBinding-secret fixes for the remaining guides were confirmed against the source repos listed above.

No em-dashes. No version references were changed (none were wrong).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SingleStore guides and quickstart examples to use the current authentication secret naming convention.
  * Corrected example commands, YAML snippets, and output samples across backup, restore, clustering, initialization, TLS, and pod templating tutorials.
  * Aligned deletion-policy and connectivity walkthroughs with the latest secret and resource names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->