### PR TITLE
docs(zookeeper): fix defects found by executing the guides

### DIFF
--- a/docs/examples/zookeeper/reconfigure-tls/zookeeper-add-tls.yaml
+++ b/docs/examples/zookeeper/reconfigure-tls/zookeeper-add-tls.yaml
@@ -9,7 +9,7 @@ spec:
     name: zk-quickstart
   tls:
     issuerRef:
-      name: zookeeper-ca-issuer
+      name: zk-issuer
       kind: Issuer
       apiGroup: "cert-manager.io"
     certificates:

--- a/docs/guides/zookeeper/backup/kubestash/_index.md
+++ b/docs/guides/zookeeper/backup/kubestash/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Backup & Restore PostgreSQL | KubeStash
+title: Backup & Restore ZooKeeper | KubeStash
 menu:
   docs_{{ .version }}:
     identifier: guides-zk-backup-stashv2

--- a/docs/guides/zookeeper/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/zookeeper/backup/kubestash/auto-backup/index.md
@@ -50,7 +50,7 @@ We are going to store our backed up data into a `s3` bucket. We have to create a
 
 **Create Secret:**
 
-Let's create a secret called `s3-secret` with access credentials to our desired GCS bucket,
+Let's create a secret called `s3-secret` with access credentials to our desired s3 bucket,
 
 ```bash
 $ echo -n '<your-aws-access-key-id-here>' > AWS_ACCESS_KEY_ID
@@ -715,7 +715,7 @@ KubeStash triggers an instant backup as soon as the `BackupConfiguration` is rea
 ```bash
 $ kubectl get backupsession -n demo -w
 NAME                                                        INVOKER-TYPE          INVOKER-NAME                   PHASE       DURATION   AGE
-appbinding-sample-zookeeper-2-frequent-backup-1726742400    BackupConfiguration   appbinding-sample-zookeeper     Succeeded   58s        112s
+appbinding-sample-zookeeper-2-frequent-backup-1726742400    BackupConfiguration   appbinding-sample-zookeeper-2   Succeeded   58s        112s
 ```
 
 We can see from the above output that the backup session has succeeded. Now, we are going to verify whether the backed up data has been stored in the backend.

--- a/docs/guides/zookeeper/backup/kubestash/logical/index.md
+++ b/docs/guides/zookeeper/backup/kubestash/logical/index.md
@@ -94,7 +94,7 @@ Let's check if the zookeeper is ready to use,
 ```bash
 $ kubectl get zk -n demo sample-zookeeper
 NAME               VERSION   STATUS   AGE
-sample-zookeeper   8.3.3     Ready    5m1s
+sample-zookeeper   3.9.1     Ready    5m1s
 ```
 
 The zookeeper is `Ready`. Verify that KubeDB has created a `Secret` and a `Service` for this zookeeper using the following commands,
@@ -121,7 +121,7 @@ Verify that the `AppBinding` has been created successfully using the following c
 ```bash
 $ kubectl get appbindings -n demo
 NAME                       TYPE                   VERSION    AGE
-sample-zookeeper           kubedb.com/zookeeper   3.8.3      9m30s
+sample-zookeeper           kubedb.com/zookeeper   3.9.1      9m30s
 ```
 
 Let's check the YAML of the above `AppBinding`,
@@ -364,7 +364,7 @@ spec:
 Let's create the `BackupConfiguration` CR that we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/zookeeper/kubestash/logical/examples/backupconfiguration.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/zookeeper/backup/kubestash/logical/examples/backupconfiguration.yaml
 backupconfiguration.core.kubestash.com/sample-zookeeper-backup created
 ```
 
@@ -563,7 +563,7 @@ If you check the database status, you will see it is stuck in **`Provisioning`**
 ```bash
 $ kubectl get zookeeper -n demo restored-zookeeper
 NAME                 VERSION   STATUS         AGE
-restored-zookeeper   3.8.3     Provisioning   61s
+restored-zookeeper   3.9.1     Provisioning   61s
 ```
 
 #### Create RestoreSession:
@@ -615,7 +615,7 @@ Once, you have created the `RestoreSession` object, KubeStash will create restor
 $ watch kubectl get restoresession -n demo
 Every 2.0s: kubectl get restores... AppsCode-PC-03: Wed Aug 21 10:44:05 2024
 NAME                      REPOSITORY          FAILURE-POLICY   PHASE       DURATION   AGE
