### PR TITLE
docs(ignite): fix config filename, hscale field, and TLS cert paths

### DIFF
--- a/docs/guides/ignite/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/ignite/reconfigure-tls/reconfigure-tls.md
@@ -298,7 +298,7 @@ Now we are going to rotate the certificate of this database. First let's check t
 
 ```bash
 $ kubectl exec -it ig-2 -n demo bash
-root@ig-2:/# openssl x509 -in /var/private/ssl/client.pem -inform PEM -enddate -nameopt RFC2253 -noout
+root@ig-2:/# openssl x509 -in /ignite/certs/client/tls.crt -inform PEM -enddate -nameopt RFC2253 -noout
 notAfter=Jun  9 13:32:20 2025 GMT
 ```
 
@@ -445,7 +445,7 @@ Now, let's check the expiration date of the certificate.
 
 ```bash
 $ kubectl exec -it ig-2 -n demo bash
-root@ig-2:/# openssl x509 -in /var/run/ignite/tls/client.pem -inform PEM -enddate -nameopt RFC2253 -noout
+root@ig-2:/# openssl x509 -in /ignite/certs/client/tls.crt -inform PEM -enddate -nameopt RFC2253 -noout
 notAfter=Jun  9 16:17:55 2025 GMT
 ```
 
@@ -641,7 +641,7 @@ Now, Let's exec into a database node and find out the ca subject to see if it ma
 
 ```bash
 $ kubectl exec -it ig-2 -n demo bash
-root@mgo-rs-tls-2:/$ openssl x509 -in /var/run/ignite/tls/ca.crt -inform PEM -subject -nameopt RFC2253 -noout
+root@ig-2:/$ openssl x509 -in /ignite/certs/client/ca.crt -inform PEM -subject -nameopt RFC2253 -noout
 subject=O=kubedb-updated,CN=ca-updated
 ```
 

--- a/docs/guides/ignite/reconfigure/reconfigure.md
+++ b/docs/guides/ignite/reconfigure/reconfigure.md
@@ -44,7 +44,7 @@ Now, we are going to deploy a `Ignite` cluster with version `2.17.0`.
 
 ### Deploy Ignite
 
-At first, we will create `ignite.conf` file containing required configuration settings.
+At first, we will create `node-configuration.xml` file containing required configuration settings.
 
 Now, we will create a secret with this configuration file.
 
@@ -106,7 +106,7 @@ m6lXjZugrC4VEpB8
 Now, we will create a new secret with this configuration file.
 
 ```bash
-$ kubectl create secret generic -n demo new-custom-config --from-file=./ignite.conf
+$ kubectl create secret generic -n demo new-custom-config --from-file=./node-configuration.xml
 secret/new-custom-config created
 ```
 

--- a/docs/guides/ignite/scaling/horizontal-scaling/horizontal-scaling.md
+++ b/docs/guides/ignite/scaling/horizontal-scaling/horizontal-scaling.md
@@ -118,7 +118,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing horizontal scaling operation on ignite.
 - `spec.type` specifies that we are performing `HorizontalScaling` on our ignite.
-- `spec.horizontalScaling.replicas` specifies the desired replicas after scaling.
+- `spec.horizontalScaling.node` specifies the desired number of nodes after scaling.
 
 Let's create the `IgniteOpsRequest` CR we have shown above,
 
@@ -265,7 +265,7 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing horizontal scaling down operation on `ignite` ignite.
 - `spec.type` specifies that we are performing `HorizontalScaling` on our ignite.
-- `spec.horizontalScaling.replicas` specifies the desired replicas after scaling.
+- `spec.horizontalScaling.node` specifies the desired number of nodes after scaling.
 
 Let's create the `IgniteOpsRequest` CR we have shown above,
 


### PR DESCRIPTION
Full re-run of the Ignite docs refresher against current master (prior refresh PR #964 is already merged). Executed the guides on a live KubeDB v2026.6.19 cluster (docs HEAD v2026.6.19-31, IgniteVersion 2.17.0, kubectl dba v0.52.0) and confirmed each value against the source of truth (kubedb/apimachinery, kubedb/ignite) and observed cluster behavior.

## Fixes

### reconfigure/reconfigure.md (verified live)
- The reconfigure config secret must contain a file named `node-configuration.xml`. The guide created `new-custom-config` from `./ignite.conf`, and the Reconfigure IgniteOpsRequest is rejected by the operator webhook: `spec.configuration: Invalid value: config secret demo/new-custom-config does not have file named 'node-configuration.xml'`. Recreating the secret from `./node-configuration.xml` makes the ops Successful. Corrected the prose ("we will create ... file") and the `kubectl create secret --from-file` command. Confirmed against `apimachinery` `IgniteConfigFileName = "node-configuration.xml"` and `ignite/pkg/controller/secret.go`.

### scaling/horizontal-scaling/horizontal-scaling.md (verified live)
- The IgniteOpsRequest horizontal scaling field is `spec.horizontalScaling.node`, not `spec.horizontalScaling.replicas`. The YAML blocks already use `node`; two field descriptions said `replicas`. Corrected both. Confirmed against `apimachinery` `IgniteHorizontalScalingSpec` (`json:"node"`) and by running scale up (node:4) and scale down (node:2) ops, both Successful.

### reconfigure-tls/reconfigure-tls.md (verified live)
- TLS certificates are mounted at `/ignite/certs/client` (`tls.crt`, `ca.crt`, `keystore.jks`, `truststore.jks`), not `/var/private/ssl/client.pem` or `/var/run/ignite/tls/{client.pem,ca.crt}`. Corrected the three openssl verification paths (and one stray `mgo-rs-tls-2` prompt to `ig-2`). Confirmed against `apimachinery` `IgniteTLSClientMountPath = "/ignite/certs/client"` and by `kubectl exec ... ls /ignite/certs/client` on a TLS-enabled cluster; ReconfigureTLS add/remove ops both Successful.

## Verification
Deployed and ran live on the cluster: quickstart (sqlline), restart, horizontal + vertical scaling, reconfigure (secret + applyConfig), reconfigure-tls (add + remove), custom-configuration (config-file + podTemplate env), custom-rbac, and builtin-prometheus. Version references (IgniteVersion 2.17.0) match the catalog; no version reference needed changing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TLS reconfiguration instructions to use the correct certificate file locations for expiration and CA checks.
  * Revised the reconfiguration guide to reference the new configuration file name and matching secret creation command.
  * Clarified horizontal scaling examples to describe the desired node count after scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->