### PR TITLE
docs(memcached): fix commands, names, and a malformed example found by executing the guides

### DIFF
--- a/docs/examples/memcached/private-registry/demo-2.yaml
+++ b/docs/examples/memcached/private-registry/demo-2.yaml
@@ -11,13 +11,11 @@ spec:
       containers:
         - name: memcached
           resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 250m
-            memory: 64Mi
-  podTemplate:
-    spec:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 250m
+              memory: 64Mi
       imagePullSecrets:
-      - name: myregistrykey
+        - name: myregistrykey

--- a/docs/guides/memcached/custom-configuration/using-config-file.md
+++ b/docs/guides/memcached/custom-configuration/using-config-file.md
@@ -51,7 +51,7 @@ apiVersion: v1
 stringData:
   memcached.conf: |
     --conn-limit=500
-    --memory-limit=128
+    --memory-limit=512
 kind: Secret
 metadata:
   name: mc-configuration
@@ -147,11 +147,17 @@ $ telnet 127.0.0.1 11211
 Trying 127.0.0.1...
 Connected to 127.0.0.1.
 Escape character is '^]'.
+# Authenticate first. Without this, the server returns `CLIENT_ERROR unauthenticated`.
+# The value is the `username` and `password` (from the auth secret) separated by a space,
+# and the byte count is the length of that value.
+set auth 0 0 21
+user tysiujogcmzapyhz
+STORED
 stats
 ...
 STAT max_connections 500
 ...
-STAT limit_maxbytes 134217728
+STAT limit_maxbytes 536870912
 ...
 END
 ```

--- a/docs/guides/memcached/custom-rbac/using-custom-rbac.md
+++ b/docs/guides/memcached/custom-rbac/using-custom-rbac.md
@@ -179,7 +179,7 @@ Now, create Memcached crd `minute-memcached` using the existing service account 
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/custom-rbac/mc-custom-db-two.yaml
-memcached.kubedb.com/quick-memcached created
+memcached.kubedb.com/minute-memcached created
 ```
 
 Below is the YAML for the Memcached crd we just created.

--- a/docs/guides/memcached/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/memcached/monitoring/using-builtin-prometheus.md
@@ -278,7 +278,7 @@ data:
 Let's create above `ConfigMap`,
 
 ```bash
-$ kubectl apply -f kubectl apply -f https://github.com/kubedb/docs/raw/v2024.8.21/docs/examples/monitoring/builtin-prometheus/prom-config.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/monitoring/builtin-prometheus/prom-config.yaml
 configmap/prometheus-config created
 ```
 

--- a/docs/guides/memcached/quickstart/quickstart.md
+++ b/docs/guides/memcached/quickstart/quickstart.md
@@ -396,7 +396,7 @@ When `deletionPolicy` is set to `DoNotTerminate`, KubeDB takes advantage of `Val
 
 ```bash
 $ kubectl delete mc memcd-quickstart -n demo
-Error from server (Forbidden): admission webhook "memcachedwebhook.validators.kubedb.com" denied the request: memcached demo/memcd-quickstart is can't terminated. To delete, change spec.deletionPolicy
+Error from server (Forbidden): admission webhook "memcachedwebhook.validators.kubedb.com" denied the request: memcached demo/memcd-quickstart can't be terminated. To delete, change spec.deletionPolicy
 ```
 Learn details of all `DeletionPolicy` [here](/docs/guides/memcached/concepts/memcached.md#specdeletionpolicy).
 

--- a/docs/guides/memcached/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/memcached/reconfigure-tls/reconfigure-tls.md
@@ -790,7 +790,7 @@ Let's create the `MemcachedOpsRequest` CR we have shown above,
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/reconfigure-tls/mc-ops-tls-remove.yaml
-Memcachedopsrequest.ops.kubedb.com/mc-ops-tls-remove created
+memcachedopsrequest.ops.kubedb.com/mc-ops-tls-remove created
 ```
 
 #### Verify TLS Removed Successfully