-sample-zookeeper-restore   gcs-zookeeper-repo                    Succeeded   7s         116s
+sample-zookeeper-restore   s3-zookeeper-repo                     Succeeded   7s         116s
 ```
 
 The `Succeeded` phase means that the restore process has been completed successfully.
@@ -629,7 +629,7 @@ At first, check if the database has gone into **`Ready`** state by the following
 ```bash
 $ kubectl get zookeeper -n demo restored-zookeeper
 NAME                 VERSION   STATUS   AGE
-restored-zookeeper   8.3.1      Ready    6m31s
+restored-zookeeper   3.9.1      Ready    6m31s
 ```
 
 Now, find out the database `Pod` by the following command,
@@ -681,7 +681,7 @@ To cleanup the Kubernetes resources created by this tutorial, run:
 
 ```bash
 kubectl delete backupconfigurations.core.kubestash.com  -n demo sample-zookeeper-backup
-kubectl delete restoresessions.core.kubestash.com -n demo restore-sample-zookeeper
+kubectl delete restoresessions.core.kubestash.com -n demo sample-zookeeper-restore
 kubectl delete retentionpolicies.storage.kubestash.com -n demo demo-retention
 kubectl delete backupstorage -n demo s3-storage
 kubectl delete secret -n demo s3-secret

--- a/docs/guides/zookeeper/backup/kubestash/overview/index.md
+++ b/docs/guides/zookeeper/backup/kubestash/overview/index.md
@@ -68,7 +68,7 @@ The backup process consists of the following steps:
 
 ## How Restore Process Works
 
-The following diagram shows how KubeStash restores backed up data into a `PostgreSQL` database. Open the image in a new tab to see the enlarged version.
+The following diagram shows how KubeStash restores backed up data into a `ZooKeeper` database. Open the image in a new tab to see the enlarged version.
 
 <figure align="center">
   <img alt="Database Restore Overview" src="/docs/guides/zookeeper/backup/kubestash/overview/images/restore_overview.svg">

--- a/docs/guides/zookeeper/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/zookeeper/monitoring/using-builtin-prometheus.md
@@ -84,7 +84,7 @@ Now, wait for the database to go into `Running` state.
 ```bash
 $ kubectl get zk -n demo 
 NAME                     VERSION   STATUS    AGE
-zookeeper-builtin-prom   3.8.3     Ready     129m
+zookeeper-builtin-prom   3.9.1     Ready     129m
 ```
 
 KubeDB will create a separate stats service with name `{ZooKeeper crd name}-stats` for monitoring purpose.

--- a/docs/guides/zookeeper/monitoring/using-prometheus-operator.md
+++ b/docs/guides/zookeeper/monitoring/using-prometheus-operator.md
@@ -212,7 +212,7 @@ Now, wait for the database to go into `Running` state.
 ```bash
 $ kubectl get zk -n demo zookeeper
 NAME              VERSION    STATUS    AGE
-zookeeper         3.8.3      Ready     34s
+zookeeper         3.9.1      Ready     34s
 ```
 
 KubeDB will create a separate stats service with name `{ZooKeeper crd name}-stats` for monitoring purpose.

--- a/docs/guides/zookeeper/quickstart/quickstart.md
+++ b/docs/guides/zookeeper/quickstart/quickstart.md
@@ -386,7 +386,7 @@ When `deletionPolicy` is `DoNotTerminate`, KubeDB takes advantage of `Validation
 
 ```bash
 $ kubectl delete zk zk-quickstart -n demo
-The ZooKeeper "zk-quickstart" is invalid: spec.teminationPolicy: Invalid value: "zk-quickstart": Can not delete as terminationPolicy is set to "DoNotTerminate"
+The ZooKeeper "zk-quickstart" is invalid: spec.deletionPolicy: Invalid value: "zk-quickstart": Can not delete as deletionPolicy is set to "DoNotTerminate"
 ```
 
 Now, run `kubectl edit zk zk-quickstart -n demo` to set `spec.deletionPolicy` to `Halt` . Then you will be able to delete/halt the database.

--- a/docs/guides/zookeeper/quickstart/quickstart.md
+++ b/docs/guides/zookeeper/quickstart/quickstart.md
@@ -386,10 +386,10 @@ When `deletionPolicy` is `DoNotTerminate`, KubeDB takes advantage of `Validation
 
 ```bash
 $ kubectl delete zk zk-quickstart -n demo
-Error from server (BadRequest): admission webhook "zookeeper.validators.kubedb.com" denied the request: zookeeper "zookeeper-quickstart" can't be deleted. To delete, change spec.deletionPolicy
+The ZooKeeper "zk-quickstart" is invalid: spec.teminationPolicy: Invalid value: "zk-quickstart": Can not delete as terminationPolicy is set to "DoNotTerminate"
 ```
 
