### PR TITLE
docs(mssqlserver): fix sqlcmd path, jq field name, and broken example references

### DIFF
--- a/docs/examples/mssqlserver/dag-cluster/mssqlserver-ca-issuer.yaml
+++ b/docs/examples/mssqlserver/dag-cluster/mssqlserver-ca-issuer.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: mssqlserver-ca-issuer
+  namespace: demo
+spec:
+  ca:
+    secretName: mssqlserver-ca

--- a/docs/guides/mssqlserver/clustering/ag_cluster.md
+++ b/docs/guides/mssqlserver/clustering/ag_cluster.md
@@ -631,7 +631,7 @@ We can see that, the primary node is now is `mssqlserver-ag-cluster-1`. The old 
 Lets exec into this new primary and see the availability replica role.
 ```bash
 $ kubectl exec -it mssqlserver-ag-cluster-1 -c mssql -n demo -- bash
-mssql@mssqlserver-ag-cluster-1:/$ opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "wFKDGnWgFP5Rdv92"
+mssql@mssqlserver-ag-cluster-1:/$ /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "wFKDGnWgFP5Rdv92" -No
 1> SELECT ar.replica_server_name, ars.role_desc
 2> FROM sys.dm_hadr_availability_replica_states ars
 3> INNER JOIN sys.availability_replicas ar ON ars.replica_id = ar.replica_id;

--- a/docs/guides/mssqlserver/initialization/index.md
+++ b/docs/guides/mssqlserver/initialization/index.md
@@ -150,7 +150,7 @@ spec:
 ```
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mssqlserver/initialization/yamls/initializ-standalone.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mssqlserver/initialization/initialize-standalone.yaml
 mssqlserver.kubedb.com/ms-init created
 ```
   </div>
@@ -208,7 +208,7 @@ spec:
 ```
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mssqlserver/initialization/yamls/initialize-ag-cluster.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mssqlserver/initialization/initialize-ag-cluster.yaml
 mssqlsever.kubedb.com/ms-ag-init created
 ```
   </div>

--- a/docs/guides/mssqlserver/reconfigure/standalone.md
+++ b/docs/guides/mssqlserver/reconfigure/standalone.md
@@ -234,8 +234,8 @@ Here,
 Let's create the `MSSQLServerOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mssqlserver/reconfigure/mops-reconfigure-standalone.yaml
-MSSQLServeropsrequest.ops.kubedb.com/mops-reconfigure-standalone created
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mssqlserver/reconfigure/msops-reconfigure-standalone.yaml
+MSSQLServeropsrequest.ops.kubedb.com/msops-reconfigure-standalone created
 ```
 
 #### Verify the new configuration is working 
@@ -255,7 +255,7 @@ msops-reconfigure-standalone   Reconfigure   Successful   2m42s
 We can see from the above output that the `MSSQLServerOpsRequest` has succeeded. If we describe the `MSSQLServerOpsRequest` we will get an overview of the steps that were followed to reconfigure the database.
 
 ```bash
-$ kubectl describe MSSQLServeropsrequest -n demo mops-reconfigure-standalone
+$ kubectl describe MSSQLServeropsrequest -n demo msops-reconfigure-standalone
 Name:         msops-reconfigure-standalone
 Namespace:    demo
 Labels:       <none>
@@ -531,5 +531,5 @@ To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
 kubectl delete ms -n demo ms-standalone
