### PR TITLE
docs(proxysql): fix guide errors found by executing the guides

### DIFF
--- a/docs/guides/proxysql/autoscaler/compute/cluster/index.md
+++ b/docs/guides/proxysql/autoscaler/compute/cluster/index.md
@@ -63,7 +63,7 @@ spec:
 ```
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/autoscaler/cluster/examples/sample-mysql.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/autoscaler/compute/cluster/examples/sample-mysql.yaml
 mysql.kubedb.com/mysql-server created
 ```
 

--- a/docs/guides/proxysql/backends/mysqlgrp/index.md
+++ b/docs/guides/proxysql/backends/mysqlgrp/index.md
@@ -62,7 +62,7 @@ spec:
 ```
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/backends/mysql/examples/sample-mysql.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/backends/mysqlgrp/examples/sample-mysql.yaml
 mysql.kubedb.com/mysql-server created
 ```
 
@@ -154,7 +154,7 @@ spec:
 ```
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/backends/mysql/examples/sample-proxysql.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/backends/mysqlgrp/examples/sample-proxysql.yaml
 proxysql.kubedb.com/mysql-proxy created
 ```
 
@@ -276,7 +276,7 @@ spec:
 Let's apply the yaml. 
 
 ```yaml
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/backends/mysql/examples/ubuntu.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/backends/mysqlgrp/examples/ubuntu.yaml
 deployment.apps/ubuntu created
 ```
 

--- a/docs/guides/proxysql/backends/xtradb-galera/external/index.md
+++ b/docs/guides/proxysql/backends/xtradb-galera/external/index.md
@@ -287,7 +287,7 @@ spec:
 ```
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/quickstart/xtradbext/examples/sample-proxysql-v1.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/backends/xtradb-galera/external/examples/sample-proxy-v1.yaml
   proxysql.kubedb.com/proxysql-server created
 ```
 
@@ -308,7 +308,7 @@ spec:
 ```
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/quickstart/xtradbext/examples/sample-proxysql-v1alpha2.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/backends/xtradb-galera/external/examples/sample-proxy-v1alpha2.yaml
   proxysql.kubedb.com/proxysql-server created
 ```
 
@@ -349,8 +349,8 @@ You can find the description of the associated objects here.
 Let's exec into the ProxySQL server pod and get into the admin panel. 
 
 ```bash
-$ kubectl exec -it -n demo proxy-mysql-0 -- bash                                                  11:20
-root@proxy-mysql-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032 --prompt="ProxySQLAdmin > " 
+$ kubectl exec -it -n demo proxy-server-0 -- bash                                                  11:20
+root@proxy-server-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032 --prompt="ProxySQLAdmin > " 
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 1204
 Server version: 8.0.35 (ProxySQL Admin Module)

--- a/docs/guides/proxysql/monitoring/builtin-prometheus/examples/proxysql.yaml
+++ b/docs/guides/proxysql/monitoring/builtin-prometheus/examples/proxysql.yaml
@@ -10,7 +10,7 @@ spec:
     name: mysql-grp
   syncUsers: true
   monitor:
-    agent: prometheus.io/operator
+    agent: prometheus.io/builtin
   deletionPolicy: WipeOut
   healthChecker:
     failureThreshold: 3

--- a/docs/guides/proxysql/monitoring/builtin-prometheus/index.md
+++ b/docs/guides/proxysql/monitoring/builtin-prometheus/index.md
@@ -65,7 +65,7 @@ spec:
 ```
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/monitoring/builtin-prometheus/example/mysql.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/monitoring/builtin-prometheus/examples/mysql.yaml
 mysql.kubedb.com/mysql-grp created 
 ```
 
@@ -88,7 +88,7 @@ spec:
     name: mysql-grp
   syncUsers: true
   monitor:
-    agent: prometheus.io/operator
+    agent: prometheus.io/builtin
   deletionPolicy: WipeOut
   healthChecker:
     failureThreshold: 3

--- a/docs/guides/proxysql/monitoring/prometheus-operator/index.md
+++ b/docs/guides/proxysql/monitoring/prometheus-operator/index.md
@@ -127,7 +127,7 @@ spec:
 ```
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/monitoring/builtin-prometheus/example/mysql.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/monitoring/prometheus-operator/examples/mysql.yaml
 mysql.kubedb.com/mysql-grp created 
 ```
 

--- a/docs/guides/proxysql/quickstart/mysqlgrp/index.md
+++ b/docs/guides/proxysql/quickstart/mysqlgrp/index.md
@@ -192,7 +192,7 @@ spec:
 ```
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/quickstart/mysqlgrp/examples/sample-proxysql.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/quickstart/mysqlgrp/examples/sample-proxysql-v1alpha2.yaml
   proxysql.kubedb.com/proxysql-server created
 ```
 

--- a/docs/guides/proxysql/quickstart/xtradbext/index.md
+++ b/docs/guides/proxysql/quickstart/xtradbext/index.md
@@ -287,7 +287,7 @@ spec:
 ```
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/quickstart/xtradbext/examples/sample-proxysql-v1.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/quickstart/xtradbext/examples/sample-proxy-v1.yaml
   proxysql.kubedb.com/proxysql-server created
 ```
 
@@ -308,7 +308,7 @@ spec:
 ```
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/quickstart/xtradbext/examples/sample-proxysql-v1alpha2.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/quickstart/xtradbext/examples/sample-proxy-v1alpha2.yaml
   proxysql.kubedb.com/proxysql-server created
 ```
 
@@ -349,8 +349,8 @@ You can find the description of the associated objects here.
 Let's exec into the ProxySQL server pod and get into the admin panel. 
 
 ```bash