-Now, run `kubectl edit zk zookeeper-quickstart -n demo` to set `spec.deletionPolicy` to `Halt` . Then you will be able to delete/halt the database.
+Now, run `kubectl edit zk zk-quickstart -n demo` to set `spec.deletionPolicy` to `Halt` . Then you will be able to delete/halt the database.
 
 
 ## Cleaning up

--- a/docs/guides/zookeeper/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/zookeeper/reconfigure-tls/reconfigure-tls.md
@@ -73,7 +73,7 @@ Now, wait until `zk-quickstart` has status `Ready`. i.e,
 ```bash
 $ watch kubectl get zookeeper -n demo
 NAME              TYPE                    VERSION   STATUS    AGE
-zk-quickstart     kubedb.com/v1alpha2     3.8.3     Ready     60s
+zk-quickstart     kubedb.com/v1alpha2     3.9.1     Ready     60s
 ```
 
 Now, we can exec one zookeeper broker pod and verify configuration that the TLS is disabled.
@@ -81,7 +81,7 @@ Now, we can exec one zookeeper broker pod and verify configuration that the TLS 
 ```bash
 $ kubectl exec -it -n demo zk-quickstart-0 -- bash
 Defaulted container "zookeeper" out of: zookeeper, zookeeper-init (init)
-zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ cat ../conf/zoo.cfg
+zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ cat ../conf/zoo.cfg
 4lw.commands.whitelist=*
 dataDir=/data
 tickTime=2000
@@ -105,7 +105,7 @@ authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 reconfigEnabled=true
 standaloneEnabled=false
 dynamicConfigFile=/data/zoo.cfg.dynamic
-zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ 
+zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ 
 ```
 
 We can verify from the above output that TLS is disabled for this Ensemble.
@@ -171,7 +171,7 @@ spec:
     name: zk-quickstart
   tls:
     issuerRef:
-      name: zookeeper-ca-issuer
+      name: zk-issuer
       kind: Issuer
       apiGroup: "cert-manager.io"
     certificates:
@@ -232,7 +232,7 @@ Spec:
     Issuer Ref:
       API Group:  cert-manager.io
       Kind:       Issuer
-      Name:       zookeeper-ca-issuer
+      Name:       zk-issuer
   Type:           ReconfigureTLS
 Status:
   Conditions:
@@ -326,7 +326,7 @@ Now, Let's exec into a zookeeper ensemble pod and verify the configuration that 
 ```bash
 $ kubectl exec -it -n demo zk-quickstart-0 -- bash
 Defaulted container "zookeeper" out of: zookeeper, zookeeper-init (init)
-zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ cat ../conf/zoo.cfg
+zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ cat ../conf/zoo.cfg
 4lw.commands.whitelist=*
 dataDir=/data
 tickTime=2000
@@ -363,7 +363,7 @@ ssl.quorum.keyStore.password=fdjk2dgffqn9
 ssl.quorum.trustStore.location=/var/private/ssl/server.truststore.jks
 ssl.quorum.trustStore.password=fdjk2dgffqn9
 ssl.quorum.hostnameVerification=false
-zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ 
+zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ 
 ```
 
 We can see from the above output that, keystore location is `/var/private/ssl/server.keystore.jks` which means that TLS is enabled.
@@ -375,7 +375,7 @@ Now we are going to rotate the certificate of this cluster. First let's check th
 ```bash
 $ kubectl exec -it -n demo zk-quickstart-0 -- bash
 Defaulted container "zookeeper" out of: zookeeper, zookeeper-init (init)
-zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ openssl x509 -in /var/private/ssl/tls.crt -inform PEM -enddate -nameopt RFC2253 -noout
+zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ openssl x509 -in /var/private/ssl/tls.crt -inform PEM -enddate -nameopt RFC2253 -noout
 notAfter=Feb  2 12:53:30 2025 GMT
 ```
 
@@ -566,7 +566,7 @@ Now, let's check the expiration date of the certificate.
 ```bash
 $ kubectl exec -it -n demo zk-quickstart-0 -- bash
 Defaulted container "zookeeper" out of: zookeeper, zookeeper-init (init)
-zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ openssl x509 -in /var/private/ssl/tls.crt -inform PEM -enddate -nameopt RFC2253 -noout
+zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ openssl x509 -in /var/private/ssl/tls.crt -inform PEM -enddate -nameopt RFC2253 -noout
 notAfter=Feb 2 13:12:42 2025 GMT
 ```
 
