### PR TITLE
docs(hazelcast): fix wrong DB names in ops output and scaling title

### DIFF
--- a/docs/guides/hazelcast/autoscaler/compute/hazelcast-compute.md
+++ b/docs/guides/hazelcast/autoscaler/compute/hazelcast-compute.md
@@ -399,7 +399,7 @@ Status:
     Status:                True
     Type:                  EvictPod--hazelcast-dev-1
     Last Transition Time:  2025-08-20T05:08:24Z
-    Message:               Successfully completed the vertical scaling for RabbitMQ
+    Message:               Successfully completed the vertical scaling for Hazelcast
     Observed Generation:   1
     Reason:                Successful
     Status:                True

--- a/docs/guides/hazelcast/rotate-auth/hazelcast.md
+++ b/docs/guides/hazelcast/rotate-auth/hazelcast.md
@@ -208,7 +208,7 @@ Status:
     Status:                True
     Type:                  RunningPod--hazelcast-quickstart-1
     Last Transition Time:  2025-08-18T06:57:06Z
-    Message:               Successfully completed reconfigure Ignite
+    Message:               Successfully completed reconfigure Hazelcast
     Observed Generation:   1
     Reason:                Successful
     Status:                True
@@ -373,7 +373,7 @@ Status:
     Status:                True
     Type:                  RunningPod--hazelcast-quickstart-1
     Last Transition Time:  2025-08-18T07:13:21Z
-    Message:               Successfully completed reconfigure Ignite
+    Message:               Successfully completed reconfigure Hazelcast
     Observed Generation:   1
     Reason:                Successful
     Status:                True

--- a/docs/guides/hazelcast/scaling/_index.md
+++ b/docs/guides/hazelcast/scaling/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Scaling Memcached
+title: Scaling Hazelcast
 menu:
   docs_{{ .version }}:
     identifier: hz-scaling

--- a/docs/guides/hazelcast/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/hazelcast/scaling/vertical-scaling/vertical-scaling.md
@@ -239,7 +239,7 @@ Status:
     Status:                True
     Type:                  EvictPod--hz-prod-1
     Last Transition Time:  2025-08-19T11:12:50Z
-    Message:               Successfully completed the vertical scaling for RabbitMQ
+    Message:               Successfully completed the vertical scaling for Hazelcast
     Observed Generation:   1
     Reason:                Successful
     Status:                True


### PR DESCRIPTION
Follow-up docs-refresh re-run for Hazelcast against current master (KubeDB v2026.6.19). The prior PR #962 is merged; this run re-validated every Hazelcast guide (server-side dry-run of all example YAMLs plus source-of-truth cross-check, since the cluster still lacks a valid Hazelcast enterprise license so no CR can reach Ready) and found copy-paste bugs from other databases still present in shown output and one page title.

Each correct value is confirmed against the operator source in `kubedb/hazelcast/pkg/ops/*.go`.

### Fixes (guide: wrong -> right, how verified)

1. `scaling/vertical-scaling/vertical-scaling.md`
   - `Message: Successfully completed the vertical scaling for RabbitMQ` -> `... for Hazelcast`
   - `pkg/ops/vertical_scaling.go` emits "Successfully completed the vertical scaling for Hazelcast"; the output block is for pod `hz-prod-1` (a Hazelcast).

2. `autoscaler/compute/hazelcast-compute.md`
   - same message `... for RabbitMQ` -> `... for Hazelcast`
   - same source; output block is for pod `hazelcast-dev-1`.

3-4. `rotate-auth/hazelcast.md` (two occurrences)
   - `Message: Successfully completed reconfigure Ignite` -> `... reconfigure Hazelcast`
   - `pkg/ops/rotate_auth.go` emits "Successfully completed reconfigure Hazelcast"; output blocks are for pod `hazelcast-quickstart-1`.

5. `scaling/_index.md`
   - page title `Scaling Memcached` -> `Scaling Hazelcast`
   - peer database scaling indexes use `Scaling <DB>` (e.g. Kafka, Druid, ClickHouse).

### Not changed (flagged for maintainers)
- `monitoring/overview.md` shows a `kind: Redis` sample and redis/mysql/mongodb next-step links; this is a shared cross-db template (solr has the identical content), not a hazelcast-specific regression.
- `tls/overview.md` reuses `/docs/images/solr/tls.svg` (no hazelcast equivalent exists; solr uses it too).

No em-dashes. All base CRs pass server dry-run; example-file references all resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Hazelcast guides to reflect the correct product name and completion messages in example command outputs.
  * Fixed scaling and rotation walkthroughs so the final status messages consistently reference Hazelcast.
  * Renamed the scaling guide page title to match Hazelcast instead of the previous product name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->