### PR TITLE
docs(pgbouncer): fix broken commands, fields, and example refs found by executing the guides

### DIFF
--- a/docs/examples/pgbouncer/monitoring/builtin-prom-pb.yaml
+++ b/docs/examples/pgbouncer/monitoring/builtin-prom-pb.yaml
@@ -1,19 +1,19 @@
 apiVersion: kubedb.com/v1
 kind: PgBouncer
 metadata:
-  name: pgbouncer-server
+  name: builtin-prom-pb
   namespace: demo
 spec:
-  version: "1.24.0"
   replicas: 1
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"
     databaseRef:
-      name: "quick-postgres"
+      name: "ha-postgres"
       namespace: demo
   connectionPool:
-    maxClientConnections: 20
-    reservePoolSize: 5
+    poolMode: session
+    port: 5432
   monitor:
     agent: prometheus.io/builtin

--- a/docs/examples/pgbouncer/monitoring/coreos-prom-pb.yaml
+++ b/docs/examples/pgbouncer/monitoring/coreos-prom-pb.yaml
@@ -1,20 +1,21 @@
 apiVersion: kubedb.com/v1
 kind: PgBouncer
 metadata:
-  name: pgbouncer-server
+  name: coreos-prom-pb
   namespace: demo
 spec:
-  version: "1.24.0"
   replicas: 1
+  version: "1.24.0"
   database:
     syncUsers: true
     databaseName: "postgres"
     databaseRef:
-      name: "quick-postgres"
+      name: "ha-postgres"
       namespace: demo
   connectionPool:
-    maxClientConnections: 20
-    reservePoolSize: 5
+    poolMode: session
+    port: 5432
+  deletionPolicy: WipeOut
   monitor:
     agent: prometheus.io/operator
     prometheus:

--- a/docs/examples/pgbouncer/private-registry/pvt-pgbouncerversion.yaml
+++ b/docs/examples/pgbouncer/private-registry/pvt-pgbouncerversion.yaml
@@ -1,23 +1,10 @@
 apiVersion: catalog.kubedb.com/v1alpha1
-kind: PostgresVersion
+kind: PgBouncerVersion
 metadata:
-  name: "13.13"
+  name: "pvt-1.17.0"
 spec:
-  coordinator:
-    image: PRIVATE_REGISTRY/pg-coordinator:v0.1.0
-  db:
-    image: PRIVATE_REGISTRY/postgres:13.2-alpine
-  distribution: PostgreSQL
   exporter:
-    image: PRIVATE_REGISTRY/postgres-exporter:v0.9.0
-  initContainer:
-    image: PRIVATE_REGISTRY/postgres-init:0.1.0
-  podSecurityPolicies:
-    databasePolicyName: postgres-db
-  stash:
-    addon:
-      backupTask:
-        name: postgres-backup-13.1
-      restoreTask:
-        name: postgres-restore-13.1
-  version: "13.13"
+    image: PRIVATE_REGISTRY/pgbouncer_exporter:v0.1.1
+  pgBouncer:
+    image: PRIVATE_REGISTRY/pgbouncer:1.17.0
+  version: 1.17.0

--- a/docs/examples/pgbouncer/private-registry/pvt-reg-pgbouncer.yaml
+++ b/docs/examples/pgbouncer/private-registry/pvt-reg-pgbouncer.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubedb.com/v1
 kind: PgBouncer
 metadata:
-  name: pgbouncer-server
+  name: pvt-reg-pgbouncer
   namespace: demo
 spec:
   version: "1.17.0"

--- a/docs/examples/pgbouncer/reconfigure/pb-custom-config.yaml
+++ b/docs/examples/pgbouncer/reconfigure/pb-custom-config.yaml
@@ -12,6 +12,8 @@ spec:
     databaseRef:
       name: "ha-postgres"
       namespace: demo
+  configSecret:
+    name: pb-custom-config
   connectionPool:
     poolMode: session
     port: 5432

--- a/docs/examples/pgbouncer/tls/pgbouncer-ssl.yaml
+++ b/docs/examples/pgbouncer/tls/pgbouncer-ssl.yaml
@@ -10,7 +10,7 @@ spec:
     syncUsers: true
     databaseName: "postgres"
     databaseRef:
-      name: "pg"
+      name: "ha-postgres"
       namespace: demo
   connectionPool:
     poolMode: session
@@ -25,7 +25,7 @@ spec:
   tls:
     issuerRef:
       apiGroup: cert-manager.io
-      name: pb-ca-issuer
+      name: pgbouncer-ca-issuer
       kind: Issuer
     certificates:
       - alias: server

--- a/docs/guides/pgbouncer/private-registry/using-private-registry.md
+++ b/docs/guides/pgbouncer/private-registry/using-private-registry.md
@@ -36,7 +36,7 @@ namespace/demo created
 - You have to push the required images from KubeDB's [Docker hub account](https://hub.docker.com/r/kubedb/) into your private registry. For pgbouncer, push `SERVER_IMAGE`, `EXPORTER_IMAGE` of following PgBouncerVersions, where `deprecated` is not true, to your private registry.
 
   ```bash
-  $ kubectl get pgbouncerversions -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,DB_IMAGE:.spec.server.image,EXPORTER_IMAGE:.spec.exporter.image,DEPRECATED:.spec.deprecated
+  $ kubectl get pgbouncerversions -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,DB_IMAGE:.spec.pgBouncer.image,EXPORTER_IMAGE:.spec.exporter.image,DEPRECATED:.spec.deprecated
   NAME     VERSION   SERVER_IMAGE              EXPORTER_IMAGE                     DEPRECATED
   1.17.0   1.17.0    kubedb/pgbouncer:1.17.0   kubedb/pgbouncer_exporter:v0.1.1   false
   ```

--- a/docs/guides/pgbouncer/quickstart/quickstart.md
+++ b/docs/guides/pgbouncer/quickstart/quickstart.md
@@ -1,5 +1,5 @@
 ---
-bastitle: PgBouncer Quickstart
+title: PgBouncer Quickstart
 menu:
   docs_{{ .version }}:
     identifier: pb-quickstart-quickstart

--- a/docs/guides/pgbouncer/reconfigure/reconfigure-pgbouncer.md
+++ b/docs/guides/pgbouncer/reconfigure/reconfigure-pgbouncer.md
@@ -80,6 +80,8 @@ spec:
     databaseRef:
       name: "ha-postgres"
       namespace: demo
+  configSecret:
+    name: pb-custom-config
   connectionPool:
     poolMode: session
     port: 5432

--- a/docs/guides/pgbouncer/rotateauth/rotateauth.md
+++ b/docs/guides/pgbouncer/rotateauth/rotateauth.md
@@ -110,7 +110,7 @@ Here,
 
 Let's create the `PgBouncerOpsRequest` CR we have shown above,
 ```shell
- $kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/pgbouncer/rotate-auth/rotate-auth.yaml
+ $kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/pgbouncer/rotateauth/rotateauth.yaml
  pgbounceropsrequest.ops.kubedb.com/pbops-rotate-auth-generated created
 ```
 Let's wait for `PgBouncerOpsrequest` to be `Successful`. Run the following command to watch `PgBouncerOpsrequest` CRO
@@ -277,7 +277,7 @@ Here,
 Let's create the `PgBouncerOpsRequest` CR we have shown above,
 
 ```shell
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/pgbouncer/rotate-auth/rotateauthuser.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/pgbouncer/rotateauth/rotateauthuser.yaml
 pgbounceropsrequest.ops.kubedb.com/pbops-rotate-auth-user created
 ```
 Let’s wait for `PgBouncerOpsRequest` to be Successful. Run the following command to watch `PgBouncerOpsRequest` CRO:

--- a/docs/guides/pgbouncer/tls/configure_ssl.md
+++ b/docs/guides/pgbouncer/tls/configure_ssl.md
@@ -130,7 +130,7 @@ spec:
     syncUsers: true
     databaseName: "postgres"
     databaseRef:
-      name: "pg"
+      name: "ha-postgres"
       namespace: demo
   connectionPool:
     poolMode: session