@@ -597,7 +597,7 @@ $ kubectl create secret tls zookeeper-new-ca \
 secret/zookeeper-new-ca created
 ```
 
-Now, Let's create a new `Issuer` using the `mongo-new-ca` secret that we have just created. The `YAML` file looks like this:
+Now, Let's create a new `Issuer` using the `zookeeper-new-ca` secret that we have just created. The `YAML` file looks like this:
 
 ```yaml
 apiVersion: cert-manager.io/v1
@@ -648,7 +648,7 @@ Let's create the `ZooKeeperOpsRequest` CR we have shown above,
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/zookeeper/reconfigure-tls/zookeeper-update-tls-issuer.yaml
-zookeeperpsrequest.ops.kubedb.com/zkops-update-issuer created
+zookeeperopsrequest.ops.kubedb.com/zkops-update-issuer created
 ```
 
 #### Verify Issuer is changed successfully
@@ -806,7 +806,7 @@ Now, Let's exec into a zookeeper node and find out the ca subject to see if it m
 ```bash
 $ kubectl exec -it -n demo zk-quickstart-0 -- bash
 Defaulted container "zookeeper" out of: zookeeper, zookeeper-init (init)
-zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ keytool -list -v -keystore /var/private/ssl/server.keystore.jks -storepass fdjk2dgffqn9 | grep 'Issuer'
+zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ keytool -list -v -keystore /var/private/ssl/server.keystore.jks -storepass fdjk2dgffqn9 | grep 'Issuer'
 Issuer: O=kubedb-updated, CN=ca-updated
 Issuer: O=kubedb-updated, CN=ca-updated
 ```
@@ -967,7 +967,7 @@ Now, Let's exec into one of the broker node and find out that TLS is disabled or
 ```bash
 $ kubectl exec -it -n demo zk-quickstart-0 -- bash
 Defaulted container "zookeeper" out of: zookeeper, zookeeper-init (init)
-zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ cat ../conf/zoo.cfg
+zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ cat ../conf/zoo.cfg
 4lw.commands.whitelist=*
 dataDir=/data
 tickTime=2000
@@ -991,7 +991,7 @@ authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 reconfigEnabled=true
 standaloneEnabled=false
 dynamicConfigFile=/data/zoo.cfg.dynamic
-zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ 
+zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ 
 ```
 
 So, we can see from the above that, output that tls is disabled successfully.

--- a/docs/guides/zookeeper/reconfigure/reconfigure.md
+++ b/docs/guides/zookeeper/reconfigure/reconfigure.md
@@ -99,7 +99,7 @@ Now, wait until `zk-quickstart` has status `Ready`. i.e,
 ```bash
 $ kubectl get zk -n demo
 NAME               VERSION     STATUS    AGE
-zk-quickstart      3.8.3      Ready     23s
+zk-quickstart      3.9.1      Ready     23s
 ```
 
 Now, we will check if the database has started with the custom configuration we have provided.
@@ -108,7 +108,7 @@ Now, you can exec into the zookeeper pod and find if the custom configuration is
 
 ```bash
 $ Defaulted container "zookeeper" out of: zookeeper, zookeeper-init (init)
-zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ echo conf | nc localhost 2181
+zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ echo conf | nc localhost 2181
 clientPort=2181
 secureClientPort=-1
 dataDir=/data/version-2
@@ -131,7 +131,7 @@ membership:
 server.1=zk-quickstart-0.zk-quickstart-pods.demo.svc.cluster.local:2888:3888:participant;0.0.0.0:2181
 server.2=zk-quickstart-1.zk-quickstart-pods.demo.svc.cluster.local:2888:3888:participant;0.0.0.0:2181
 server.3=zk-quickstart-2.zk-quickstart-pods.demo.svc.cluster.local:2888:3888:participant;0.0.0.0:2181
-version=100000011zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ exit
+version=100000011zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ exit
 exit
 ```
 
@@ -302,14 +302,14 @@ Now, wait until `zk-quickstart` has status `Ready`. i.e,
 ```bash
 $ kubectl get zk -n demo
 NAME            VERSION     STATUS    AGE
-zk-quickstart   3.8.3      Ready     20s
+zk-quickstart   3.9.1      Ready     20s
 ```
 
 Now let’s exec into the zookeeper pod and check the new configuration we have provided.
 
 ```bash
 $ Defaulted container "zookeeper" out of: zookeeper, zookeeper-init (init)
-zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ echo conf | nc localhost 2181
+zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ echo conf | nc localhost 2181
 clientPort=2181
 secureClientPort=-1
 dataDir=/data/version-2