--- a/docs/guides/memcached/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/memcached/reconfigure-tls/reconfigure-tls.md
@@ -790,7 +790,7 @@ Let's create the `MemcachedOpsRequest` CR we have shown above,
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/memcached/reconfigure-tls/mc-ops-tls-remove.yaml
-Memcachedopsrequest.ops.kubedb.com/mc-ops-remove created
+Memcachedopsrequest.ops.kubedb.com/mc-ops-tls-remove created
 ```
 
 #### Verify TLS Removed Successfully
@@ -913,9 +913,9 @@ $ kubectl delete issuer -n demo memcached-ca-issuer mc-new-issuer
 issuer.cert-manager.io "memcached-ca-issuer" deleted
 issuer.cert-manager.io "mc-new-issuer" deleted
 
-$ kubectl delete memcachedopsrequest -n demo mc-add-tls mc-ops-remove mc-ops-rotate mc-change-issuer
+$ kubectl delete memcachedopsrequest -n demo mc-add-tls mc-ops-tls-remove mc-ops-rotate mc-change-issuer
 memcachedopsrequest.ops.kubedb.com "mc-add-tls" deleted
-memcachedopsrequest.ops.kubedb.com "mc-ops-remove" deleted
+memcachedopsrequest.ops.kubedb.com "mc-ops-tls-remove" deleted
 memcachedopsrequest.ops.kubedb.com "mc-ops-rotate" deleted
 memcachedopsrequest.ops.kubedb.com "mc-change-issuer" deleted
 ```

--- a/docs/guides/memcached/reconfigure/reconfigure.md
+++ b/docs/guides/memcached/reconfigure/reconfigure.md
@@ -113,6 +113,11 @@ $ telnet 127.0.0.1 11211
 Trying 127.0.0.1...
 Connected to 127.0.0.1.
 Escape character is '^]'.
+# Authenticate first. Without this, the server returns `CLIENT_ERROR unauthenticated`.
+# The value is the username and password (from the auth secret) separated by a space.
+set auth 0 0 21
+user tysiujogcmzapyhz
+STORED
 stats
 ...
 STAT max_connections 500
@@ -296,6 +301,11 @@ $ telnet 127.0.0.1 11211
 Trying 127.0.0.1...
 Connected to 127.0.0.1.
 Escape character is '^]'.
+# Authenticate first. Without this, the server returns `CLIENT_ERROR unauthenticated`.
+# The value is the username and password (from the auth secret) separated by a space.
+set auth 0 0 21
+user tysiujogcmzapyhz
+STORED
 stats
 ...
 STAT max_connections 2000
@@ -453,6 +463,11 @@ $ telnet 127.0.0.1 11211
 Trying 127.0.0.1...
 Connected to 127.0.0.1.
 Escape character is '^]'.
+# Authenticate first. Without this, the server returns `CLIENT_ERROR unauthenticated`.
+# The value is the username and password (from the auth secret) separated by a space.
+set auth 0 0 21
+user tysiujogcmzapyhz
+STORED
 stats
 ...
 STAT max_connections 3000

--- a/docs/guides/memcached/rotate-auth/rotateauth.md
+++ b/docs/guides/memcached/rotate-auth/rotateauth.md
@@ -55,7 +55,7 @@ NAME       VERSION   DB_IMAGE                                          DEPRECATE
 1.6.33     1.6.33    ghcr.io/appscode-images/memcached:1.6.33-alpine                5d19h
 ```
 
-> **Note:** YAML files used in this tutorial are stored in [docs/examples/memcached](/docs/examples/memcached/update-version) directory of [kubedb/docs](https://github.com/kubedb/docs) repository.
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/memcached/rotate-auth](/docs/examples/memcached/rotate-auth) directory of [kubedb/docs](https://github.com/kubedb/docs) repository.
 
 ## Create a Memcached Server
 
@@ -509,7 +509,7 @@ Connection closed by foreign host.
 ```
 Your credentials have been rotated successfully, so everything’s working.
 
