### PR TITLE
docs: fix codespan schema check errors

### DIFF
--- a/docs/examples/pgbouncer/private-registry/pvt-pgbouncerversion.yaml
+++ b/docs/examples/pgbouncer/private-registry/pvt-pgbouncerversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: PgBouncerVersion
 metadata:
-  name: "pvt-1.17.0"
+  name: "1.17.0"
 spec:
   exporter:
     image: PRIVATE_REGISTRY/pgbouncer_exporter:v0.1.1

--- a/docs/guides/hanadb/concepts/hanadb.md
+++ b/docs/guides/hanadb/concepts/hanadb.md
@@ -43,6 +43,7 @@ spec:
       replicationMode: fullsync
       operationMode: logreplay_readaccess
   authSecret:
+    kind: Secret
     name: hanadb-cluster-auth
   configuration:
     secretName: hanadb-configuration

--- a/docs/guides/milvus/recommendation/guide.md
+++ b/docs/guides/milvus/recommendation/guide.md
@@ -68,6 +68,7 @@ spec:
       requests:
         storage: 1Gi
   authSecret:
+    kind: Secret
     name: milvus-standalone-auth
     rotateAfter: 15m
   tls:

--- a/docs/guides/milvus/recommendation/yamls/distributed.yaml
+++ b/docs/guides/milvus/recommendation/yamls/distributed.yaml
@@ -21,6 +21,7 @@ spec:
             requests:
               storage: 1Gi
   authSecret:
+    kind: Secret
     name: milvus-cluster-auth
     rotateAfter: 15m
   tls:

--- a/docs/guides/milvus/recommendation/yamls/standalone.yaml
+++ b/docs/guides/milvus/recommendation/yamls/standalone.yaml
@@ -19,6 +19,7 @@ spec:
       requests:
         storage: 1Gi
   authSecret:
+    kind: Secret
     name: milvus-standalone-auth
     rotateAfter: 15m
   tls:

--- a/docs/guides/milvus/rotate-auth/guide.md
+++ b/docs/guides/milvus/rotate-auth/guide.md
@@ -71,6 +71,7 @@ spec:
     name: milvus-standalone
   authentication:
     secretRef:
+      kind: Secret
       name: milvus-new-auth1
 ```
 
@@ -154,6 +155,7 @@ spec:
     name: milvus-cluster
   authentication:
     secretRef:
+      kind: Secret
       name: milvus-new-auth1
 ```
 

--- a/docs/guides/milvus/rotate-auth/yamls/rotate-auth-distributed.yaml
+++ b/docs/guides/milvus/rotate-auth/yamls/rotate-auth-distributed.yaml
@@ -20,4 +20,5 @@ spec:
     name: milvus-cluster
   authentication:
     secretRef:
+      kind: Secret
       name: milvus-new-auth1

--- a/docs/guides/milvus/rotate-auth/yamls/rotate-auth-standalone.yaml
+++ b/docs/guides/milvus/rotate-auth/yamls/rotate-auth-standalone.yaml
@@ -20,4 +20,5 @@ spec:
     name: milvus-standalone
   authentication:
     secretRef:
+      kind: Secret
       name: milvus-new-auth1

--- a/docs/guides/pgbouncer/private-registry/using-private-registry.md
+++ b/docs/guides/pgbouncer/private-registry/using-private-registry.md
@@ -94,12 +94,12 @@ Now, create the PgBouncerVersion crd,
 
 ```bash
 $ kubectl apply -f pvt-pgbouncerversion.yaml
-pgbouncerversion.kubedb.com/pvt-1.17.0 created
+pgbouncerversion.kubedb.com/1.17.0 created
 ```
 
 ## Deploy PgBouncer from Private Registry
 
-While deploying PgBouncer from private repository, you have to add `myregistrykey` secret in PgBouncer `spec.podTemplate.spec.imagePullSecrets` and specify `pvt-1.17.0` in `spec.version` field.
+While deploying PgBouncer from private repository, you have to add `myregistrykey` secret in PgBouncer `spec.podTemplate.spec.imagePullSecrets` and specify `1.17.0` in `spec.version` field.
 
 Below is the PgBouncer object we will create in this tutorial
 

--- a/docs/guides/weaviate/concepts/weaviate.md
+++ b/docs/guides/weaviate/concepts/weaviate.md
@@ -40,6 +40,7 @@ spec:
       requests:
         storage: 1Gi
   authSecret:
+    kind: Secret
     name: weaviate-sample-auth
   configuration:
     secretName: weaviate-custom-config

--- a/docs/guides/weaviate/quickstart/quickstart.md
+++ b/docs/guides/weaviate/quickstart/quickstart.md
@@ -491,8 +491,6 @@ spec:
       port: 8080
       scheme: http
   secret:
-    apiGroup: ""
-    kind: ""
     name: weaviate-sample-auth
   type: kubedb.com/weaviate
   version: 1.33.1


### PR DESCRIPTION
Fixes the failing `Check codespan schema` CI job.

## Fixed
- **authSecret** — added required `kind: Secret` in full manifests: `hanadb/concepts`, `milvus/recommendation` (guide + distributed/standalone yamls), `weaviate/concepts`.
- **MilvusOpsRequest secretRef** — added required `kind: Secret` in `milvus/rotate-auth` (guide + both yamls).
- **Weaviate AppBinding** — removed invalid `apiGroup`/`kind` from `spec.secret` (only `name` is allowed).
- **PgBouncer private-registry** — renamed `PgBouncerVersion` `pvt-1.17.0` → `1.17.0` (a real catalog version, matching the guide's PgBouncer resource) and updated the two matching mentions.

## Not addressed (need feature/catalog work by owners)
- `rabbitmq/initialization/script_source.md` uses `spec.init`, which the RabbitMQ CRD does not define.
- `ignite/update-version/update-version.md` demos `2.16.0 → 2.17.0`, but the catalog only ships `2.17.0` (no older version to upgrade from).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified several setup and example manifests across PgBouncer, HanaDB, Milvus, and Weaviate guides.
  * Added missing `kind: Secret` fields in secret references to make examples more complete and consistent.
  * Updated PgBouncer private-registry examples to use the plain version name `1.17.0`.
  * Cleaned up a Weaviate quickstart example by removing empty fields from the service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->