-$ kubectl exec -it -n demo proxy-mysql-0 -- bash                                                  11:20
-root@proxy-mysql-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032 --prompt="ProxySQLAdmin > " 
+$ kubectl exec -it -n demo proxy-server-0 -- bash                                                  11:20
+root@proxy-server-0:/# mysql -uadmin -padmin -h127.0.0.1 -P6032 --prompt="ProxySQLAdmin > " 
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 1204
 Server version: 8.4.8 (ProxySQL Admin Module)

--- a/docs/guides/proxysql/restart/index.md
+++ b/docs/guides/proxysql/restart/index.md
@@ -61,7 +61,7 @@ spec:
 ```
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/backends/mysql/examples/sample-mysql.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/backends/mysqlgrp/examples/sample-mysql.yaml
 mysql.kubedb.com/mysql-server created
 ```
 
@@ -98,7 +98,7 @@ spec:
 ```
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/backends/mysql/examples/sample-proxysql.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/backends/mysqlgrp/examples/sample-proxysql.yaml
 proxysql.kubedb.com/mysql-proxy created
 ```
 

--- a/docs/guides/proxysql/scaling/horizontal-scaling/cluster/index.md
+++ b/docs/guides/proxysql/scaling/horizontal-scaling/cluster/index.md
@@ -61,7 +61,7 @@ spec:
 ```
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/scaling/horizontal-scaling/cluster/example/sample-mysql.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/scaling/horizontal-scaling/cluster/examples/sample-mysql.yaml
 mysql.kubedb.com/mysql-server created 
 ```
 
@@ -93,7 +93,7 @@ spec:
 Let's create the `ProxySQL` CR we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/scaling/horizontal-scaling/cluster/example/sample-proxysql.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/scaling/horizontal-scaling/cluster/examples/sample-proxysql.yaml
 proxysql.kubedb.com/proxy-server created
 ```
 
@@ -110,7 +110,7 @@ Let's check the number of replicas this cluster has from the ProxySQL object, nu
 ```bash
 $ kubectl get proxysql -n demo proxy-server -o json | jq '.spec.replicas'
 3
-$ kubectl get sts -n demo proxy-server -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo proxy-server -o json | jq '.spec.replicas'
 3
 ```
 
@@ -168,7 +168,7 @@ Here,
 Let's create the `ProxySQLOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/scaling/horizontal-scaling/cluster/example/proxyops-upscale.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/scaling/horizontal-scaling/cluster/examples/proxyops-upscale.yaml
 proxysqlopsrequest.ops.kubedb.com/scale-up created
 ```
 
@@ -190,7 +190,7 @@ We can see from the above output that the `ProxySQLOpsRequest` has succeeded. No
 ```bash
 $ kubectl get proxysql -n demo proxy-server -o json | jq '.spec.replicas'
 5
-$ kubectl get sts -n demo proxy-server -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo proxy-server -o json | jq '.spec.replicas'
 5
 ```
 
@@ -246,7 +246,7 @@ Here,
 Let's create the `ProxySQLOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/scaling/horizontal-scaling/cluster/example/proxyops-downscale.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/scaling/horizontal-scaling/cluster/examples/proxyops-downscale.yaml
 proxysqlopsrequest.ops.kubedb.com/scale-down created
 ```
 
@@ -268,7 +268,7 @@ We can see from the above output that the `ProxySQLOpsRequest` has succeeded. No
 ```bash
 $ kubectl get proxysql -n demo proxy-server -o json | jq '.spec.replicas' 
 4
-$ kubectl get sts -n demo proxy-server -o json | jq '.spec.replicas'
+$ kubectl get petset -n demo proxy-server -o json | jq '.spec.replicas'
 4
 ```
 

--- a/docs/guides/proxysql/tls/configure/index.md
+++ b/docs/guides/proxysql/tls/configure/index.md
@@ -176,7 +176,7 @@ $ kubectl get proxysql -n demo proxy-server
 NAME             VERSION       STATUS   AGE
 proxy-server   3.0.1-debian    Ready    5m48s
 
-$ kubectl get sts -n demo proxy-server
+$ kubectl get petset -n demo proxy-server
 NAME             READY   AGE
 proxy-server     3/3     7m5s
 ```