-Also, there will be two more new keys in the secretthat stores the previous credentials. The keys are `username.prev` and `password.prev`. You can find the secretand its data by running the following command:
+Also, there will be a new key in the secretthat stores the previous credentials. The key is `authData.prev`. You can find the secretand its data by running the following command:
 ```shell
 $ kubectl get secret -n demo mc-new-auth -o go-template='{{ index .data "authData.prev" }}' | base64 -d
 user:yjf3Oc;ZlSs.iMVO
@@ -524,12 +524,15 @@ To clean up the Kubernetes resources you can delete the CRD or namespace.
 Or, you can delete one by one resource by their name by this tutorial, run:
 
 ```shell
-$ kubectl delete Memcachedopsrequest mcops-rotate-auth-generated mcops-rotate-auth-user -n demo
-Memcachedopsrequest.ops.kubedb.com "mcops-rotate-auth-generated" "mcops-rotate-auth-user" deleted
+$ kubectl delete memcachedopsrequest -n demo mcops-rotate-auth-generated mcops-rotate-auth-user
+memcachedopsrequest.ops.kubedb.com "mcops-rotate-auth-generated" deleted
+memcachedopsrequest.ops.kubedb.com "mcops-rotate-auth-user" deleted
 $ kubectl delete secret -n demo mc-new-auth
-secret"mc-new-auth" deleted
-$ kubectl delete secret -n demo  memcd-quickstart-auth
-secret"memcd-quickstart-auth" deleted
+secret "mc-new-auth" deleted
+$ kubectl delete secret -n demo memcd-quickstart-auth
+secret "memcd-quickstart-auth" deleted
+$ kubectl delete memcached -n demo memcd-quickstart
+memcached.kubedb.com "memcd-quickstart" deleted
 ```
 
 ## Next Steps

--- a/docs/guides/memcached/rotate-auth/rotateauth.md
+++ b/docs/guides/memcached/rotate-auth/rotateauth.md
@@ -55,7 +55,7 @@ NAME       VERSION   DB_IMAGE                                          DEPRECATE
 1.6.33     1.6.33    ghcr.io/appscode-images/memcached:1.6.33-alpine                5d19h
 ```
 