@@ -145,7 +145,7 @@ spec:
   tls:
     issuerRef:
       apiGroup: cert-manager.io
-      name: pb-ca-issuer
+      name: pgbouncer-ca-issuer
       kind: Issuer
     certificates:
       - alias: server


### PR DESCRIPTION
These fixes were found by executing every PgBouncer guide on a live KubeDB v2026.6.19 cluster (kubectl dba v0.52.0) and comparing real output to the docs.

## Fixes (guide: wrong -> right, how verified)

1. **quickstart/quickstart.md** front-matter `bastitle:` -> `title:`. Every other guide uses `title:`; the typo broke the page title metadata.

2. **reconfigure/reconfigure-pgbouncer.md** + `examples/pgbouncer/reconfigure/pb-custom-config.yaml`: added missing `spec.configSecret.name: pb-custom-config`. Without it the deployed pod showed `auth_type = md5`, contradicting the guide's claimed `scram-sha-256`. Field confirmed in apimachinery `apis/kubedb/v1/pgbouncer_types.go` (`configSecret`). After adding it, the pod serves `auth_type = scram-sha-256`. Both reconfigure OpsRequests (configSecret swap, applyConfig) then verified Successful.

3. **rotateauth/rotateauth.md**: fixed 2 broken example paths `docs/examples/pgbouncer/rotate-auth/rotate-auth.yaml` -> `rotateauth/rotateauth.yaml` and `rotate-auth/rotateauthuser.yaml` -> `rotateauth/rotateauthuser.yaml` (the `rotate-auth/` directory does not exist). Both RotateAuth ops (generated + user) run to Successful with the corrected files.

4. **tls/configure_ssl.md** + `examples/pgbouncer/tls/pgbouncer-ssl.yaml`: `databaseRef.name "pg"` -> `"ha-postgres"` and `tls.issuerRef.name pb-ca-issuer` -> `pgbouncer-ca-issuer`. Applying as-is was rejected by the admission webhook (`Issuer.cert-manager.io "pb-ca-issuer" not found`); the guide creates issuer `pgbouncer-ca-issuer` and prepares `ha-postgres`. Corrected version provisions Ready with verify-ca and a working client-cert TLS connection.

5. **monitoring/using-builtin-prometheus.md** and **using-prometheus-operator.md**: the guides reference `builtin-prom-pb.yaml` / `coreos-prom-pb.yaml`, which did not exist (files were `*-prom-pgbouncer.yaml`) and whose content did not match the guides' inline YAML. Renamed the example files to the referenced names and aligned their content (name `builtin-prom-pb` / `coreos-prom-pb`, `databaseRef ha-postgres`). Builtin path verified: stats service + scrape annotations + served metrics endpoint.

6. **private-registry/using-private-registry.md**: `kubectl get pgbouncerversions ... .spec.server.image` returned `<none>`; corrected to `.spec.pgBouncer.image` (verified on cluster). `examples/pgbouncer/private-registry/pvt-pgbouncerversion.yaml` contained a `PostgresVersion` (wrong Kind) -> replaced with a `PgBouncerVersion` `pvt-1.17.0` matching the guide (schema validated via server dry-run). `pvt-reg-pgbouncer.yaml` resource name `pgbouncer-server` -> `pvt-reg-pgbouncer` to match the guide.

## Not fixed
- **initialization/gitsync.md**: git-sync sidecar correctly syncs the repo into the pod, but the init script is never executed (`my_table` is not created on pgbouncer or the backend). Could not determine whether this is a doc overclaim or a feature/image behavior issue, so left unchanged (flagged for maintainers).
- Env-limited guides (autoscaler, prometheus-operator monitoring scrape, virtual_secret, volume/storage) could not be fully exercised on this single-node cluster; example schemas validated where possible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PgBouncer examples and guides to use current resource names and paths.
  * Added examples for connecting to a high-availability PostgreSQL backend, using session pooling, and referencing the correct TLS issuer.
  * Expanded reconfiguration guidance to show loading PgBouncer settings from a secret.
  * Refreshed private registry and RotateAuth instructions to match the latest example locations and image references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->