### PR TITLE
docs(clickhouse): fix broken custom-config example path and wrong horizontalScaling field name

### DIFF
--- a/docs/guides/clickhouse/concepts/clickhouseopsrequest.md
+++ b/docs/guides/clickhouse/concepts/clickhouseopsrequest.md
@@ -307,9 +307,9 @@ If you want to update you ClickHouse version, you have to specify the `spec.upda
 
 > You can only update between ClickHouse versions. KubeDB does not support downgrade for ClickHouse.
 
-### spec.horizontalScaling.node
+### spec.horizontalScaling.replicas
 
-If you want to scale-up or scale-down your ClickHouse cluster or different components of it, you have to specify `spec.horizontalScaling.node` section.
+If you want to scale-up or scale-down your ClickHouse cluster or different components of it, you have to specify `spec.horizontalScaling.replicas` section.
 
 ### spec.verticalScaling.node
 

--- a/docs/guides/clickhouse/configuration/using-config-file.md
+++ b/docs/guides/clickhouse/configuration/using-config-file.md
@@ -103,7 +103,7 @@ spec:
 ```
 
 ```bash
-➤ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/clickhouse/configuration/ch-custom-config-standalone.yaml
+➤ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/clickhouse/custom-config/ch-custom-config-standalone.yaml
 clickhouse.kubedb.com/ch-standalone created
 ```
 


### PR DESCRIPTION
Follow-up to #960 (which merged before these two additional bugs were found during a full re-execution of the ClickHouse guides on a live KubeDB v2026.6.19 cluster).

## Fixes
1. **configuration/using-config-file.md**: the create command pointed at `docs/examples/clickhouse/configuration/ch-custom-config-standalone.yaml`, but that directory does not exist. Corrected to `docs/examples/clickhouse/custom-config/ch-custom-config-standalone.yaml`. Verified on cluster: config applies and `max_query_size` = 200000.
2. **concepts/clickhouseopsrequest.md**: heading and prose used `spec.horizontalScaling.node`, but the API type `ClickHouseHorizontalScalingSpec` only has `replicas` (no `node` field). Corrected to `spec.horizontalScaling.replicas`. Verified: horizontal scale up/down succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the horizontal scaling guidance to use `replicas` for scaling ClickHouse clusters and related components.
  * Revised the custom configuration tutorial to point to the latest example manifest location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->