-> **Note:** YAML files used in this tutorial are stored in [docs/examples/memcached](/docs/examples/memcached/update-version) directory of [kubedb/docs](https://github.com/kube/docs) repository.
+> **Note:** YAML files used in this tutorial are stored in [docs/examples/memcached](/docs/examples/memcached/update-version) directory of [kubedb/docs](https://github.com/kubedb/docs) repository.
 
 ## Create a Memcached Server
 
@@ -104,7 +104,7 @@ The user can verify whether they are authorized by executing a query directly in
 ````shell
 $ kubectl get memcached -n demo memcd-quickstart -ojson | jq .spec.authSecret.name
 "memcd-quickstart-auth"
-$ kubectl get secret-n demo memcd-quickstart-auth -o=jsonpath='{.data.authData}' | base64 -d
+$ kubectl get secret -n demo memcd-quickstart-auth -o=jsonpath='{.data.authData}' | base64 -d
 user:ikbkjbodeewenrgj
 ````
 Here, `username`is `user` and `password` is `ikbkjbodeewenrgj`
@@ -271,7 +271,7 @@ Events:
 ```shell
 $ kubectl get mc -n demo memcd-quickstart -ojson | jq .spec.authSecret.name
 "memcd-quickstart-auth"
-$ kubectl get secret-n demo memcd-quickstart-auth -o=jsonpath='{.data.authData}' | base64 -d
+$ kubectl get secret -n demo memcd-quickstart-auth -o=jsonpath='{.data.authData}' | base64 -d
 user:yjf3Oc;ZlSs.iMVO                    
 ```
 **Let's verify whether the credential is working or not:**
@@ -313,7 +313,7 @@ Your credentials have been rotated successfully, so everything’s working.
 Also, there will be two more new keys in the secretthat stores the previous credentials. The key is `authData.prev`. You can find the secretand its data by running the following command:
 
 ```shell
-$ kubectl get secret-n demo memcd-quickstart-auth -o go-template='{{ index .data "authData.prev" }}' | base64 -d
+$ kubectl get secret -n demo memcd-quickstart-auth -o go-template='{{ index .data "authData.prev" }}' | base64 -d
 user:ikbkjbodeewenrgj
 ```
 The above output shows that the password has been changed successfully. The previous username & password is stored for rollback purpose.
@@ -352,7 +352,7 @@ metadata:
 spec:
   type: RotateAuth
   databaseRef:
-    name: memcached-quickstart
+    name: memcd-quickstart
   authentication:
     secretRef:
       kind: Secret
@@ -469,7 +469,7 @@ Events:
 ```shell
 $ kubectl get mc -n demo memcd-quickstart -ojson | jq .spec.authSecret.name
 "mc-new-auth"
-$  kubectl get secret-n demo mc-new-auth -o=jsonpath='{.data.authData}' | base64 -d
+$  kubectl get secret -n demo mc-new-auth -o=jsonpath='{.data.authData}' | base64 -d
 user:pass                                                                                   
 ```
 **Let's verify whether the credential is working or not:**
@@ -511,7 +511,7 @@ Your credentials have been rotated successfully, so everything’s working.
 
 Also, there will be two more new keys in the secretthat stores the previous credentials. The keys are `username.prev` and `password.prev`. You can find the secretand its data by running the following command:
 ```shell
-$ kubectl get secret-n demo mc-new-auth -o go-template='{{ index .data "authData.prev" }}' | base64 -d
+$ kubectl get secret -n demo mc-new-auth -o go-template='{{ index .data "authData.prev" }}' | base64 -d
 user:yjf3Oc;ZlSs.iMVO
                   
 ```
@@ -526,9 +526,9 @@ Or, you can delete one by one resource by their name by this tutorial, run:
 ```shell
 $ kubectl delete Memcachedopsrequest mcops-rotate-auth-generated mcops-rotate-auth-user -n demo
 Memcachedopsrequest.ops.kubedb.com "mcops-rotate-auth-generated" "mcops-rotate-auth-user" deleted
-$ kubectl delete secret-n demo mc-new-auth
+$ kubectl delete secret -n demo mc-new-auth
 secret"mc-new-auth" deleted
-$ kubectl delete secret-n demo  memcd-quickstart-auth
+$ kubectl delete secret -n demo  memcd-quickstart-auth
 secret"memcd-quickstart-auth" deleted
 ```
 

--- a/docs/guides/memcached/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/memcached/scaling/vertical-scaling/vertical-scaling.md
@@ -185,7 +185,7 @@ To clean up the Kubernetes resources created by this turorial, run:
 
 ```bash
 
-$ kubectl patch -n demo mc/memcached-quickstart -p '{"spec":{"deletionPolicy":"WipeOut"}}' --type="merge"
+$ kubectl patch -n demo mc/memcd-quickstart -p '{"spec":{"deletionPolicy":"WipeOut"}}' --type="merge"
 memcached.kubedb.com/memcd-quickstart patched
 
 $ kubectl delete -n demo memcached memcd-quickstart

--- a/docs/guides/memcached/tls/tls.md
+++ b/docs/guides/memcached/tls/tls.md
@@ -31,7 +31,7 @@ KubeDB supports providing TLS/SSL encryption for `Memcached`. This tutorial will
   namespace/demo created
   ```
 
-> Note: YAML files used in this tutorial are stored in [docs/examples/Memcached](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/Memcached) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+> Note: YAML files used in this tutorial are stored in [docs/examples/memcached](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/examples/memcached) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
 
 ## Overview
 
@@ -129,7 +129,7 @@ memcached.kubedb.com/memcd-quickstart created
 Now, wait until `memcd-quickstart` has status `Ready`. i.e,
 
 ```bash
-$ watch kubectl get rd -n demo
+$ watch kubectl get memcached -n demo
 Every 2.0s: kubectl get memcached -n demo
 NAME               VERSION   STATUS   AGE
 memcd-quickstart   1.6.40    Ready    19m

--- a/docs/guides/memcached/update-version/update-version.md
+++ b/docs/guides/memcached/update-version/update-version.md
@@ -161,6 +161,6 @@ memcached.kubedb.com/memcd-quickstart patched
 $ kubectl delete -n demo Memcached memcd-quickstart
 memcached.kubedb.com "memcd-quickstart" deleted
 
-$ kubectl delete -n demo memcachedopsrequest update-standalone
+$ kubectl delete -n demo memcachedopsrequest update-memcd
 memcachedopsrequest.ops.kubedb.com "update-memcd" deleted
 ```


### PR DESCRIPTION
Follow-up docs refresh for memcached. Every guide under `docs/docs/guides/memcached/` was executed against a live KubeDB **v2026.6.19** cluster (`kubectl dba` v0.52.0); these are the remaining bugs that are still present on `master`. Each fix and how it was verified:

| Guide / file | Wrong | Right | Verified |
|---|---|---|---|
| quickstart/quickstart.md | `memcached ... is can't terminated` | `memcached ... can't be terminated` | live webhook output + `apimachinery/pkg/webhooks/kubedb/v1/memcached.go:332` |
| update-version/update-version.md | cleanup `memcachedopsrequest update-standalone` | `update-memcd` | opsrequest name is `update-memcd` (UpdateVersion ran Successful) |
| scaling/vertical-scaling/vertical-scaling.md | cleanup `mc/memcached-quickstart` | `mc/memcd-quickstart` | DB name is `memcd-quickstart` (vertical scaling ran Successful) |
| custom-configuration/using-config-file.md | inline `--memory-limit=128`; `limit_maxbytes 134217728`; no auth before `stats` | `--memory-limit=512`; `536870912`; add SASL auth step | example file uses 512; live `stats` with 512 -> `limit_maxbytes 536870912`; unauth `stats` -> `CLIENT_ERROR unauthenticated` |
| tls/tls.md | note path `docs/examples/Memcached`; `watch kubectl get rd` | `docs/examples/memcached`; `kubectl get memcached` | path casing; `rd` is the Redis short name |
| monitoring/using-builtin-prometheus.md | `kubectl apply -f kubectl apply -f .../v2024.8.21/...prom-config.yaml` | single `kubectl apply -f .../{{< param "info.version" >}}/...prom-config.yaml` | duplicated command; matches postgres/redis builtin guides |
| custom-rbac/using-custom-rbac.md | `mc-custom-db-two.yaml` output `quick-memcached created` | `minute-memcached created` | that manifest's object is `minute-memcached` (both DBs ran Ready) |
| reconfigure-tls/reconfigure-tls.md | `mc-ops-remove` (created output + cleanup) | `mc-ops-tls-remove` | the ops name is `mc-ops-tls-remove` (add/remove TLS ran Successful) |
| reconfigure/reconfigure.md | no auth before the 3 `stats` checks | add SASL auth step | unauth `stats` -> `CLIENT_ERROR unauthenticated` |
| rotate-auth/rotateauth.md | `kubectl get/delete secret-n demo` (7x); `github.com/kube/docs`; user-rotate `databaseRef.name: memcached-quickstart` | `secret -n demo`; `github.com/kubedb/docs`; `memcd-quickstart` | `secret-n` is not a resource; example file uses `memcd-quickstart` (both rotate flows ran Successful) |
| examples/memcached/private-registry/demo-2.yaml | duplicate `podTemplate:` key drops the `resources` block; broken `resources` indentation | single well-formed `podTemplate` with `resources` + `imagePullSecrets` | on cluster the corrected manifest yields a pod with both resources and imagePullSecrets (previously resources were silently dropped) |

Not included (out of scope for a docs fix):
- Operator bug: a `type: Reconfigure` MemcachedOpsRequest reports `Successful` but leaves the running pod on the old config revision (petset `updateRevision != currentRevision`); `stats` show the stale value until a manual pod restart. The docs' expected output is correct, so no doc change.
- Env-limited guides not fully executed: `monitoring/using-prometheus-operator` (no Prometheus operator) and `autoscaler/compute` (no metrics-server / VPA CRD).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Memcached guides with corrected example commands, resource names, and cleanup steps.
  * Updated authentication steps in several walkthroughs to match the current workflow before running checks.
  * Fixed outdated links, paths, and command outputs in TLS, monitoring, scaling, version update, and RBAC examples.
  * Clarified configuration examples, including updated memory settings and more accurate verification output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->