-kubectl delete MSSQLServeropsrequest -n demo mops-reconfigure-standalone msops-reconfigure-standalone-apply
+kubectl delete MSSQLServeropsrequest -n demo msops-reconfigure-standalone msops-reconfigure-standalone-apply
 ```

--- a/docs/guides/mssqlserver/rotate-auth/rotateauth.md
+++ b/docs/guides/mssqlserver/rotate-auth/rotateauth.md
@@ -133,7 +133,7 @@ mssqlserver-quickstart   2022-cu12   Ready    75m
 The user can verify whether they are authorized by executing a query directly in the database. To do this, the user needs `username` and `password` in order to connect to the database. Below is an example showing how to retrieve the credentials from the secret.
 
 ````shell
-$ kubectl get ms -n demo mssqlserver-quickstart -ojson | jq .spec.authsecret.name
+$ kubectl get ms -n demo mssqlserver-quickstart -ojson | jq .spec.authSecret.name
 "mssqlserver-quickstart-auth"
 $ kubectl get secret -n demo mssqlserver-quickstart-auth -o jsonpath='{.data.username}' | base64 -d
 sa⏎                            
@@ -291,7 +291,7 @@ Events:
 ```
 **Verify Auth is rotated**
 ```shell
-$ kubectl get ms -n demo mssqlserver-quickstart -ojson | jq .spec.authsecret.name
+$ kubectl get ms -n demo mssqlserver-quickstart -ojson | jq .spec.authSecret.name
 "mssqlserver-quickstart-auth"
 $ kubectl get secret -n demo mssqlserver-quickstart-auth -o jsonpath='{.data.username}' | base64 -d
 sa⏎  
@@ -485,7 +485,7 @@ Events:
 ```
 **Verify auth is rotate**
 ```shell
-$ kubectl get ms -n demo mssqlserver-quickstart -ojson | jq .spec.authsecret.name
+$ kubectl get ms -n demo mssqlserver-quickstart -ojson | jq .spec.authSecret.name
 "mssqlserver-quickstart-auth "
 $ kubectl get secret -n demo mssqlserver-quickstart-auth -o=jsonpath='{.data.username}' | base64 -d
 sa⏎                                      

--- a/docs/guides/mssqlserver/volume-expansion/ag_cluster.md
+++ b/docs/guides/mssqlserver/volume-expansion/ag_cluster.md
@@ -208,7 +208,7 @@ During `Online` VolumeExpansion KubeDB expands volume without deleting the pods,
 Let's create the `MSSQLServerOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/example/mssqlserver/volume-expansion/mops-volume-exp-ag-cluster.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mssqlserver/volume-expansion/mops-volume-exp-ag-cluster.yaml
 mssqlserveropsrequest.ops.kubedb.com/mops-volume-exp-ag-cluster created
 ```
 

--- a/docs/guides/mssqlserver/volume-expansion/standalone.md
+++ b/docs/guides/mssqlserver/volume-expansion/standalone.md
@@ -206,7 +206,7 @@ During `Online` VolumeExpansion KubeDB expands volume without deleting the pods,
 Let's create the `MSSQLServerOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/example/mssqlserver/volume-expansion/mops-volume-exp-std.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mssqlserver/volume-expansion/mops-volume-exp-std.yaml
 mssqlserveropsrequest.ops.kubedb.com/mops-volume-exp-std created
 ```
 


### PR DESCRIPTION
Follow-up docs refresher re-run for mssqlserver against current master. Each fix was found by executing the guides on a live KubeDB v2026.6.19 cluster (single-node k3s) and confirmed against the source of truth (apimachinery API types, the in-repo examples tree, and live pod/cluster behavior).

## Fixes

1. **clustering/ag_cluster.md** (failover section): connection command used `opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "..."` (missing leading `/` and the `18` suffix, and missing the `-No` flag). Every sibling command in the same file uses `/opt/mssql-tools18/bin/sqlcmd ... -No`. Fixed to match.
   - Verified: `/opt/mssql-tools/bin/sqlcmd` does not exist in the mssql container (`ls` returns no such file); `/opt/mssql-tools18/bin/sqlcmd ... -No` runs the documented query successfully.

2. **rotate-auth/rotateauth.md** (3 places): `kubectl get ms ... -ojson | jq .spec.authsecret.name` used the lowercase key `authsecret`. The field is camelCase `authSecret` (apimachinery `apis/kubedb/v1alpha2/mssqlserver_types.go`: `json:"authSecret"`). jq is case-sensitive, so the documented command returns `null`, not the secret name. Fixed to `.spec.authSecret.name`.

3. **reconfigure/standalone.md** (4 lines): the OpsRequest is named `msops-reconfigure-standalone` (inline YAML, describe output, get output, event log), but the apply URL, the "created" output, the `kubectl describe` command, and the cleanup `kubectl delete` used the typo `mops-reconfigure-standalone`. The URL 404s (the example file is `msops-reconfigure-standalone.yaml`) and the describe/delete commands would target a nonexistent object. Fixed all four to `msops-reconfigure-standalone`.

4. **initialization/index.md** (2 URLs): referenced `.../initialization/yamls/initializ-standalone.yaml` and `.../initialization/yamls/initialize-ag-cluster.yaml`. The `yamls/` subdirectory does not exist and `initializ-standalone` is misspelled. The real files are `.../initialization/initialize-standalone.yaml` and `.../initialization/initialize-ag-cluster.yaml`. Fixed (404 -> resolves).

5. **volume-expansion/standalone.md** and **volume-expansion/ag_cluster.md**: apply URLs used `docs/example/mssqlserver/...` (singular `example`); the files live under `docs/examples/...` (plural). Fixed (404 -> resolves).

6. **examples/mssqlserver/dag-cluster/mssqlserver-ca-issuer.yaml**: added the missing Issuer example file that `clustering/dag_cluster.md` creates via `kubectl create -f .../dag-cluster/mssqlserver-ca-issuer.yaml` (the reference 404'd). Content matches the Issuer YAML shown inline in the guide.

## Verification
- quickstart, restart, vertical-scaling, and rotate-auth OpsRequests were executed end-to-end on the cluster and reached their documented results.
- After the fixes, every `docs/examples/mssqlserver/*.yaml` URL referenced across the mssqlserver guide tree resolves to an existing file.
- No page front-matter or Hugo shortcodes were touched; no internal links changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an example manifest for an internal certificate issuer used by MSSQL Server demos.
  * Corrected several guide commands and links so examples point to the right paths and resource names.
  * Updated shell command examples to use the current SQL tools location and flags.
  * Fixed secret lookup syntax in authentication rotation steps for clearer verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->