### PR TITLE
docs(solr): fix zookeeperRef, auth secret name, and apply URL found by running the guides

### DIFF
--- a/docs/guides/solr/clustering/combined_cluster.md
+++ b/docs/guides/solr/clustering/combined_cluster.md
@@ -165,7 +165,7 @@ persistentvolumeclaim/solr-combined-data-solr-combined-0   Bound    pvc-c073b8b8
     - `{Solr-Name}-pods` - the node discovery service which is used by the Solr nodes to communicate each other. It is a headless service.
 - `AppBinding` - an [AppBinding](/docs/guides/solr/concepts/appbinding.md) which hold to connect information for the database. It is also named after the solr instance.
 - `Secrets` - 3 types of secrets are generated for each Solr database.
-    - `{Solr-Name}-auth` - the auth secrets which hold the `username` and `password` for the solr users. The auth secret `solr-combined-admin-cred` holds the `username` and `password` for `admin` user which lets administrative access.
+    - `{Solr-Name}-auth` - the auth secrets which hold the `username` and `password` for the solr users. The auth secret `solr-combined-auth` holds the `username` and `password` for `admin` user which lets administrative access.
     - `{Solr-Name}-config` - the default configuration secret created by the operator.
     - `{Solr-Name}-auth-config` - the configuration secret of admin user information created by the operator.
     - `{Solr-Name}-zk-digest` - the auth secret which contains the `username` and `password` for zookeeper digest secret which is able to access zookeeper data.