@@ -262,7 +262,7 @@ Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 mysql> create user 'test'@'%' identified by 'pass';
 Query OK, 0 rows affected (0.00 sec)
 
-mysql> grant all privileges on test.* to 'again'@'%';
+mysql> grant all privileges on test.* to 'test'@'%';
 Query OK, 0 rows affected (0.00 sec)
 
 mysql> flush privileges;

--- a/docs/guides/proxysql/update-version/cluster/index.md
+++ b/docs/guides/proxysql/update-version/cluster/index.md
@@ -139,7 +139,7 @@ Here,
 Let's create the `ProxySQLOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/update-version/cluster/examples/proxyops-update.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/proxysql/update-version/cluster/examples/proxyops-upgrade.yaml
 proxysqlopsrequest.ops.kubedb.com/proxyops-update created
 ```
 
@@ -164,7 +164,7 @@ Now, we are going to verify whether the `ProxySQL` and the related `PetSets` and
 $ kubectl get proxysql -n demo proxy-server -o=jsonpath='{.spec.version}{"\n"}'
 3.0.1-debian
 
-$ kubectl get sts -n demo proxy-server -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+$ kubectl get petset -n demo proxy-server -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
 kubedb/proxysql:3.0.1-debian@sha256....
 
 $ kubectl get pods -n demo proxy-server-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'


### PR DESCRIPTION
Ran every ProxySQL guide under \`docs/guides/proxysql/\` on a live KubeDB v2026.6.19 cluster (kubectl dba v0.52.0) and fixed the errors that broke the documented commands. Each fix was verified by cluster execution or by confirming the target file path exists on disk.

## Broken example raw-URLs (returned 404 vs the on-disk dirs)
- \`backends/mysqlgrp\` (x3) and \`restart\` (x2): \`backends/mysql/examples/\` -> \`backends/mysqlgrp/examples/\` (no \`backends/mysql\` dir exists).
- \`scaling/horizontal-scaling/cluster\` (x4): \`cluster/example/\` -> \`cluster/examples/\`.
- \`monitoring/builtin-prometheus\`: \`builtin-prometheus/example/mysql.yaml\` -> \`.../examples/mysql.yaml\`.
- \`monitoring/prometheus-operator\`: pointed at \`builtin-prometheus/example/mysql.yaml\` -> its own \`prometheus-operator/examples/mysql.yaml\`.
- \`quickstart/mysqlgrp\` (v1alpha2 block): \`sample-proxysql.yaml\` -> \`sample-proxysql-v1alpha2.yaml\`.
- \`quickstart/xtradbext\` (x2): \`sample-proxysql-v1*.yaml\` -> \`sample-proxy-v1*.yaml\`.
- \`backends/xtradb-galera/external\` (x2): cross-referenced \`quickstart/xtradbext/examples/sample-proxysql-v1*.yaml\` -> its own \`external/examples/sample-proxy-v1*.yaml\`.
- \`update-version/cluster\`: \`proxyops-update.yaml\` -> \`proxyops-upgrade.yaml\`.
- \`autoscaler/compute/cluster\`: \`autoscaler/cluster/examples/sample-mysql.yaml\` -> \`autoscaler/compute/cluster/examples/sample-mysql.yaml\`.

## Broken commands / wrong values (verified on cluster)
- \`kubectl get sts -n demo proxy-server ...\` returned \`NotFound\` because KubeDB provisions a PetSet, not a StatefulSet. Changed to \`kubectl get petset\` in \`update-version/cluster\` (x1), \`scaling/horizontal-scaling/cluster\` (x3), \`tls/configure\` (x1). Verified \`kubectl get petset ...\` returns the documented output.
- \`tls/configure\`: \`grant all privileges on test.* to 'again'@'%';\` fails with \`ERROR 1410\` on MySQL 8.4 (\`again\` was never created). Changed to \`to 'test'@'%'\`.
- \`quickstart/xtradbext\` and \`backends/xtradb-galera/external\`: exec target \`proxy-mysql-0\` does not exist; the pod is \`proxy-server-0\`.
- \`monitoring/builtin-prometheus\`: the ProxySQL sample used \`monitor.agent: prometheus.io/operator\` in a builtin-Prometheus guide. Changed to \`prometheus.io/builtin\` in both the inline YAML and \`examples/proxysql.yaml\`. Verified the builtin agent creates the documented annotated \`proxy-server-stats\` service (the operator agent needs the ServiceMonitor CRD the guide never installs).

## Not changed (out of scope for a docs fix)
- ReconfigureTLS cert-field update (\`reconfigure-tls/cluster\`) panics the ops-manager (nil pointer deref); this is an operator bug, not a doc error (add/rotate/remove work).
- \`custom-rbac\` sample references a backend AppBinding the guide never provisions; leaving the sample-backend decision to maintainers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several ProxySQL guides with corrected example paths and manifest names.
  * Aligned deployment, scaling, restart, TLS, monitoring, and version-upgrade steps with the latest expected commands and resource checks.
  * Fixed a few verification commands and access steps so the examples better match the intended setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->