### PR TITLE
docs(qdrant): fix incorrect commands, fields, and samples found by executing the guides

### DIFF
--- a/docs/examples/qdrant/configuration/qdrant.yaml
+++ b/docs/examples/qdrant/configuration/qdrant.yaml
@@ -9,7 +9,7 @@ spec:
   configuration:
     secretName: qdrant-configuration
   storage:
-    storageClassName: "longhorn"
+    storageClassName: "standard"
     accessModes:
       - ReadWriteOnce
     resources:

--- a/docs/examples/qdrant/monitoring/qdrant-monitoring.yaml
+++ b/docs/examples/qdrant/monitoring/qdrant-monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   version: "1.17.0"
   storage:
-    storageClassName: "longhorn"
+    storageClassName: "standard"
     accessModes:
     - ReadWriteOnce
     resources:

--- a/docs/examples/qdrant/rotate-auth/custom-auth-secret.yaml
+++ b/docs/examples/qdrant/rotate-auth/custom-auth-secret.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 stringData:
   api-key: MyCus0mAPIKey
+  read-only-api-key: MyCus0mReadOnlyKey
 kind: Secret
 metadata:
   name: my-custom-auth-secret

--- a/docs/examples/qdrant/scaling/horizontal-scaling/qdrant.yaml
+++ b/docs/examples/qdrant/scaling/horizontal-scaling/qdrant.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: demo
 spec:
   version: "1.17.0"
+  mode: Distributed
   replicas: 3
   storage:
     storageClassName: "standard"

--- a/docs/guides/qdrant/configuration/using-config-file.md
+++ b/docs/guides/qdrant/configuration/using-config-file.md
@@ -110,7 +110,7 @@ spec:
   configuration:
     secretName: qdrant-configuration
   storage:
-    storageClassName: "longhorn"
+    storageClassName: "standard"
     accessModes:
       - ReadWriteOnce
     resources:
@@ -167,10 +167,12 @@ spec:
   replicas: 3
   configuration:
     inline:
-      log_level: DEBUG
-      max_request_size_mb: "64"
+      config.yaml: |
+        log_level: DEBUG
+        service:
+          max_request_size_mb: 64
   storage:
-    storageClassName: "longhorn"
+    storageClassName: "standard"
     accessModes:
       - ReadWriteOnce
     resources:
@@ -179,7 +181,7 @@ spec:
   deletionPolicy: WipeOut
 ```
 
-> **Note:** The `inline` field is a `map[string]string`, so values must be strings. To set the config key `max_request_size_mb` to `64`, write `max_request_size_mb: "64"`. The config Secret method (shown above) supports full nested YAML structure.
+> **Note:** The `inline` field is a `map[string]string` keyed by config file name. Use the key `config.yaml` and put the full Qdrant configuration (nested YAML is supported) as its string value, exactly as you would in the config Secret. Bare config keys such as `log_level` placed directly under `inline` are ignored.
 
 When both `spec.configuration.secretName` and `spec.configuration.inline` are set, the inline values override the corresponding keys from the config Secret. Keys not specified in inline retain their values from the config Secret.
 

--- a/docs/guides/qdrant/migration/storageMigration.md
+++ b/docs/guides/qdrant/migration/storageMigration.md
@@ -90,12 +90,16 @@ persistentvolumeclaim/data-sample-qdrant-2   Bound    pvc-a75bd538-8a71-4f62-8d3
 The database is `Ready` and all the `PersistentVolumeClaim` uses `standard` StorageClass. Let's create a collection and insert some data.
 
 ```bash
+# get the API key from the auth secret
+$ export API_KEY=$(kubectl get secret -n demo sample-qdrant-auth -o jsonpath='{.data.api-key}' | base64 -d)
+
 # port-forward the Qdrant service
 $ kubectl port-forward -n demo svc/sample-qdrant 6333:6333 &
 Forwarding from 127.0.0.1:6333 -> 6333
 
 # create a collection
 $ curl -X PUT 'http://localhost:6333/collections/demo_vectors' \
+  -H "api-key: $API_KEY" \
   -H 'Content-Type: application/json' \
   -d '{
     "vectors": { "size": 4, "distance": "Cosine" }
@@ -104,6 +108,7 @@ $ curl -X PUT 'http://localhost:6333/collections/demo_vectors' \
 
 # insert points
 $ curl -X PUT 'http://localhost:6333/collections/demo_vectors/points' \