@@ -332,7 +332,7 @@ membership:
 server.1=zk-quickstart-0.zk-quickstart-pods.demo.svc.cluster.local:2888:3888:participant;0.0.0.0:2181
 server.2=zk-quickstart-1.zk-quickstart-pods.demo.svc.cluster.local:2888:3888:participant;0.0.0.0:2181
 server.3=zk-quickstart-2.zk-quickstart-pods.demo.svc.cluster.local:2888:3888:participant;0.0.0.0:2181
-version=100000011zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ exit
+version=100000011zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ exit
 exit
 ```
 
@@ -483,14 +483,14 @@ Now, wait until `zk-quickstart` has status `Ready`. i.e,
 ```bash
 $ kubectl get zk -n demo
 NAME            VERSION     STATUS    AGE
-zk-quickstart   3.8.3      Ready     20s
+zk-quickstart   3.9.1      Ready     20s
 ```
 
 Now let’s exec into the zookeeper pod and check the new configuration we have provided.
 
 ```bash
 $ Defaulted container "zookeeper" out of: zookeeper, zookeeper-init (init)
-zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ echo conf | nc localhost 2181
+zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ echo conf | nc localhost 2181
 clientPort=2181
 secureClientPort=-1
 dataDir=/data/version-2
@@ -513,7 +513,7 @@ membership:
 server.1=zk-quickstart-0.zk-quickstart-pods.demo.svc.cluster.local:2888:3888:participant;0.0.0.0:2181
 server.2=zk-quickstart-1.zk-quickstart-pods.demo.svc.cluster.local:2888:3888:participant;0.0.0.0:2181
 server.3=zk-quickstart-2.zk-quickstart-pods.demo.svc.cluster.local:2888:3888:participant;0.0.0.0:2181
-version=100000011zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ exit
+version=100000011zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ exit
 exit
 ```
 

--- a/docs/guides/zookeeper/scaling/horizontal-scaling/horizontal-scaling.md
+++ b/docs/guides/zookeeper/scaling/horizontal-scaling/horizontal-scaling.md
@@ -75,7 +75,7 @@ Now, wait until `zk-quickstart` has status `Ready`. i.e,
 ```bash
 $ kubectl get zk -n demo
 NAME            VERSION    STATUS    AGE
-zk-quickstart   3.8.3      Ready     5m56s
+zk-quickstart   3.9.1      Ready     5m56s
 ```
 
 Let's check the number of replicas this zookeeper has from the ZooKeeper object, number of pods the PetSet have,
@@ -104,7 +104,7 @@ In order to scale up the replicas of the zookeeper, we have to create a `ZooKeep
 apiVersion: ops.kubedb.com/v1alpha1
 kind: ZooKeeperOpsRequest
 metadata:
-  name: zookeeper-horizontal-scale-up
+  name: horizontal-scale-up
   namespace: demo
 spec:
   type: HorizontalScaling
@@ -123,8 +123,8 @@ Here,
 Let's create the `ZooKeeperOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/zookeeper/scaling/horizontal-scaling/zk-hscale-up-ops.yaml
-zookeeperopsrequest.ops.kubedb.com/zookeeper-horizontal-scale-up created
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/zookeeper/scaling/zk-hscale-up-ops.yaml
+zookeeperopsrequest.ops.kubedb.com/horizontal-scale-up created
 ```
 
 #### Verify replicas scaled up successfully
@@ -136,14 +136,14 @@ Let's wait for `ZooKeeperOpsRequest` to be `Successful`.  Run the following comm
 ```bash
 $ watch kubectl get zookeeperopsrequest -n demo
 NAME                            TYPE                STATUS       AGE
-zookeeper-horizontal-scale-up   HorizontalScaling   Successful   2m49s
+horizontal-scale-up   HorizontalScaling   Successful   2m49s
 ```
 
 We can see from the above output that the `ZooKeeperOpsRequest` has succeeded. If we describe the `ZooKeeperOpsRequest` we will get an overview of the steps that were followed to scale the zookeeper.
 
 ```bash
-$ kubectl describe zookeeperopsrequest -n demo zookeeper-horizontal-scale-up
-Name:         zookeeper-horizontal-scale-up
+$ kubectl describe zookeeperopsrequest -n demo horizontal-scale-up
+Name:         horizontal-scale-up
 Namespace:    demo
 Labels:       <none>
 Annotations:  <none>
