### PR TITLE
docs(druid): fix copy-paste, name-mismatch, and field bugs found by executing the guides

### DIFF
--- a/docs/guides/druid/autoscaler/compute/guide.md
+++ b/docs/guides/druid/autoscaler/compute/guide.md
@@ -628,7 +628,7 @@ Status:
     Status:                True
     Type:                  CheckPodRunning--druid-cluster-coordinators-0
     Last Transition Time:  2024-10-24T10:07:43Z
-    Message:               Successfully completed the vertical scaling for RabbitMQ
+    Message:               Successfully completed the vertical scaling for Druid
     Observed Generation:   1
     Reason:                Successful
     Status:                True
@@ -771,7 +771,7 @@ Status:
     Status:                True
     Type:                  CheckPodRunning--druid-cluster-historicals-0
     Last Transition Time:  2024-10-24T10:06:37Z
-    Message:               Successfully completed the vertical scaling for RabbitMQ
+    Message:               Successfully completed the vertical scaling for Druid
     Observed Generation:   1
     Reason:                Successful
     Status:                True

--- a/docs/guides/druid/autoscaler/compute/yamls/druid-autoscaler.yaml
+++ b/docs/guides/druid/autoscaler/compute/yamls/druid-autoscaler.yaml
@@ -1,7 +1,7 @@
 apiVersion: autoscaling.kubedb.com/v1alpha1
 kind: DruidAutoscaler
 metadata:
-    name: druid-storage-autoscaler
+    name: druid-autoscaler
     namespace: demo
 spec:
     databaseRef:

--- a/docs/guides/druid/autoscaler/storage/guide.md
+++ b/docs/guides/druid/autoscaler/storage/guide.md
@@ -222,7 +222,7 @@ spec:
 
 Here,
 
-- `spec.clusterRef.name` specifies that we are performing vertical scaling operation on `druid-cluster` cluster.
+- `spec.databaseRef.name` specifies that we are performing storage autoscaling operation on `druid-cluster` cluster.
 - `spec.storage.historicals.trigger/spec.storage.middleManagers.trigger` specifies that storage autoscaling is enabled for historicals and middleManagers of topology cluster.
 - `spec.storage.historicals.usageThreshold/spec.storage.middleManagers.usageThreshold` specifies storage usage threshold, if storage usage exceeds `60%` then storage autoscaling will be triggered.
 - `spec.storage.historicals.scalingThreshold/spec.storage.historicals.scalingThreshold` specifies the scaling threshold. Storage will be scaled to `100%` of the current amount.
@@ -882,7 +882,7 @@ To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
 kubectl delete druidopsrequests -n demo drops-druid-cluster-gq9huj drops-druid-cluster-kbw4fd