+  -H "api-key: $API_KEY" \
   -H 'Content-Type: application/json' \
   -d '{
     "points": [
@@ -114,7 +119,8 @@ $ curl -X PUT 'http://localhost:6333/collections/demo_vectors/points' \
 {"result":null,"status":"ok","time":0.045}
 
 # verify points count
-$ curl 'http://localhost:6333/collections/demo_vectors'
+$ curl 'http://localhost:6333/collections/demo_vectors' \
+  -H "api-key: $API_KEY"
 {"result":{"status":"green","vectors_count":2,"segments_count":4,...},"status":"ok","time":0.001}
 ```
 
@@ -180,12 +186,16 @@ data-sample-qdrant-2   Bound    pvc-a75bd538-8a71-4f62-8d38-3f4e42ffb225   2Gi  
 The `PersistentVolumeClaim` StorageClass has changed to `longhorn-custom`. Now, we will verify that the data remains intact after the `StorageMigration` operation.
 
 ```bash
+# get the API key from the auth secret
+$ export API_KEY=$(kubectl get secret -n demo sample-qdrant-auth -o jsonpath='{.data.api-key}' | base64 -d)
+
 # port-forward the Qdrant service
 $ kubectl port-forward -n demo svc/sample-qdrant 6333:6333 &
 Forwarding from 127.0.0.1:6333 -> 6333
 
 # check the collection exists and data is intact
-$ curl 'http://localhost:6333/collections/demo_vectors'
+$ curl 'http://localhost:6333/collections/demo_vectors' \
+  -H "api-key: $API_KEY"
 {"result":{"status":"green","vectors_count":2,"segments_count":4,...},"status":"ok","time":0.001}
 ```
 

--- a/docs/guides/qdrant/monitoring/using-prometheus-operator.md
+++ b/docs/guides/qdrant/monitoring/using-prometheus-operator.md
@@ -179,7 +179,7 @@ metadata:
 spec:
   version: "1.17.0"
   storage:
-    storageClassName: "longhorn"
+    storageClassName: "standard"
     accessModes:
       - ReadWriteOnce
     resources:

--- a/docs/guides/qdrant/quickstart/quickstart.md
+++ b/docs/guides/qdrant/quickstart/quickstart.md
@@ -20,7 +20,7 @@ This tutorial will show you how to use KubeDB to run a Qdrant database.
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
 
-- Now, install KubeDB operator in your cluster following the steps [here](/docs/setup/README.md)  and make sure install with helm command including `--set global.featureGates.Qdrant=true` to ensure Qdrant CRD installation.
+- Now, install KubeDB operator in your cluster following the steps in the [KubeDB setup guide](/docs/setup/README.md) and make sure the Helm command includes `--set global.featureGates.Qdrant=true` to ensure Qdrant CRD installation.
 
 - To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
 

--- a/docs/guides/qdrant/quickstart/quickstart.md
+++ b/docs/guides/qdrant/quickstart/quickstart.md
@@ -20,7 +20,7 @@ This tutorial will show you how to use KubeDB to run a Qdrant database.
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
 
-- Now, install KubeDB operator in your cluster following the steps [here](/docs/setup/README.md)  and make sure install with helm command including `--set global.featureGates.Qdrant=true` to ensure MSSQLServer CRD installation.
+- Now, install KubeDB operator in your cluster following the steps [here](/docs/setup/README.md)  and make sure install with helm command including `--set global.featureGates.Qdrant=true` to ensure Qdrant CRD installation.
 
 - To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial.
 

--- a/docs/guides/qdrant/rotate-auth/rotate-auth.md
+++ b/docs/guides/qdrant/rotate-auth/rotate-auth.md
@@ -146,12 +146,15 @@ You can also rotate the authentication credentials using a custom secret that yo
 apiVersion: v1
 stringData:
   api-key: MyCus0mAPIKey
+  read-only-api-key: MyCus0mReadOnlyKey
 kind: Secret
 metadata:
   name: my-custom-auth-secret
   namespace: demo
 type: Opaque
 ```
+
+> **Note:** The custom auth secret must contain both `api-key` and `read-only-api-key`. If `read-only-api-key` is missing, the `RotateAuth` OpsRequest will not complete.
 
 Let's create the `Secret` we have shown above:
 

--- a/docs/guides/qdrant/scaling/horizontal-scaling/horizontal-scaling.md
+++ b/docs/guides/qdrant/scaling/horizontal-scaling/horizontal-scaling.md
@@ -56,6 +56,7 @@ metadata:
   namespace: demo
 spec:
   version: "1.17.0"
+  mode: Distributed
   replicas: 3
   storage:
     storageClassName: "standard"

--- a/docs/guides/qdrant/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/qdrant/scaling/vertical-scaling/vertical-scaling.md
@@ -103,8 +103,8 @@ $ kubectl get pod -n demo qdrant-sample-0 -o json | jq '.spec.containers[0].reso
     "memory": "1Gi"
   },
   "requests": {
-    "cpu": "250m",
-    "memory": "512Mi"
+    "cpu": "500m",
+    "memory": "1Gi"
   }
 }
 ```


### PR DESCRIPTION
Fixes found by executing the Qdrant guides against a live KubeDB v2026.6.19 cluster (kubectl dba v0.52.0). Each fix was confirmed against the source of truth (kubedb/qdrant, kubedb/apimachinery) or by re-running on the cluster.

## Fixes

1. **quickstart/quickstart.md** - the "Before You Begin" note said `--set global.featureGates.Qdrant=true` ensures "MSSQLServer CRD installation" (copy-paste from the MSSQLServer docs). Now reads "Qdrant CRD installation".

2. **configuration/using-config-file.md** (+ `examples/qdrant/configuration/qdrant.yaml`) - the inline config example was wrong. It showed bare keys under `spec.configuration.inline` (`log_level`, `max_request_size_mb`). The operator reads `Inline["config.yaml"]` (qdrant/pkg/controller/config.go:130, key `QdrantConfigFileName` = `config.yaml`), so bare keys are silently ignored. Applied as documented, the rendered `/qdrant/config/config.yaml` was just `log_level: INFO` (default). Corrected to key the map by `config.yaml` with the full config as the value, and fixed the accompanying Note. Re-verified on cluster: the corrected form renders `log_level: DEBUG` + `service.max_request_size_mb: 64`. Also changed the unexplained `storageClassName: "longhorn"` to the repo-standard `standard`.

3. **rotate-auth/rotate-auth.md** (+ `examples/qdrant/rotate-auth/custom-auth-secret.yaml`) - the custom auth secret only had `api-key`. The RotateAuth OpsRequest then hung in `Progressing` forever (ops-manager: `Failed to ensure Authentication secret err="read-only API key is missing"`; qdrant/pkg/controller/secret.go:232 requires `read-only-api-key`, and pkg/ops/rotate_auth.go reads both keys from the user secret). Added `read-only-api-key` to the sample and a note. Re-verified: with both keys the ops completes and the auth secret switches to the custom secret.

4. **scaling/vertical-scaling/vertical-scaling.md** - the "before" pod resources were shown as `requests cpu 250m / memory 512Mi`. The actual default (apimachinery constants.go DefaultResources) is `requests cpu 500m / memory 1Gi, limits memory 1Gi`, which is also what the pod reports. Corrected the shown output.

5. **scaling/horizontal-scaling/horizontal-scaling.md** (+ `examples/qdrant/scaling/horizontal-scaling/qdrant.yaml`) - the sample Qdrant CR did not set `mode`, so it defaulted to `Standalone` (apimachinery qdrant_helpers.go). `/cluster` was then `disabled` with 0 peers, and the HorizontalScaling OpsRequest hung indefinitely on RebalanceShards ("new peers haven't joined the cluster"). Added `mode: Distributed`. Re-verified: the corrected sample forms a 3-peer cluster, and scale up 3->5 and scale down 5->4 both complete.

6. **monitoring/using-prometheus-operator.md** (+ `examples/qdrant/monitoring/qdrant-monitoring.yaml`) - changed the unexplained `storageClassName: "longhorn"` to the repo-standard `standard`, consistent with the rest of the guides.

7. **migration/storageMigration.md** - the `curl` commands omitted the `api-key` header and there was no step to fetch the key. Qdrant enforces the API key: GET `/collections` without it returns HTTP 401 ("Must provide an API key or an Authorization bearer token"), verified on the cluster. Added an `API_KEY` fetch step and the `-H "api-key: $API_KEY"` header to each curl, matching the quickstart and backup guides.

## Notes

- StorageClass `standard` is kept as the canonical placeholder repo-wide; only the two unexplained `longhorn` outliers (configuration, monitoring) were normalized to `standard`. volume-expansion keeps `longhorn` because that guide explains it (needs allowVolumeExpansion).
- Guides executed and passing: quickstart, configuration, distributed-deployment, restart, rotate-auth (operator + custom), reconfigure (secret/applyConfig/removeCustomConfig), update-version (1.16.2 -> 1.17.0), vertical-scaling, horizontal-scaling, tls, reconfigure-tls (add/rotate/remove). Env-gapped (validated at schema level only): volume-expansion, migration, monitoring, autoscaler (compute/storage), backup (logical/volume-snapshot).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Qdrant examples and guides to use the `standard` storage class in multiple manifests.
  * Expanded auth rotation documentation to include and require a `read-only-api-key`.
  * Improved the Qdrant migration guide to use API authentication for validation calls.
  * Clarified horizontal scaling setup by adding `spec.mode: Distributed`.
  * Corrected Qdrant quickstart wording for the operator installation step.
  * Updated vertical scaling output to match revised CPU and memory requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->