@@ -224,7 +224,7 @@ Events:
   Normal   Successful                                                      27s   KubeDB Ops-manager Operator  Successfully resumed ZooKeeper database: demo/zk-quickstart for ZooKeeperOpsRequest: horizontal-scale-up
 ```
 
-Now, we are going to verify the number of replicas this zookeeper has from the Pgpool object, number of pods the PetSet have,
+Now, we are going to verify the number of replicas this zookeeper has from the ZooKeeper object, number of pods the PetSet have,
 
 ```bash
 $ kubectl get zookeeper -n demo zk-quickstart -o json | jq '.spec.replicas'
@@ -248,7 +248,7 @@ In order to scale down the replicas of the zookeeper, we have to create a `ZooKe
 apiVersion: ops.kubedb.com/v1alpha1
 kind: ZooKeeperOpsRequest
 metadata:
-  name: zookeeper-horizontal-scale-down
+  name: horizontal-scale-down
   namespace: demo
 spec:
   type: HorizontalScaling
@@ -268,8 +268,8 @@ Here,
 Let's create the `ZooKeeperOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/zookeeper/scaling/horizontal-scaling/zk-hscale-down-ops.yaml
-zookeeperopsrequest.ops.kubedb.com/zookeeper-horizontal-scale-down created
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/zookeeper/scaling/zk-hscale-down-ops.yaml
+zookeeperopsrequest.ops.kubedb.com/horizontal-scale-down created
 ```
 
 #### Verify replicas scaled down successfully
@@ -281,14 +281,14 @@ Let's wait for `ZooKeeperOpsRequest` to be `Successful`.  Run the following comm
 ```bash
 $ watch kubectl get zookeeperopsrequest -n demo
 NAME                              TYPE                STATUS       AGE
-zookeeper-horizontal-scale-down   HorizontalScaling   Successful   75s
+horizontal-scale-down   HorizontalScaling   Successful   75s
 ```
 
 We can see from the above output that the `ZooKeeperOpsRequest` has succeeded. If we describe the `ZooKeeperOpsRequest` we will get an overview of the steps that were followed to scale the zookeeper.
 
 ```bash
-$ kubectl describe zookeeperopsrequest -n demo zookeeper-horizontal-scale-down
-Name:         zookeeper-horizontal-scale-down
+$ kubectl describe zookeeperopsrequest -n demo horizontal-scale-down
+Name:         horizontal-scale-down
 Namespace:    demo
 Labels:       <none>
 Annotations:  <none>
@@ -415,5 +415,5 @@ To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
 kubectl delete zk -n demo
-kubectl delete zookeeperopsrequest -n demo zookeeper-horizontal-scale-down
+kubectl delete zookeeperopsrequest -n demo horizontal-scale-down
 ```

--- a/docs/guides/zookeeper/scaling/horizontal-scaling/horizontal-scaling.md
+++ b/docs/guides/zookeeper/scaling/horizontal-scaling/horizontal-scaling.md
@@ -415,5 +415,6 @@ To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
 kubectl delete zk -n demo
+kubectl delete zookeeperopsrequest -n demo horizontal-scale-up
 kubectl delete zookeeperopsrequest -n demo horizontal-scale-down
 ```