@@ -192,14 +192,14 @@ Now, our Solr cluster is accessible at `localhost:8983`.
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo solr-combined-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo solr-combined-auth -o jsonpath='{.data.username}' | base64 -d
   admin
     ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo solr-combined-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo solr-combined-auth -o jsonpath='{.data.password}' | base64 -d
   Xy3ZjyU)~(9IO8_n
   ```
 
@@ -266,7 +266,7 @@ spec:
   replicas: 2
   enableSSL: true
   zookeeperRef:
-    name: zoo
+    name: zoo-com
     namespace: demo
   storage:
     accessModes:
@@ -280,7 +280,7 @@ spec:
 Let's deploy the above example by the following command:
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/solr/clusteringyamls/combined-multinode.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/solr/clustering/yamls/combined-multinode.yaml
 solr.kubedb.com/solr-combined created
 ```
 

--- a/docs/guides/solr/quickstart/overview/index.md
+++ b/docs/guides/solr/quickstart/overview/index.md
@@ -115,7 +115,7 @@ Here,
 Let's create the ZooKeeper CR that is shown above:
 
 ```bash
-$ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/solr/quickstart/overview/yamls/zookeeper/zookeeper.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/solr/quickstart/overview/yamls/zookeeper/zookeeper.yaml
 zooKeeper.kubedb.com/zoo-com created
 ```
 
@@ -142,7 +142,7 @@ spec:
   deletionPolicy: Delete
   replicas: 2
   zookeeperRef:
-    name: zk-com
+    name: zoo-com
     namespace: demo
   storage:
     accessModes:
@@ -353,7 +353,7 @@ persistentvolumeclaim/solr-combined-data-solr-combined-2   Bound    pvc-dcb8c9e2
     - `{Solr-Name}-pods` - the node discovery service which is used by the Solr nodes to communicate each other. It is a headless service.
 - `AppBinding` - an [AppBinding](/docs/guides/solr/concepts/appbinding.md) which hold to connect information for the database. It is also named after the solr instance.
 - `Secrets` - 3 types of secrets are generated for each Solr database.
-    - `{Solr-Name}-admin-cred` - the auth secrets which hold the `username` and `password` for the solr users. The auth secret `solr-combined-admin-cred` holds the `username` and `password` for `admin` user which lets administrative access.
+    - `{Solr-Name}-auth` - the auth secrets which hold the `username` and `password` for the solr users. The auth secret `solr-combined-auth` holds the `username` and `password` for `admin` user which lets administrative access.
     - `{Solr-Name}-config` - the default configuration secret created by the operator.
     - `{Solr-Name}-auth-config` - the configuration secret of admin user information created by the operator.
     - `{Solr-Name}-zk-digest` - the auth secret which contains the `username` and `password` for zookeeper digest secret which is able to access zookeeper data.
@@ -380,14 +380,14 @@ Now, our Solr cluster is accessible at `localhost:8983`.
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo solr-combined-admin-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo solr-combined-auth -o jsonpath='{.data.username}' | base64 -d
   admin
     ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo solr-combined-admin-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo solr-combined-auth -o jsonpath='{.data.password}' | base64 -d
   Xy3ZjyU)~(9IO8_n
   ```
 

--- a/docs/guides/solr/quickstart/overview/yamls/solr/solr.yaml
+++ b/docs/guides/solr/quickstart/overview/yamls/solr/solr.yaml
@@ -8,7 +8,7 @@ spec:
   deletionPolicy: Halt
   replicas: 2
   zookeeperRef:
-    name: zk-com
+    name: zoo-com
     namespace: demo
   storage:
     accessModes:


### PR DESCRIPTION
While executing the Solr guides against a KubeDB v2026.6.19 cluster as a new user, the following documentation bugs were found and fixed. Each was confirmed against the source of truth (apimachinery API helpers / the guide's own resources) or observed cluster behavior.

## quickstart/overview

1. **Wrong `zookeeperRef.name`.** The guide creates a ZooKeeper named `zoo-com` (inline block and `yamls/zookeeper/zookeeper.yaml`), but the Solr referenced `zk-com` in both the inline block and `yamls/solr/solr.yaml`. With `zk-com`, the Solr never binds its ZooKeeper and stays in `Provisioning`. Fixed `zk-com` to `zoo-com`.
   - Verified on cluster: applied as written (`zk-com`) the Solr never reaches `SolrZkReady`; with `zoo-com` the condition `SolrZkReady=True` is set and provisioning proceeds past the ZooKeeper stage. Every other Solr guide already uses `zoo-com`/`zoo`.

2. **Wrong auth secret name in the connection commands.** The Connection section read `solr-combined-admin-cred`, but the operator names the auth secret `solr-combined-auth`. Fixed both `kubectl get secret` commands and the Secrets description.
   - Confirmed against source of truth: `apimachinery/apis/kubedb/v1alpha2/solr_helpers.go` `Solr.GetAuthSecretName()` returns `<name>-auth`. Confirmed on cluster: the operator created `solr-combined-auth` (basic-auth, keys `username`/`password`); no `solr-combined-admin-cred` exists. The `clustering/topology_cluster.md` runnable commands already use `solr-cluster-auth`.

3. **Doubled shell prompt.** `$ $ kubectl apply -f ...zookeeper.yaml` fixed to a single `$`.

## clustering/combined_cluster.md

1. **Wrong `zookeeperRef.name` in the multi-node example.** Used `zoo` while the guide creates `zoo-com` (and the matching `clustering/yamls/combined-multinode.yaml` uses `zoo-com`). Fixed to `zoo-com`.

2. **Broken apply URL.** `.../solr/clusteringyamls/combined-multinode.yaml` was missing a slash; fixed to `.../solr/clustering/yamls/combined-multinode.yaml`. The file exists at that path and the sibling standalone command already uses `clustering/yamls/`.

3. **Wrong auth secret name** `solr-combined-admin-cred` to `solr-combined-auth` in the two connection commands and the Secrets description (same fix as quickstart).

No em-dashes were introduced. Stale illustrative snapshot outputs (describe dumps, resource listings) were left as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Solr quickstart and clustering guides to match the current resource names and connection details.
  * Corrected ZooKeeper reference names in example configurations so the shown setup works as written.
  * Fixed example commands and URLs in the tutorials, including the command used to apply ZooKeeper and the multi-node deployment link.
  * Revised the described auth secret name in the examples to reflect the current generated secret used for admin credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->