-kubectl delete druidutoscaler -n demo druid-storage-autoscaler
+kubectl delete druidautoscaler -n demo druid-storage-autoscaler
 kubectl delete dr -n demo druid-cluster
 ```
 

--- a/docs/guides/druid/backup/application-level/index.md
+++ b/docs/guides/druid/backup/application-level/index.md
@@ -449,7 +449,7 @@ spec:
 - `.spec.sessions[*].addon.tasks[*].name[*]` specifies that both the `manifest-backup` and `mysql-metadata-storage-backup` tasks will be executed.
 
 > **Note**: 
-> - To create `BackupConfiguration` for druid with `PostgreSQL` as metadata storage update the `spec.sessions[*].addon.tasks.name` from `mysql-metadata-storage-backup` to `postgres-metadata-storage-restore`
+> - To create `BackupConfiguration` for druid with `PostgreSQL` as metadata storage update the `spec.sessions[*].addon.tasks.name` from `mysql-metadata-storage-backup` to `postgres-metadata-storage-backup`
 > - When we backup a `Druid`, KubeStash operator will also take backup of the dependency of the `MySQL` and `ZooKeeper` cluster as well.
 > - When we backup a `Druid` where `spec.metadatastorage.externallyManaged` is false then KubeStash operator will also take backup of
 

--- a/docs/guides/druid/backup/auto-backup/index.md
+++ b/docs/guides/druid/backup/auto-backup/index.md
@@ -551,7 +551,7 @@ Here,
   - `.repositories[*].directory` defines two variables, `${namespace}` and `${targetName}`, which are used to determine the path where the backup will be stored. 
   - `.addon.tasks[*]databases` defines `${targetedDatabases}` variable, which identifies list of databases to backup.
 
-> **Note**: To create `BackupBlueprint` for druid with `PostgreSQL` as metadata storage just update `spec.sessions[*].addon.tasks.name` to `postgres-metadata-storage-restore`
+> **Note**: To create `BackupBlueprint` for druid with `PostgreSQL` as metadata storage just update `spec.sessions[*].addon.tasks.name` to `postgres-metadata-storage-backup`
 
 Let's create the `BackupBlueprint` we have shown above,
 

--- a/docs/guides/druid/backup/customization/examples/restore/resources-limit.yaml
+++ b/docs/guides/druid/backup/customization/examples/restore/resources-limit.yaml
@@ -27,4 +27,4 @@ spec:
             cpu: "200m"
             memory: "1Gi"
     tasks:
-      - name: mysql-metadata-storage-backup
+      - name: mysql-metadata-storage-restore

--- a/docs/guides/druid/backup/customization/examples/restore/specific-snapshot.yaml
+++ b/docs/guides/druid/backup/customization/examples/restore/specific-snapshot.yaml
@@ -18,4 +18,4 @@ spec:
   addon:
     name: druid-addon
     tasks:
-      - name: mysql-metadata-storage-backup
+      - name: mysql-metadata-storage-restore

--- a/docs/guides/druid/backup/customization/examples/restore/specific-user.yaml
+++ b/docs/guides/druid/backup/customization/examples/restore/specific-user.yaml
@@ -23,4 +23,4 @@ spec:
           runAsUser: 0
           runAsGroup: 0
     tasks:
-      - name: mysql-metadata-storage-backup
+      - name: mysql-metadata-storage-restore

--- a/docs/guides/druid/backup/customization/index.md
+++ b/docs/guides/druid/backup/customization/index.md
@@ -217,7 +217,7 @@ spec:
   addon:
     name: druid-addon
     tasks:
-      - name: mysql-metadata-storage-backup
+      - name: mysql-metadata-storage-restore
 ```
 
 
@@ -251,7 +251,7 @@ spec:
           runAsUser: 0
           runAsGroup: 0
     tasks:
-      - name: mysql-metadata-storage-backup
+      - name: mysql-metadata-storage-restore
 ```
 
 ### Specifying Memory/CPU limit/request for the restore job
@@ -288,7 +288,7 @@ spec:
             cpu: "200m"
             memory: "1Gi"
     tasks:
-      - name: mysql-metadata-storage-backup
+      - name: mysql-metadata-storage-restore
 ```
 
 > You can configure additional runtime settings for restore jobs within the `addon.jobTemplate.spec` sections. For further details, please refer to the [reference](https://kubestash.com/docs/latest/concepts/crds/restoresession/#podtemplate-spec).

--- a/docs/guides/druid/clustering/guide/index.md
+++ b/docs/guides/druid/clustering/guide/index.md
@@ -909,7 +909,7 @@ To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
 $ kubectl patch -n demo druid druid-cluster -p '{"spec":{"deletionPolicy":"WipeOut"}}' --type="merge"
-kafka.kubedb.com/druid-cluster patched
+druid.kubedb.com/druid-cluster patched
 
 $ kubectl delete dr druid-cluster  -n demo
 druid.kubedb.com "druid-cluster" deleted

--- a/docs/guides/druid/concepts/druid.md
+++ b/docs/guides/druid/concepts/druid.md
@@ -44,7 +44,7 @@ spec:
     externallyManaged: true
   authSecret:
     kind: Secret
-    name: druid-admin-cred
+    name: druid-auth
   configuration:
     secretName: druid-custom-config
   enableSSL: true
@@ -173,7 +173,7 @@ spec:
 
 - `28.0.1`
 - `30.0.1`
-- `31.0.1`
+- `31.0.0`
 - `36.0.0`
 
 ### spec.replicas
@@ -204,7 +204,7 @@ authSecret:
 
 3. Let KubeDB do everything for you. In this case, no work for you.
 
-AuthSecret contains a `user` key and a `password` key which contains the `username` and `password` respectively for Druid `admin` user.
+AuthSecret contains a `username` key and a `password` key which contains the `username` and `password` respectively for Druid `admin` user.
 
 Example:
 
@@ -246,7 +246,7 @@ spec:
 ```
 ### spec.topology
 
-`spec.topology` represents the topology configuration for Druid cluster in KRaft mode.
+`spec.topology` represents the topology configuration for Druid cluster.
 
 When `spec.topology` is set, the following fields needs to be empty, otherwise validating webhook will throw error.
 
@@ -508,7 +508,7 @@ The `spec.<node-name>.podTemplate.spec.containers[].name` field used to specify 
 
 ##### spec.<node-name>.podTemplate.spec.containers[].env
 
-`spec.<node-name>.podTemplate.spec.containers[].env` is an optional field that specifies the environment variables to pass to the Redis containers.
+`spec.<node-name>.podTemplate.spec.containers[].env` is an optional field that specifies the environment variables to pass to the Druid containers.
 
 ##### spec.<node-name>.podTemplate.spec.containers[].resources
 

--- a/docs/guides/druid/concepts/druidopsrequest.md
+++ b/docs/guides/druid/concepts/druidopsrequest.md
@@ -357,10 +357,11 @@ Example usage of this field is given below:
 ```yaml
 spec:
   volumeExpansion:
-    node: "2Gi"
+    historicals: "2Gi"
+    middleManagers: "2Gi"
 ```
 
-This will expand the volume size of all the combined nodes to 2 GB.
+This will expand the volume size of the `historicals` and `middleManagers` nodes to 2 GB.
 
 ### spec.configuration
 
@@ -377,7 +378,7 @@ middleManagers.properties: |
 
 - `applyConfig` contains the new custom config as a string which will be merged with the previous configuration.
 
-- `applyConfig` is a map where key supports 3 values, namely `server.properties`, `broker.properties`, `controller.properties`. And value represents the corresponding configurations.
+- `applyConfig` is a map where key supports values like `common.runtime.properties`, `coordinators.properties`, `overlords.properties`, `brokers.properties`, `routers.properties`, `historicals.properties` and `middleManagers.properties`. And value represents the corresponding configurations.
 
 ```yaml
   applyConfig:

--- a/docs/guides/druid/configuration/config-file/index.md
+++ b/docs/guides/druid/configuration/config-file/index.md
@@ -123,7 +123,7 @@ Let's create a k8s secret containing the above configuration where the file name
 apiVersion: v1
 kind: Secret
 metadata:
-  name: configsecret
+  name: config-secret
   namespace: demo
 stringData:
   middleManagers.properties: |-
@@ -266,9 +266,9 @@ You can see that there are 5 task slots reflecting with our provided custom conf
 To cleanup the Kubernetes resources created by this tutorial, run:
 
 ```bash
-$ kubectl delete dr -n demo druid-dev 
+$ kubectl delete dr -n demo druid-with-config 
 
-$ kubectl delete secret -n demo configsecret-combined 
+$ kubectl delete secret -n demo config-secret 
 
 $ kubectl delete namespace demo
 ```

--- a/docs/guides/druid/configuration/config-file/yamls/config-secret.yaml
+++ b/docs/guides/druid/configuration/config-file/yamls/config-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: new-config
+  name: config-secret
   namespace: demo
 stringData:
   middleManagers.properties: |-

--- a/docs/guides/druid/configuration/podtemplating/index.md
+++ b/docs/guides/druid/configuration/podtemplating/index.md
@@ -298,9 +298,9 @@ druid-node-selector   kubedb.com/v1alpha2   36.0.0    Ready    54m
 ```
 You can verify that by running `kubectl get pods -n demo druid-node-selector-0 -o wide` and looking at the “NODE” to which the Pod was assigned.
 ```bash
-$ kubectl get pods -n demo druid-node-selector-cooridnators-0 -o wide
+$ kubectl get pods -n demo druid-node-selector-coordinators-0 -o wide
 NAME                                    READY   STATUS    RESTARTS   AGE     IP            NODE                         NOMINATED NODE   READINESS GATES
-druid-node-selector-cooridnators-0      1/1     Running   0          3m19s   10.2.1.7   lke212553-307295-5541798e0000   <none>           <none>
+druid-node-selector-coordinators-0      1/1     Running   0          3m19s   10.2.1.7   lke212553-307295-5541798e0000   <none>           <none>
 ```
 We can successfully verify that our pod was scheduled to our desired node.
 
@@ -385,7 +385,7 @@ Check that the petset's pod is running or not,
 $ kubectl get pods -n demo -l app.kubernetes.io/instance=druid-without-tolerations
 NAME                                          READY   STATUS    RESTARTS   AGE
 druid-without-tolerations-brokers-0           0/1     Pending   0          3m35s
-druid-without-tolerations-cooridnators-0      0/1     Pending   0          3m35s
+druid-without-tolerations-coordinators-0      0/1     Pending   0          3m35s
 druid-without-tolerations-historicals-0       0/1     Pending   0          3m35s
 druid-without-tolerations-middlemanager-0     0/1     Pending   0          3m35s
 druid-without-tolerations-routers-0           0/1     Pending   0          3m35s

--- a/docs/guides/druid/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/druid/monitoring/using-builtin-prometheus.md
@@ -103,7 +103,7 @@ druid-with-monitoring-stats           ClusterIP     10.96.222.96    <none>      
 Here, `druid-with-monitoring-stats` service has been created for monitoring purpose. Let's describe the service.
 
 ```bash
-$ kubectl describe svc -n druid-demo builtin-prom-stats
+$ kubectl describe svc -n demo druid-with-monitoring-stats
 Name:              druid-with-monitoring-stats
 Namespace:         demo
 Labels:            app.kubernetes.io/component=database

--- a/docs/guides/druid/reconfigure/overview.md
+++ b/docs/guides/druid/reconfigure/overview.md
@@ -19,8 +19,8 @@ This guide will give an overview on how KubeDB Ops-manager operator reconfigures
 ## Before You Begin
 
 - You should be familiar with the following `KubeDB` concepts:
-    - [Druid](/docs/guides/kafka/concepts/kafka.md)
-    - [DruidOpsRequest](/docs/guides/kafka/concepts/kafkaopsrequest.md)
+    - [Druid](/docs/guides/druid/concepts/druid.md)
+    - [DruidOpsRequest](/docs/guides/druid/concepts/druidopsrequest.md)
 
 ## How Reconfiguring Druid Process Works
 
@@ -45,7 +45,7 @@ The Reconfiguring Druid process consists of the following steps:
 
 6. When it finds a `DruidOpsRequest` CR, it halts the `Druid` object which is referred from the `DruidOpsRequest`. So, the `KubeDB` Provisioner  operator doesn't perform any operations on the `Druid` object during the reconfiguring process.
 
-7. Then the `KubeDB` Ops-manager operator will replace the existing configuration with the new configuration provided or merge the new configuration with the existing configuration according to the `MogoDBOpsRequest` CR.
+7. Then the `KubeDB` Ops-manager operator will replace the existing configuration with the new configuration provided or merge the new configuration with the existing configuration according to the `DruidOpsRequest` CR.
 
 8. Then the `KubeDB` Ops-manager operator will restart the related PetSet Pods so that they restart with the new configuration defined in the `DruidOpsRequest` CR.
 

--- a/docs/guides/druid/scaling/vertical-scaling/guide.md
+++ b/docs/guides/druid/scaling/vertical-scaling/guide.md
@@ -381,7 +381,7 @@ Status:
     Status:                True
     Type:                  CheckPodRunning--druid-cluster-historicals-0
     Last Transition Time:  2024-10-21T12:54:23Z
-    Message:               Successfully completed the vertical scaling for RabbitMQ
+    Message:               Successfully completed the vertical scaling for Druid
     Observed Generation:   1
     Reason:                Successful
     Status:                True

--- a/docs/guides/druid/scaling/vertical-scaling/overview.md
+++ b/docs/guides/druid/scaling/vertical-scaling/overview.md
@@ -19,8 +19,8 @@ This guide will give an overview on how KubeDB Ops-manager operator updates the 
 ## Before You Begin
 
 - You should be familiar with the following `KubeDB` concepts:
-    - [Druid](/docs/guides/kafka/concepts/kafka.md)
-    - [DruidOpsRequest](/docs/guides/kafka/concepts/kafkaopsrequest.md)
+    - [Druid](/docs/guides/druid/concepts/druid.md)
+    - [DruidOpsRequest](/docs/guides/druid/concepts/druidopsrequest.md)
 
 ## How Vertical Scaling Process Works
 

--- a/docs/guides/druid/update-version/guide.md
+++ b/docs/guides/druid/update-version/guide.md
@@ -96,7 +96,7 @@ In this section, we are going to deploy a Druid topology cluster. Then, in the n
 apiVersion: kubedb.com/v1alpha2
 kind: Druid
 metadata:
-  name: druid-quickstart
+  name: druid-cluster
   namespace: demo
 spec:
   version: 35.0.1


### PR DESCRIPTION
Found by re-running the Druid guides on a live KubeDB v2026.6.19 cluster (single-node k3s) after the previous druid docs-refresh PR merged. These are bugs still present in current master. Each fix is verified against the source of truth (apimachinery API types, the installed `druid-addon` tasks, repo file listing) or observed cluster behavior.

## Empirically verified on cluster
- **configuration/config-file**: the Druid CR `druid-with-config` sets `spec.configuration.secretName: config-secret`, but `yamls/config-secret.yaml` creates a secret named `new-config`. Following the guide verbatim leaves every pod stuck in `Init` with `MountVolume.SetUp failed for volume "custom-config": secret "config-secret" not found`. Creating a secret named `config-secret` unblocks the pods. Fixed the secret name to `config-secret` and the inconsistent inline/cleanup names (`configsecret`, `druid-dev`, `configsecret-combined`).

## Source-verified fixes
- **concepts/druid.md**: auth secret example `druid-admin-cred` -> `druid-auth` (`Druid.GetAuthSecretName()` returns `<name>-auth`); auth key `user` -> `username`; `31.0.1` -> `31.0.0` (not in the DruidVersion catalog); dropped Kafka `KRaft mode` wording; `Redis containers` -> `Druid containers`.
- **concepts/druidopsrequest.md**: `volumeExpansion.node` -> `historicals`/`middleManagers` (the only expandable nodes per `DruidVolumeExpansionSpec`); `applyConfig` keys corrected from Kafka `server/broker/controller.properties` to Druid property files.
- **reconfigure/overview.md, scaling/vertical-scaling/overview.md**: `Before You Begin` links pointed at `/docs/guides/kafka/...`; corrected to druid. `MogoDBOpsRequest` -> `DruidOpsRequest`.
- **autoscaler**: `compute/yamls/druid-autoscaler.yaml` metadata name `druid-storage-autoscaler` -> `druid-autoscaler` (the guide applies this file then references `druid-autoscaler`); storage guide `spec.clusterRef.name` -> `spec.databaseRef.name`; `druidutoscaler` typo -> `druidautoscaler`; `RabbitMQ` -> `Druid` in describe output.
- **clustering/guide**: patch output `kafka.kubedb.com/druid-cluster patched` -> `druid.kubedb.com/...`.
- **update-version/guide**: inline CR name `druid-quickstart` -> `druid-cluster` (matches the applied file and every other reference).
- **configuration/podtemplating**: `cooridnators` -> `coordinators` (the `kubectl get pods ...` command fails as written).
- **monitoring/using-builtin-prometheus**: `kubectl describe svc -n druid-demo builtin-prom-stats` -> `-n demo druid-with-monitoring-stats` (matches the output shown directly below it).
- **backup**: PostgreSQL metadata note in a backup context said `postgres-metadata-storage-restore` -> `postgres-metadata-storage-backup`; customization RestoreSession examples used `mysql-metadata-storage-backup` -> `mysql-metadata-storage-restore` (the `druid-addon` provides both `-backup` and `-restore` tasks; restore must use `-restore`).

## Not included (need maintainer rewrite, filed separately from this mechanical pass)
- `reconfigure/guide.md` is heavily Kafka-contaminated (DB referenced as `druid-prod`, a `druid-configs.sh --bootstrap-server` verification command with no Druid equivalent, `kfops-*` ops name applying a nonexistent example file). Needs a real reconfigure run to rewrite, not a mechanical fix.
- `failover/guide.md` applies `docs/examples/druid/quickstart/druid-with-monitoring.yaml`, which does not exist.
- `configuration/podtemplating/index.md` still describes Pinot `aggregator`/`leaf` nodes.
- `concepts/druid.md` `spec.replicas` section references Kafka `controller`/`broker` replicas.

Guides executed on the cluster: quickstart, rotate-auth, config-file (all pass; config-file only after the fix).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple Druid guides to match the current resource names, commands, and examples.
  * Fixed several walkthroughs and status messages so they now reference Druid correctly, including autoscaling, scaling, monitoring, configuration, backup/restore, reconfiguration, and version update docs.
  * Clarified configuration and restore examples to use the proper backup/restore task names and updated prerequisite links to Druid-specific concepts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->