--- a/docs/guides/zookeeper/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/zookeeper/scaling/vertical-scaling/vertical-scaling.md
@@ -138,7 +138,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `zk-quickstart` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
-- `spec.VerticalScaling.node` specifies the desired resources after scaling.
+- `spec.verticalScaling.node` specifies the desired resources after scaling.
 - Have a look [here](/docs/guides/zookeeper/concepts/opsrequest.md#spectimeout) on the respective sections to understand the `timeout` & `apply` fields.
 
 Let's create the `ZooKeeperOpsRequest` CR we have shown above,

--- a/docs/guides/zookeeper/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/zookeeper/scaling/vertical-scaling/vertical-scaling.md
@@ -81,7 +81,7 @@ Now, wait until `zk-quickstart` has status `Ready`. i.e,
 ```bash
 $ kubectl get zk -n demo
 NAME            VERSION    STATUS    AGE
-zk-quickstart   3.8.3      Ready     5m56s
+zk-quickstart   3.9.1      Ready     5m56s
 ```
 
 Let's check the Pod containers resources,
@@ -136,7 +136,7 @@ spec:
 
 Here,
 
-- `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `vscale` database.
+- `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `zk-quickstart` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.VerticalScaling.node` specifies the desired resources after scaling.
 - Have a look [here](/docs/guides/zookeeper/concepts/opsrequest.md#spectimeout) on the respective sections to understand the `timeout` & `apply` fields.
@@ -144,7 +144,7 @@ Here,
 Let's create the `ZooKeeperOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/zookeeper/scaling/vertical-scaling/zk-vscale.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/zookeeper/scaling/zk-vscale.yaml
 zookeeperopsrequest.ops.kubedb.com/vscale created
 ```
 

--- a/docs/guides/zookeeper/tls/configure-ssl.md
+++ b/docs/guides/zookeeper/tls/configure-ssl.md
@@ -94,7 +94,7 @@ Below is the YAML for ZooKeeper with TLS enabled:
 apiVersion: kubedb.com/v1alpha2
 kind: ZooKeeper
 metadata:
-  name: zk-tls
+  name: zk-quickstart
   namespace: demo
 spec:
   version: "3.9.1"
@@ -124,15 +124,15 @@ Here,
 
 ```bash
 $ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/zookeeper/tls/zookeeper-tls.yaml
-zookeeper.kubedb.com/zk-tls created
+zookeeper.kubedb.com/zk-quickstart created
 ```
 
-Now, wait until `zookeeper-tls created` has status `Ready`. i.e,
+Now, wait until `zk-quickstart` has status `Ready`. i.e,
 
 ```bash
 $ watch kubectl get zookeeper -n demo
-NAME        TYPE                    VERSION   STATUS    AGE
-zk-tls      kubedb.com/v1alpha2     3.8.3     Ready     60s
+NAME            TYPE                    VERSION   STATUS    AGE
+zk-quickstart   kubedb.com/v1alpha2     3.9.1     Ready     60s
 ```
 
 ### Verify TLS/SSL in ZooKeeper Ensemble
@@ -173,7 +173,7 @@ Now, Let's exec into a ZooKeeper pod and verify the configuration that the TLS i
 ```bash
 $ kubectl exec -it -n demo zk-quickstart-0 -- bash
 Defaulted container "zookeeper" out of: zookeeper, zookeeper-init (init)
-zookeeper@zk-quickstart-0:/apache-zookeeper-3.8.3-bin$ cd ../var/private/ssl
+zookeeper@zk-quickstart-0:/apache-zookeeper-3.9.1-bin$ cd ../var/private/ssl
 zookeeper@zk-quickstart-0:/var/private/ssl$ openssl s_client -connect localhost:2182 -CAfile ca.crt -cert tls.crt -key tls.key
 CONNECTED(00000003)
 depth=1 CN = zookeeper, O = kubedb
@@ -257,7 +257,7 @@ From the above output, we can see that we are able to connect to the ZooKeeper E
 To cleanup the Kubernetes resources created by this tutorial, run:
 
 ```bash
-kubectl delete zookeeper -n demo zk-tls
+kubectl delete zookeeper -n demo zk-quickstart
 kubectl delete issuer -n demo zookeeper-ca-issuer
 kubectl delete ns demo
 ```

--- a/docs/guides/zookeeper/update-version/update-version.md
+++ b/docs/guides/zookeeper/update-version/update-version.md
@@ -34,7 +34,7 @@ $ kubectl create ns demo
 namespace/demo created
 ```
 
-> **Note:** YAML files used in this tutorial are stored in [docs/examples/zookeeper](/docs/examples/zookeeper) directory of [kubedb/docs](https://github.com/kube/docs) repository.
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/zookeeper](/docs/examples/zookeeper) directory of [kubedb/docs](https://github.com/kubedb/docs) repository.
 
 ## Prepare ZooKeeper Ensemble
 
@@ -77,7 +77,7 @@ Now, wait until `zk-quickstart` created has status `Ready`. i.e,
 ```bash
 $ kubectl get zk -n demo                                                                                                                                             
 NAME               VERSION    STATUS    AGE
-zk-quickstart      3.9.1      Ready     109s
+zk-quickstart      3.8.3      Ready     109s
 ```
 
 We are now ready to apply the `ZooKeeperOpsRequest` CR to update this database.

--- a/docs/guides/zookeeper/volume-expansion/volume-expansion.md
+++ b/docs/guides/zookeeper/volume-expansion/volume-expansion.md
@@ -93,7 +93,7 @@ Now, wait until `zk-quickstart` has status `Ready`. i.e,
 ```bash
 $ kubectl get zk -n demo
 NAME            VERSION    STATUS    AGE
-zk-quickstart   3.8.3      Ready     5m56s
+zk-quickstart   3.9.1      Ready     5m56s
 ```
 
 Let's check volume size from PetSet, and from the persistent volume,


### PR DESCRIPTION
Executed every guide under `docs/guides/zookeeper/` against a live KubeDB v2026.6.19 cluster (ZooKeeper 3.9.1) and fixed the defects found. Each fix was verified by re-running the corrected command/YAML on the cluster or against the source of truth (the in-repo example YAMLs and the apimachinery API types).

## Fixes

### reconfigure-tls/reconfigure-tls.md (+ example)
- Execution-breaking: `docs/examples/.../reconfigure-tls/zookeeper-add-tls.yaml` and the doc referenced issuer `zookeeper-ca-issuer`, but the guide creates issuer `zk-issuer`. Applying as-shipped failed with `issuers.cert-manager.io "zookeeper-ca-issuer" not found`. Corrected issuerRef name to `zk-issuer` in the example YAML and the doc; re-ran add/rotate/change-issuer/remove TLS ops, all Successful.
- Stale version `3.8.3` in the get output and pod bin paths corrected to `3.9.1` (live cluster shows 3.9.1, pod dir `/apache-zookeeper-3.9.1-bin`).
- `mongo-new-ca` copy-paste corrected to `zookeeper-new-ca`.
- Apply-output typo `zookeeperpsrequest.ops.kubedb.com` corrected to `zookeeperopsrequest.ops.kubedb.com`.

### scaling/horizontal-scaling/horizontal-scaling.md
- Broken example URLs pointed to a non-existent `scaling/horizontal-scaling/` path; corrected to `scaling/`.
- OpsRequest names aligned to the example files and observed apply output (`horizontal-scale-up` / `horizontal-scale-down`).
- Pre-scale get output version `3.8.3` corrected to `3.9.1`.
- `from the Pgpool object` corrected to `from the ZooKeeper object`.

### scaling/vertical-scaling/vertical-scaling.md
- Broken example URL `scaling/vertical-scaling/zk-vscale.yaml` corrected to `scaling/zk-vscale.yaml`.
- Pre-scale get output version `3.8.3` corrected to `3.9.1`.
- Description "operation on `vscale` database" corrected to `zk-quickstart`.

### tls/configure-ssl.md
- CR name split-brain: inline YAML / create / get / cleanup used `zk-tls` while the example file and verify section use `zk-quickstart`. Aligned the doc to `zk-quickstart` (live create confirms `zookeeper.kubedb.com/zk-quickstart created`). Front-matter menu identifiers left unchanged.
- Stale version `3.8.3` corrected to `3.9.1` (get output + pod bin path).

### update-version/update-version.md
- Pre-update get output showed `3.9.1`; corrected to `3.8.3` (the guide deploys 3.8.3, then upgrades to 3.9.1).
- Broken repo link `https://github.com/kube/docs` corrected to `https://github.com/kubedb/docs`.

### reconfigure/reconfigure.md
- Stale version `3.8.3` corrected to `3.9.1` in three get outputs and six pod bin paths (verified live).

### quickstart/quickstart.md
- DoNotTerminate section used wrong CR name `zookeeper-quickstart` (actual `zk-quickstart`) and stale webhook error text; corrected to the actual message observed on the cluster.

### monitoring/using-builtin-prometheus.md, monitoring/using-prometheus-operator.md
- Get output version `3.8.3` corrected to `3.9.1` (builtin verified live incl. stats service; operator schema-validated, operator not installed on test cluster).

### volume-expansion/volume-expansion.md
- Get output version `3.8.3` corrected to `3.9.1` (schema validated; local-path SC does not allow volume expansion on the test cluster).

### backup/kubestash
- `logical/index.md`: impossible versions `8.3.3` and `8.3.1` and stale `3.8.3` corrected to `3.9.1`; backupconfiguration apply URL missing `/backup/` segment corrected; RestoreSession repository `gcs-zookeeper-repo` corrected to `s3-zookeeper-repo`; cleanup RestoreSession name `restore-sample-zookeeper` corrected to `sample-zookeeper-restore`. (Deploy/AppBinding/data-insert verified live; S3 backend not available on test cluster.)
- `auto-backup/index.md`: "GCS bucket" corrected to "s3 bucket"; BackupSession INVOKER-NAME corrected to `appbinding-sample-zookeeper-2`.
- `overview/index.md` and `_index.md`: `PostgreSQL` copy-paste corrected to `ZooKeeper` (restore diagram text and page title).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ZooKeeper guides and examples to reflect the current ZooKeeper version and corrected command outputs.
  * Fixed several tutorial steps, resource names, and cleanup commands for TLS, backup/restore, scaling, monitoring, reconfiguration, volume expansion, and version upgrade workflows.
  * Clarified backup/restore instructions and corrected repository, issuer, and manifest references for better accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->