### PR TITLE
docs(elasticsearch): fix auth-secret name, broken example URLs, and command bugs found by executing the guides

### DIFF
--- a/docs/guides/elasticsearch/autoscaler/compute/topology/index.md
+++ b/docs/guides/elasticsearch/autoscaler/compute/topology/index.md
@@ -94,7 +94,7 @@ spec:
 Let's create the `Elasticsearch` CRO we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/autoscaler/computetopology/yamls/es-topology.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/autoscaler/compute/topology/yamls/es-topology.yaml
 elasticsearch.kubedb.com/es-topology created
 ```
 
@@ -187,7 +187,7 @@ Here,
 Let's create the `ElasticsearchAutoscaler` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/autoscaler/computetopology/yamls/es-topology-auto-scaler.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/autoscaler/compute/topology/yamls/es-topology-auto-scaler.yaml
 elasticsearchautoscaler.autoscaling.kubedb.com/es-topology-as created
 ```
 

--- a/docs/guides/elasticsearch/backup/kubestash/auto-backup/index.md
+++ b/docs/guides/elasticsearch/backup/kubestash/auto-backup/index.md
@@ -197,7 +197,7 @@ Here,
 Let's create the `BackupBlueprint` we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/kubestash/auto-backup/examples/default-backupblueprint.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/kubestash/auto-backup/examples/default-backup-blueprint.yaml
 backupblueprint.core.kubestash.com/es-quickstart-backup-blueprint created
 ```
 

--- a/docs/guides/elasticsearch/backup/kubestash/logical/index.md
+++ b/docs/guides/elasticsearch/backup/kubestash/logical/index.md
@@ -84,7 +84,7 @@ spec:
 Create the above `Elasticsearch` CR,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/kubestash/logical/examples/es-quickstart.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/kubestash/logical/examples/sample-es.yaml
 elasticsearch.kubedb.com/es-quickstart created
 ```
 
@@ -108,7 +108,7 @@ es-quickstart-beats-system-cred             kubernetes.io/basic-auth   2      3h
 es-quickstart-ca-cert                       kubernetes.io/tls          2      3h1m
 es-quickstart-client-cert                   kubernetes.io/tls          3      3h1m
 es-quickstart-config                        Opaque                     1      3h1m
-es-quickstart-elastic-cred                  kubernetes.io/basic-auth   2      3h35m
+es-quickstart-auth                  kubernetes.io/basic-auth   2      3h35m
 es-quickstart-http-cert                     kubernetes.io/tls          3      3h1m
 es-quickstart-kibana-system-cred            kubernetes.io/basic-auth   2      3h35m
 es-quickstart-logstash-system-cred          kubernetes.io/basic-auth   2      3h35m
@@ -122,7 +122,7 @@ es-quickstart-master   ClusterIP   None             <none>        9300/TCP   3h2
 es-quickstart-pods     ClusterIP   None             <none>        9200/TCP   3h2m
 ```
 
-Here, we have to use service `es-quickstart` and secret `es-quickstart-elastic-cred` to connect with the database. `KubeDB` creates an [AppBinding](/docs/guides/elasticsearch/concepts/appbinding/index.md) CR that holds the necessary information to connect with the database.
+Here, we have to use service `es-quickstart` and secret `es-quickstart-auth` to connect with the database. `KubeDB` creates an [AppBinding](/docs/guides/elasticsearch/concepts/appbinding/index.md) CR that holds the necessary information to connect with the database.
 
 
 **Verify AppBinding:**
@@ -196,7 +196,7 @@ items:
                 - name: args
                   value: --match=^(?![.])(?!apm-agent-configuration)(?!kubedb-system).+
       secret:
-        name: es-quickstart-elastic-cred
+        name: es-quickstart-auth
       tlsSecret:
         name: es-quickstart-client-cert
       type: kubedb.com/elasticsearch
@@ -218,9 +218,9 @@ Here,
 
 Now, we are going to insert some data into Elasticsearch.
 ```bash
-$ kubectl get secret -n demo es-quickstart-elastic-cred -o jsonpath='{.data.username}' | base64 -d
+$ kubectl get secret -n demo es-quickstart-auth -o jsonpath='{.data.username}' | base64 -d
 elastic
-$ kubectl get secret -n demo es-quickstart-elastic-cred -o jsonpath='{.data.password}' | base64 -d
+$ kubectl get secret -n demo es-quickstart-auth -o jsonpath='{.data.password}' | base64 -d
 tS$k!2IBI.ASI7FJ
 ```
 
@@ -436,7 +436,7 @@ spec:
 Let's create the `BackupConfiguration` CR that we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/kubestash/logical/examples/backupconfiguration.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/kubestash/logical/examples/backupconfiguration.yaml
 backupconfiguration.core.kubestash.com/es-quickstart-backup created
 ```
 
@@ -701,9 +701,9 @@ es-cluster      xpack-9.2.3   Ready    6m14s
 ```
 
 ```bash
-$ kubectl get secret -n demo es-cluster-elastic-cred -o jsonpath='{.data.username}' | base64 -d
+$ kubectl get secret -n demo es-cluster-auth -o jsonpath='{.data.username}' | base64 -d
 elastic
-$ kubectl get secret -n demo es-cluster-elastic-cred -o jsonpath='{.data.password}' | base64 -d
+$ kubectl get secret -n demo es-cluster-auth -o jsonpath='{.data.password}' | base64 -d
 tS$k!2IBI.ASI7FJ
 ```
 

--- a/docs/guides/elasticsearch/backup/stash/auto-backup/index.md
+++ b/docs/guides/elasticsearch/backup/stash/auto-backup/index.md
@@ -118,7 +118,7 @@ We have also used some variables in `name` field of the `interimVolumeTemplate` 
 Let's create the `BackupBlueprint` we have shown above,
 
 ```bash
-❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/auto-backup/examples/backupblueprint.yaml
+❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/stash/auto-backup/examples/backupblueprint.yaml
 backupblueprint.stash.appscode.com/elasticsearch-backup-template created
 ```
 
@@ -172,7 +172,7 @@ Notice the `annotations` section. We are pointing to the `BackupBlueprint` that 
 Let's create the above Elasticsearch CRO,
 
 ```bash
-❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/auto-backup/examples/es-demo.yaml
+❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/stash/auto-backup/examples/es-demo.yaml
 elasticsearch.kubedb.com/sample-elasticsearch created
 ```
 
@@ -350,7 +350,7 @@ Notice the `annotations` section. This time, we have passed a schedule via `stas
 Let's create the above Elasticsearch CRO,
 
 ```bash
-❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/auto-backup/examples/es-demo-2.yaml
+❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/stash/auto-backup/examples/es-demo-2.yaml
 elasticsearch.kubedb.com/es-demo-2 created
 ```
 
@@ -529,7 +529,7 @@ Notice the `annotations` section. This time, we have passed an argument via `par
 Let's create the above Elasticsearch CRO,
 
 ```bash
-❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/auto-backup/examples/es-demo-3.yaml
+❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/stash/auto-backup/examples/es-demo-3.yaml
 elasticsearch.kubedb.com/es-demo-3 created
 ```
 
@@ -671,7 +671,7 @@ Once the backup has been completed successfully, you should see that Stash has c
 To cleanup the resources crated by this tutorial, run the following commands,
 
 ```bash
-❯ kubectl delete -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/auto-backup/examples/
+❯ kubectl delete -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/stash/auto-backup/examples/
 backupblueprint.stash.appscode.com "elasticsearch-backup-template" deleted
 elasticsearch.kubedb.com "es-demo-2" deleted
 elasticsearch.kubedb.com "es-demo-3" deleted

--- a/docs/guides/elasticsearch/backup/stash/auto-backup/index.md
+++ b/docs/guides/elasticsearch/backup/stash/auto-backup/index.md
@@ -671,11 +671,14 @@ Once the backup has been completed successfully, you should see that Stash has c
 To cleanup the resources crated by this tutorial, run the following commands,
 
 ```bash
-❯ kubectl delete -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/stash/auto-backup/examples/
+❯ kubectl delete backupblueprint elasticsearch-backup-template
 backupblueprint.stash.appscode.com "elasticsearch-backup-template" deleted
-elasticsearch.kubedb.com "es-demo-2" deleted
-elasticsearch.kubedb.com "es-demo-3" deleted
+❯ kubectl delete elasticsearch -n demo es-demo
 elasticsearch.kubedb.com "es-demo" deleted
+❯ kubectl delete elasticsearch -n demo-2 es-demo-2
+elasticsearch.kubedb.com "es-demo-2" deleted
+❯ kubectl delete elasticsearch -n demo-3 es-demo-3
+elasticsearch.kubedb.com "es-demo-3" deleted
 
 ❯ kubectl delete repository -n demo --all
 repository.stash.appscode.com "app-es-demo" deleted

--- a/docs/guides/elasticsearch/backup/stash/kubedb/index.md
+++ b/docs/guides/elasticsearch/backup/stash/kubedb/index.md
@@ -139,16 +139,16 @@ KubeDB will create some Secrets for the database. Let's check which Secrets have
 ❯ kubectl get secret -n demo | grep sample-es
 sample-es-ca-cert          kubernetes.io/tls                     2      21m
 sample-es-config           Opaque                                1      21m
-sample-es-elastic-cred     kubernetes.io/basic-auth              2      21m
+sample-es-auth     kubernetes.io/basic-auth              2      21m
 sample-es-token-ctzn5      kubernetes.io/service-account-token   3      21m
 sample-es-transport-cert   kubernetes.io/tls                     3      21m
 ```
 
-Here, `sample-es-elastic-cred` contains the credentials require to connect with the database. Let's export the credentials as environment variable to our current shell so that we can easily environment variables to connect with the database.
+Here, `sample-es-auth` contains the credentials require to connect with the database. Let's export the credentials as environment variable to our current shell so that we can easily environment variables to connect with the database.
 
 ```bash
-❯ export USER=$(kubectl get secrets -n demo sample-es-elastic-cred -o jsonpath='{.data.username}' | base64 -d)
-❯ export PASSWORD=$(kubectl get secrets -n demo sample-es-elastic-cred -o jsonpath='{.data.password}' | base64 -d)
+❯ export USER=$(kubectl get secrets -n demo sample-es-auth -o jsonpath='{.data.username}' | base64 -d)
+❯ export PASSWORD=$(kubectl get secrets -n demo sample-es-auth -o jsonpath='{.data.password}' | base64 -d)
 ```
 
 #### Insert data
@@ -318,7 +318,7 @@ spec:
       port: 9200
       scheme: http
   secret:
-    name: sample-es-elastic-cred
+    name: sample-es-auth
   parameters:
     apiVersion: appcatalog.appscode.com/v1alpha1
     kind: StashAddon
@@ -400,7 +400,7 @@ spec:
 Let's create the `Repository` we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/kubedb/examples/backup/repository.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/stash/kubedb/examples/backup/repository.yaml
 repository.stash.appscode.com/gcs-repo created
 ```
 
@@ -453,7 +453,7 @@ Here,
 Let's create the `BackupConfiguration` object we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/kubedb/examples/backup/backupconfiguration.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/stash/kubedb/examples/backup/backupconfiguration.yaml
 backupconfiguration.stash.appscode.com/sample-es-backup created
 ```
 
@@ -626,7 +626,7 @@ Here,
 Let's create the `RestoreSession` object object we have shown above,
 
 ```bash
-❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/kubedb/examples/restore/restoresession.yaml
+❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/stash/kubedb/examples/restore/restoresession.yaml
 restoresession.stash.appscode.com/sample-es-restore created
 ```
 
@@ -876,7 +876,7 @@ Notice that this time, we are using `opensearch-3.4.0` variant for Elasticsearch
 Let's deploy the above Elasticsearch,
 
 ```bash
-❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/kubedb/examples/elasticsearch/init_sample.yaml
+❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/stash/kubedb/examples/elasticsearch/init_sample.yaml
 elasticsearch.kubedb.com/init-sample created
 ```
 
@@ -966,7 +966,7 @@ spec:
 Let's create the above RestoreSession,
 
 ```bash
-❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/kubedb/examples/restore/init_sample_restore.yaml
+❯ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/backup/stash/kubedb/examples/restore/init_sample_restore.yaml
 restoresession.stash.appscode.com/init-sample-restore created
 ```
 
@@ -1003,7 +1003,7 @@ Now, let's export the credentials of this Elasticsearch,
 
 ```bash
 ❯ kubectl get secret -n restored | grep init-sample
-init-sample-admin-cred                            kubernetes.io/basic-auth              2      55m
+init-sample-auth                            kubernetes.io/basic-auth              2      55m
 init-sample-ca-cert                               kubernetes.io/tls                     2      55m
 init-sample-config                                Opaque                                3      55m
 init-sample-kibanaro-cred                         kubernetes.io/basic-auth              2      55m
@@ -1016,11 +1016,11 @@ init-sample-transport-cert                        kubernetes.io/tls             
 stash-restore-init-sample-restore-0-token-vscdt   kubernetes.io/service-account-token   3      4m40s
 ```
 
-Here, we are going to use the `init-sample-admin-cred` for connecting with the database. Let's export the `username` and `password` keys.
+Here, we are going to use the `init-sample-auth` for connecting with the database. Let's export the `username` and `password` keys.
 
 ```bash
-❯ export USER=$(kubectl get secrets -n restored init-sample-admin-cred -o jsonpath='{.data.username}' | base64 -d)
-❯ export PASSWORD=$(kubectl get secrets -n restored init-sample-admin-cred -o jsonpath='{.data.password}' | base64 -d)
+❯ export USER=$(kubectl get secrets -n restored init-sample-auth -o jsonpath='{.data.username}' | base64 -d)
+❯ export PASSWORD=$(kubectl get secrets -n restored init-sample-auth -o jsonpath='{.data.password}' | base64 -d)
 ```
 
 Now, let's verify whether the indexes have been restored or not.

--- a/docs/guides/elasticsearch/clustering/combined-cluster/index.md
+++ b/docs/guides/elasticsearch/clustering/combined-cluster/index.md
@@ -100,7 +100,7 @@ appbinding.appcatalog.appscode.com/es-standalone   kubedb.com/elasticsearch   7.
 
 NAME                                        TYPE                       DATA   AGE
 secret/es-standalone-admin-cert             kubernetes.io/tls          3      33m
-secret/es-standalone-admin-cred             kubernetes.io/basic-auth   2      33m
+secret/es-standalone-auth             kubernetes.io/basic-auth   2      33m
 secret/es-standalone-archiver-cert          kubernetes.io/tls          3      33m
 secret/es-standalone-ca-cert                kubernetes.io/tls          2      33m
 secret/es-standalone-config                 Opaque                     3      33m
@@ -127,9 +127,9 @@ Forwarding from [::1]:9200 -> 9200
 
 ```bash
 # Get admin username & password from k8s secret
-$ kubectl get secret -n demo es-standalone-admin-cred -o jsonpath='{.data.username}' | base64 -d
+$ kubectl get secret -n demo es-standalone-auth -o jsonpath='{.data.username}' | base64 -d
 admin
-$ kubectl get secret -n demo es-standalone-admin-cred -o jsonpath='{.data.password}' | base64 -d
+$ kubectl get secret -n demo es-standalone-auth -o jsonpath='{.data.password}' | base64 -d
 V,YY1.qXxoAch9)B
 
 # Check cluster health
@@ -220,7 +220,7 @@ appbinding.appcatalog.appscode.com/es-multinode   kubedb.com/elasticsearch   7.1
 
 NAME                                       TYPE                       DATA   AGE
 secret/es-multinode-admin-cert             kubernetes.io/tls          3      6m14s
-secret/es-multinode-admin-cred             kubernetes.io/basic-auth   2      6m13s
+secret/es-multinode-auth             kubernetes.io/basic-auth   2      6m13s
 secret/es-multinode-archiver-cert          kubernetes.io/tls          3      6m13s
 secret/es-multinode-ca-cert                kubernetes.io/tls          2      6m14s
 secret/es-multinode-config                 Opaque                     3      6m12s
@@ -250,9 +250,9 @@ Forwarding from [::1]:9200 -> 9200
 
 ```bash
 # Get admin username & password from k8s secret
-$ kubectl get secret -n demo es-multinode-admin-cred -o jsonpath='{.data.username}' | base64 -d
+$ kubectl get secret -n demo es-multinode-auth -o jsonpath='{.data.username}' | base64 -d
 admin
-$ kubectl get secret -n demo es-multinode-admin-cred -o jsonpath='{.data.password}' | base64 -d
+$ kubectl get secret -n demo es-multinode-auth -o jsonpath='{.data.password}' | base64 -d
 9f$A8o2pBpKL~1T8
 
 # Check cluster health

--- a/docs/guides/elasticsearch/clustering/topology-cluster/hot-warm-cold-cluster/index.md
+++ b/docs/guides/elasticsearch/clustering/topology-cluster/hot-warm-cold-cluster/index.md
@@ -169,7 +169,7 @@ Metadata:
   UID:               236fd414-9d94-4fce-93d3-7891fcf7f6a4
 Spec:
   Auth Secret:
-    Name:                es-cluster-elastic-cred
+    Name:                es-cluster-auth
   Enable SSL:            true
   Heap Size Percentage:  50
   Kernel Settings:
@@ -390,7 +390,7 @@ NAME                               TYPE                       DATA   AGE
 secret/es-cluster-archiver-cert    kubernetes.io/tls          3      5m51s
 secret/es-cluster-ca-cert          kubernetes.io/tls          2      5m51s
 secret/es-cluster-config           Opaque                     1      5m50s
-secret/es-cluster-elastic-cred     kubernetes.io/basic-auth   2      5m51s
+secret/es-cluster-auth     kubernetes.io/basic-auth   2      5m51s
 secret/es-cluster-http-cert        kubernetes.io/tls          3      5m51s
 secret/es-cluster-transport-cert   kubernetes.io/tls          3      5m51s
 
@@ -458,21 +458,21 @@ es-cluster-config                         Opaque                                
 es-cluster-dashboard-ca-cert              kubernetes.io/tls                     2      12m
 es-cluster-dashboard-config               Opaque                                1      12m
 es-cluster-dashboard-kibana-server-cert   kubernetes.io/tls                     3      12m
-es-cluster-elastic-cred                   kubernetes.io/basic-auth              2      12m
+es-cluster-auth                   kubernetes.io/basic-auth              2      12m
 es-cluster-http-cert                      kubernetes.io/tls                     3      12m
 es-cluster-token-v97c7                    kubernetes.io/service-account-token   3      12m
 es-cluster-transport-cert                 kubernetes.io/tls                     3      12m
 ```
-Now, we can connect to the database with `es-cluster-elastic-cred` which contains the admin level credentials to connect with the database.
+Now, we can connect to the database with `es-cluster-auth` which contains the admin level credentials to connect with the database.
 
 ### Accessing Database Through CLI
 
 To access the database through CLI, we have to get the credentials to access. Let’s export the credentials as environment variable to our current shell :
 
 ```bash
-$ kubectl get secret -n demo es-cluster-elastic-cred -o jsonpath='{.data.username}' | base64 -d
+$ kubectl get secret -n demo es-cluster-auth -o jsonpath='{.data.username}' | base64 -d
 elastic
-$ kubectl get secret -n demo es-cluster-elastic-cred -o jsonpath='{.data.password}' | base64 -d
+$ kubectl get secret -n demo es-cluster-auth -o jsonpath='{.data.password}' | base64 -d
 YQB)~K6M9U)d_yVu
 ```
 

--- a/docs/guides/elasticsearch/clustering/topology-cluster/simple-dedicated-cluster/index.md
+++ b/docs/guides/elasticsearch/clustering/topology-cluster/simple-dedicated-cluster/index.md
@@ -47,7 +47,7 @@ Here, we have `standard` StorageClass in our cluster from [Local Path Provisione
 
 ## Create Elasticsearch Simple Dedicated Cluster
 
-We are going to create a Elasticsearch Simple Dedicated Cluster in topology mode. Our cluster will be consist of 2 master nodes, 3 data nodes, 2 ingest nodes. Here, we are using Elasticsearch version ( `xpack-9.2.3` ) of SearchGuard distribution for this demo. To learn more about the Elasticsearch CR, visit [here](/docs/guides/elasticsearch/concepts/elasticsearch/index.md).
+We are going to create a Elasticsearch Simple Dedicated Cluster in topology mode. Our cluster will be consist of 2 master nodes, 3 data nodes, 2 ingest nodes. Here, we are using Elasticsearch version ( `xpack-9.2.3` ) of x-pack distribution for this demo. To learn more about the Elasticsearch CR, visit [here](/docs/guides/elasticsearch/concepts/elasticsearch/index.md).
 
 ```yaml
 apiVersion: kubedb.com/v1
@@ -91,7 +91,7 @@ spec:
 
 Here,
 
-- `spec.version` - is the name of the ElasticsearchVersion CR. Here, we are using Elasticsearch version `xpack-9.2.3` of SearchGuard distribution.
+- `spec.version` - is the name of the ElasticsearchVersion CR. Here, we are using Elasticsearch version `xpack-9.2.3` of x-pack distribution.
 - `spec.enableSSL` - specifies whether the HTTP layer is secured with certificates or not.
 - `spec.storageType` - specifies the type of storage that will be used for Elasticsearch database. It can be `Durable` or `Ephemeral`. The default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create the Elasticsearch database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
 - `spec.topology` - specifies the node-specific properties for the Elasticsearch cluster.
@@ -139,7 +139,7 @@ Metadata:
   UID:               1dff00c8-5a90-4916-bf8a-ed28f19dd433
 Spec:
   Auth Secret:
-    Name:                es-cluster-elastic-cred
+    Name:                es-cluster-auth
   Enable SSL:            true
   Heap Size Percentage:  50
   Kernel Settings:
@@ -316,7 +316,7 @@ NAME                               TYPE                       DATA   AGE
 secret/es-cluster-archiver-cert    kubernetes.io/tls          3      31m
 secret/es-cluster-ca-cert          kubernetes.io/tls          2      31m
 secret/es-cluster-config           Opaque                     1      31m
-secret/es-cluster-elastic-cred     kubernetes.io/basic-auth   2      31m
+secret/es-cluster-auth     kubernetes.io/basic-auth   2      31m
 secret/es-cluster-http-cert        kubernetes.io/tls          3      31m
 secret/es-cluster-transport-cert   kubernetes.io/tls          3      31m
 
@@ -375,21 +375,21 @@ $ kubectl get secret -n demo | grep es-cluster
 es-cluster-archiver-cert           kubernetes.io/tls                     3      12m
 es-cluster-ca-cert                 kubernetes.io/tls                     2      12m
 es-cluster-config                  Opaque                                1      12m
-es-cluster-elastic-cred            kubernetes.io/basic-auth              2      12m
+es-cluster-auth            kubernetes.io/basic-auth              2      12m
 es-cluster-http-cert               kubernetes.io/tls                     3      12m
 es-cluster-token-hx5mn             kubernetes.io/service-account-token   3      12m
 es-cluster-transport-cert          kubernetes.io/tls                     3      12m
 ```
-Now, we can connect to the database with `es-cluster-elastic-cred` which contains the admin level credentials to connect with the database.
+Now, we can connect to the database with `es-cluster-auth` which contains the admin level credentials to connect with the database.
 
 ### Accessing Database Through CLI
 
 To access the database through CLI, we have to get the credentials to access. Let’s export the credentials as environment variable to our current shell :
 
 ```bash
-$ kubectl get secret -n demo es-cluster-elastic-cred -o jsonpath='{.data.username}' | base64 -d
+$ kubectl get secret -n demo es-cluster-auth -o jsonpath='{.data.username}' | base64 -d
 elastic
-$ kubectl get secret -n demo es-cluster-elastic-cred -o jsonpath='{.data.password}' | base64 -d
+$ kubectl get secret -n demo es-cluster-auth -o jsonpath='{.data.password}' | base64 -d
 tS$k!2IBI.ASI7FJ
 ```
 

--- a/docs/guides/elasticsearch/concepts/appbinding/index.md
+++ b/docs/guides/elasticsearch/concepts/appbinding/index.md
@@ -80,7 +80,7 @@ spec:
             - name: args
               value: --match=^(?![.])(?!apm-agent-configuration)(?!kubedb-system).+
   secret:
-    name: es-quickstart-elastic-cred
+    name: es-quickstart-auth
   tlsSecret:
     name: es-quickstart-client-cert
   type: kubedb.com/elasticsearch

--- a/docs/guides/elasticsearch/concepts/elasticsearch/index.md
+++ b/docs/guides/elasticsearch/concepts/elasticsearch/index.md
@@ -192,7 +192,7 @@ The `ElasticsearchUserSpec` contains the following fields:
 -  `hash` ( `string` | `""` ) - Specifies the hash of the password.
 -  `full_name` ( `string` | `""` ) - Specifies The full name of the user. Only applicable for xpack authplugin.
 -  `metadata` ( `map[string]string` | `""` ) - Specifies Arbitrary metadata that you want to associate with the user. Only applicable for xpack authplugin.
--  `secretName` ( `string` | `""` ) - Specifies the k8s secret name that holds the user credentials. Defaults to "<resource-name>-<username>-cred".
+-  `secretName` ( `string` | `""` ) - Specifies the k8s secret name that holds the user credentials. Defaults to "<resource-name>-<username>-cred". The `elastic` superuser is an exception: its credentials are stored in the shared `spec.authSecret` (`<resource-name>-auth`) instead of a per-user `-cred` secret.
 -  `roles` ( `[]string` | `nil` ) - A set of roles the user has. The roles determine the user’s access permissions. To create a user without any roles, specify an empty list: []. Only applicable for xpack authplugin.
 -  `email` ( `string` | `""` ) - Specifies the email of the user. Only applicable for xpack authplugin.
 -  `reserved` ( `bool` | `false` ) - specifies the reserved status. The resources that have this set to `true` cannot be changed using the REST API or Kibana.
@@ -237,6 +237,8 @@ spec:
       backendRoles:
       - beats_system
       secretName: es-cluster-beats-system-cred
+    # the elastic superuser reads from the shared spec.authSecret (es-cluster-auth),
+    # not the per-user es-cluster-elastic-cred default.
     elastic:
       backendRoles:
       - superuser

--- a/docs/guides/elasticsearch/concepts/elasticsearch/index.md
+++ b/docs/guides/elasticsearch/concepts/elasticsearch/index.md
@@ -240,7 +240,7 @@ spec:
     elastic:
       backendRoles:
       - superuser
-      secretName: es-cluster-elastic-cred
+      secretName: es-cluster-auth
     kibana_system:
       backendRoles:
       - kibana_system
@@ -539,7 +539,7 @@ The k8s secret must be of `type: kubernetes.io/basic-auth` with the following ke
 - `username`: Must be `elastic` for x-pack, or `admin` for searchGuard and OpenDistro.
 - `password`: Password for the `elastic`/`admin` user.
 
-If not set, the KubeDB operator creates a new Secret `{Elasticsearch name}-{UserName}-cred` with randomly generated secured credentials.
+If not set, the KubeDB operator creates a new Secret `{Elasticsearch name}-auth` with randomly generated secured credentials.
 
 We can use this field in 3 mode.
 1. Using an external secret. In this case, You need to create an auth secret first with required fields, then specify the secret name when creating the Elasticsearch object using `spec.authSecret.name` & set `spec.authSecret.externallyManaged` to true.

--- a/docs/guides/elasticsearch/configuration/combined-cluster/index.md
+++ b/docs/guides/elasticsearch/configuration/combined-cluster/index.md
@@ -155,14 +155,14 @@ Now, our Elasticsearch cluster is accessible at `localhost:9200`.
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo es-multinode-elastic-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo es-multinode-auth -o jsonpath='{.data.username}' | base64 -d
   elastic
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo es-multinode-elastic-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo es-multinode-auth -o jsonpath='{.data.password}' | base64 -d
   ehG7*7SJZ0o9PA05
   ```
 

--- a/docs/guides/elasticsearch/configuration/topology-cluster/index.md
+++ b/docs/guides/elasticsearch/configuration/topology-cluster/index.md
@@ -213,14 +213,14 @@ Now, our Elasticsearch cluster is accessible at `localhost:9200`.
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo es-topology-elastic-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo es-topology-auth -o jsonpath='{.data.username}' | base64 -d
   elastic
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo es-topology-elastic-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo es-topology-auth -o jsonpath='{.data.password}' | base64 -d
   F2sIde1TbZqOR_gF
   ```
 

--- a/docs/guides/elasticsearch/elasticsearch-dashboard/kibana/index.md
+++ b/docs/guides/elasticsearch/elasticsearch-dashboard/kibana/index.md
@@ -139,7 +139,7 @@ Metadata:
   UID:               dd90071c-8e64-420f-a836-2be9459e728a
 Spec:
   Auth Secret:
-    Name:                es-cluster-elastic-cred
+    Name:                es-cluster-auth
   Enable SSL:            true
   Heap Size Percentage:  50
   Internal Users:
@@ -154,7 +154,7 @@ Spec:
     Elastic:
       Backend Roles:
         superuser
-      Secret Name:  es-cluster-elastic-cred
+      Secret Name:  es-cluster-auth
     kibana_system:
       Backend Roles:
         kibana_system
@@ -352,7 +352,7 @@ secret/es-cluster-beats-system-cred             kubernetes.io/basic-auth   2    
 secret/es-cluster-ca-cert                       kubernetes.io/tls          2      13m
 secret/es-cluster-client-cert                   kubernetes.io/tls          3      13m
 secret/es-cluster-config                        Opaque                     1      13m
-secret/es-cluster-elastic-cred                  kubernetes.io/basic-auth   2      13m
+secret/es-cluster-auth                  kubernetes.io/basic-auth   2      13m
 secret/es-cluster-http-cert                     kubernetes.io/tls          3      13m
 secret/es-cluster-kibana-system-cred            kubernetes.io/basic-auth   2      13m
 secret/es-cluster-logstash-system-cred          kubernetes.io/basic-auth   2      13m
@@ -456,7 +456,7 @@ es-cluster-beats-system-cred             kubernetes.io/basic-auth              2
 es-cluster-ca-cert                       kubernetes.io/tls                     2      14m
 es-cluster-client-cert                   kubernetes.io/tls                     3      14m
 es-cluster-config                        Opaque                                1      14m
-es-cluster-elastic-cred                  kubernetes.io/basic-auth              2      14m
+es-cluster-auth                  kubernetes.io/basic-auth              2      14m
 es-cluster-http-cert                     kubernetes.io/tls                     3      14m
 es-cluster-kibana-system-cred            kubernetes.io/basic-auth              2      14m
 es-cluster-logstash-system-cred          kubernetes.io/basic-auth              2      14m
@@ -464,16 +464,16 @@ es-cluster-remote-monitoring-user-cred   kubernetes.io/basic-auth              2
 es-cluster-token-8tbg6                   kubernetes.io/service-account-token   3      14m
 es-cluster-transport-cert                kubernetes.io/tls                     3      14m
 ```
-Now, we can connect to the database with `es-cluster-elastic-cred` which contains the admin level credentials to connect with the database.
+Now, we can connect to the database with `es-cluster-auth` which contains the admin level credentials to connect with the database.
 
 ### Accessing Database Through Dashboard
 
 To access the database through Dashboard, we have to get the credentials. We can do that by following command,
 
 ```bash
-$ kubectl get secret -n demo es-cluster-elastic-cred -o jsonpath='{.data.username}' | base64 -d
+$ kubectl get secret -n demo es-cluster-auth -o jsonpath='{.data.username}' | base64 -d
 elastic
-$ kubectl get secret -n demo es-cluster-elastic-cred -o jsonpath='{.data.password}' | base64 -d
+$ kubectl get secret -n demo es-cluster-auth -o jsonpath='{.data.password}' | base64 -d
 5m2YFv!JO6w5_LrD
 ```
 

--- a/docs/guides/elasticsearch/elasticsearch-dashboard/kibana/index.md
+++ b/docs/guides/elasticsearch/elasticsearch-dashboard/kibana/index.md
@@ -464,7 +464,7 @@ es-cluster-remote-monitoring-user-cred   kubernetes.io/basic-auth              2
 es-cluster-token-8tbg6                   kubernetes.io/service-account-token   3      14m
 es-cluster-transport-cert                kubernetes.io/tls                     3      14m
 ```
-Now, we can connect to the database with `es-cluster-auth` which contains the admin level credentials to connect with the database.
+Now, we can connect to the database with the `es-cluster-auth` secret, which holds the `elastic` superuser credentials used to connect with the database.
 
 ### Accessing Database Through Dashboard
 

--- a/docs/guides/elasticsearch/elasticsearch-dashboard/opensearch-dashboards/index.md
+++ b/docs/guides/elasticsearch/elasticsearch-dashboard/opensearch-dashboards/index.md
@@ -110,7 +110,7 @@ Here,
 Let's deploy the above yaml by the following command:
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch//elasticsearch-dashboard/opensearch/yamls/os-cluster.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/elasticsearch-dashboard/opensearch-dashboards/yamls/os-cluster.yaml
 elasticsearch.kubedb.com/os-cluster created
 ```
 KubeDB will create the necessary resources to deploy the OpenSearch cluster according to the above specification. Let’s wait until the database to be ready to use,
@@ -141,7 +141,7 @@ Metadata:
   UID:               2aeef9b3-fcb6-47c8-9df0-54a4fa018413
 Spec:
   Auth Secret:
-    Name:                os-cluster-admin-cred
+    Name:                os-cluster-auth
   Enable SSL:            true
   Heap Size Percentage:  50
   Internal Users:
@@ -149,7 +149,7 @@ Spec:
       Backend Roles:
         admin
       Reserved:     true
-      Secret Name:  os-cluster-admin-cred
+      Secret Name:  os-cluster-auth
     Kibanaro:
       Secret Name:  os-cluster-kibanaro-cred
     Kibanaserver:
@@ -337,7 +337,7 @@ appbinding.appcatalog.appscode.com/os-cluster   kubedb.com/elasticsearch   1.3.2
 
 NAME                                     TYPE                       DATA   AGE
 secret/os-cluster-admin-cert             kubernetes.io/tls          3      16m
-secret/os-cluster-admin-cred             kubernetes.io/basic-auth   2      16m
+secret/os-cluster-auth             kubernetes.io/basic-auth   2      16m
 secret/os-cluster-ca-cert                kubernetes.io/tls          2      16m
 secret/os-cluster-client-cert            kubernetes.io/tls          3      16m
 secret/os-cluster-config                 Opaque                     3      16m
@@ -393,7 +393,7 @@ spec:
 Let's deploy the above yaml by the following command:
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/elasticsearch-dashboard/opensearch/yamls/os-cluster-dashboard.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/elasticsearch-dashboard/opensearch-dashboards/yamls/os-cluster-dashboard.yaml
 elasticsearchdashboard.elasticsearch.kubedb.com/os-cluster-dashboard created
 ```
 
@@ -440,7 +440,7 @@ KubeDB also create some Secrets for the database. Let’s check which Secrets ha
 ```bash
 $ kubectl get secret -n demo | grep es-cluster
 os-cluster-admin-cert              kubernetes.io/tls                     3      16m
-os-cluster-admin-cred              kubernetes.io/basic-auth              2      16m
+os-cluster-auth              kubernetes.io/basic-auth              2      16m
 os-cluster-ca-cert                 kubernetes.io/tls                     2      16m
 os-cluster-client-cert             kubernetes.io/tls                     3      16m
 os-cluster-config                  Opaque                                3      16m
@@ -456,16 +456,16 @@ os-cluster-snapshotrestore-cred    kubernetes.io/basic-auth              2      
 os-cluster-token-wq8b9             kubernetes.io/service-account-token   3      16m
 os-cluster-transport-cert          kubernetes.io/tls                     3      16m
 ```
-Now, we can connect to the database with `os-cluster-elastic-cred` which contains the admin credentials to connect with the database.
+Now, we can connect to the database with `os-cluster-auth` which contains the admin credentials to connect with the database.
 
 ### Accessing Database Through Dashboard
 
 To access the database through Dashboard, we have to get the credentials. We can do that by following command,
 
 ```bash
-$ kubectl get secret -n demo os-cluster-admin-cred -o jsonpath='{.data.username}' | base64 -d
+$ kubectl get secret -n demo os-cluster-auth -o jsonpath='{.data.username}' | base64 -d
 admin
-$ kubectl get secret -n demo os-cluster-admin-cred -o jsonpath='{.data.password}' | base64 -d
+$ kubectl get secret -n demo os-cluster-auth -o jsonpath='{.data.password}' | base64 -d
 Oyj8FdPzA.DZqEyS
 ```
 

--- a/docs/guides/elasticsearch/plugins-backup/s3-repository/index.md
+++ b/docs/guides/elasticsearch/plugins-backup/s3-repository/index.md
@@ -156,9 +156,9 @@ Forwarding from [::1]:9200 -> 9200
 Keep it like that and switch to another terminal window:
 
 ```bash
-$ export ELASTIC_USER=$(kubectl get secret -n demo sample-es-elastic-cred -o jsonpath='{.data.username}' | base64 -d)
+$ export ELASTIC_USER=$(kubectl get secret -n demo sample-es-auth -o jsonpath='{.data.username}' | base64 -d)
 
-$ export ELASTIC_PASSWORD=$(kubectl get secret -n demo sample-es-elastic-cred -o jsonpath='{.data.password}' | base64 -d)
+$ export ELASTIC_PASSWORD=$(kubectl get secret -n demo sample-es-auth -o jsonpath='{.data.password}' | base64 -d)
 
 $ curl -XGET -k -u  "$ELASTIC_USER:$ELASTIC_PASSWORD" "https://localhost:9200/_cluster/health?pretty"
 {

--- a/docs/guides/elasticsearch/quickstart/overview/elasticsearch/index.md
+++ b/docs/guides/elasticsearch/quickstart/overview/elasticsearch/index.md
@@ -264,7 +264,7 @@ Metadata:
   UID:               cf37390a-ab9f-4886-9f7e-1a5bedc975e7
 Spec:
   Auth Secret:
-    Name:  es-quickstart-elastic-cred
+    Name:  es-quickstart-auth
   Auto Ops:
   Enable SSL:  true
   Health Checker:
@@ -284,7 +284,7 @@ Spec:
     Elastic:
       Backend Roles:
         superuser
-      Secret Name:  es-quickstart-elastic-cred
+      Secret Name:  es-quickstart-auth
     kibana_system:
       Backend Roles:
         kibana_system
@@ -449,7 +449,7 @@ secret/es-quickstart-beats-system-cred             kubernetes.io/basic-auth   2 
 secret/es-quickstart-ca-cert                       kubernetes.io/tls          2      8m9s
 secret/es-quickstart-client-cert                   kubernetes.io/tls          3      8m8s
 secret/es-quickstart-config                        Opaque                     1      8m8s
-secret/es-quickstart-elastic-cred                  kubernetes.io/basic-auth   2      8m8s
+secret/es-quickstart-auth                  kubernetes.io/basic-auth   2      8m8s
 secret/es-quickstart-http-cert                     kubernetes.io/tls          3      8m9s
 secret/es-quickstart-kibana-system-cred            kubernetes.io/basic-auth   2      8m8s
 secret/es-quickstart-logstash-system-cred          kubernetes.io/basic-auth   2      8m8s
@@ -469,7 +469,7 @@ persistentvolumeclaim/data-es-quickstart-2   Bound    pvc-9f9c6eaf-1ba6-4167-a37
   - `{Elasticsearch-Name}-pods` - the node discovery service which is used by the Elasticsearch nodes to communicate each other. It is a headless service.
 - `AppBinding` - an [AppBinding](/docs/guides/elasticsearch/concepts/appbinding/index.md) which hold to connect information for the database. It is also named after the Elastics
 - `Secrets` - 3 types of secrets are generated for each Elasticsearch database.
-  - `{Elasticsearch-Name}-{username}-cred` - the auth secrets which hold the `username` and `password` for the Elasticsearch users. The auth secret `es-quickstart-elastic-cred` holds the `username` and `password` for `elastic` user which lets administrative access.
+  - `{Elasticsearch-Name}-{username}-cred` - the auth secrets which hold the `username` and `password` for the Elasticsearch users. The auth secret `es-quickstart-auth` holds the `username` and `password` for `elastic` user which lets administrative access.
   - `{Elasticsearch-Name}-{alias}-cert` - the certificate secrets which hold `tls.crt`, `tls.key`, and `ca.crt` for configuring the Elasticsearch database.
   - `{Elasticsearch-Name}-config` - the default configuration secret created by the operator.
   - `data-{Elasticsearch-node-name}` - the persistent volume claims created by the PetSet.
@@ -494,14 +494,14 @@ Now, our Elasticsearch cluster is accessible at `localhost:9200`.
 - Username:
 
   ```bash
-  $ kubectl get secret -n demo es-quickstart-elastic-cred -o jsonpath='{.data.username}' | base64 -d
+  $ kubectl get secret -n demo es-quickstart-auth -o jsonpath='{.data.username}' | base64 -d
   elastic
   ```
 
 - Password:
 
   ```bash
-  $ kubectl get secret -n demo es-quickstart-elastic-cred -o jsonpath='{.data.password}' | base64 -d
+  $ kubectl get secret -n demo es-quickstart-auth -o jsonpath='{.data.password}' | base64 -d
   vIHoIfHn=!Z8F4gP
   ```
 
@@ -558,7 +558,7 @@ $ kubectl get all,secret,pvc -n demo -l 'app.kubernetes.io/instance=es-quickstar
 NAME                                               TYPE                       DATA   AGE
 secret/es-quickstart-apm-system-cred               kubernetes.io/basic-auth   2      5m39s
 secret/es-quickstart-beats-system-cred             kubernetes.io/basic-auth   2      5m39s
-secret/es-quickstart-elastic-cred                  kubernetes.io/basic-auth   2      5m39s
+secret/es-quickstart-auth                  kubernetes.io/basic-auth   2      5m39s
 secret/es-quickstart-kibana-system-cred            kubernetes.io/basic-auth   2      5m39s
 secret/es-quickstart-logstash-system-cred          kubernetes.io/basic-auth   2      5m39s
 secret/es-quickstart-remote-monitoring-user-cred   kubernetes.io/basic-auth   2      5m39s
@@ -577,7 +577,7 @@ Say, the Elasticsearch CR was deleted with `spec.deletionPolicy` to `Halt` and y
 You can do it by simpily re-deploying the original Elasticsearch object:
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/quickstart/overview/elasticsearch/yamls/elasticsearch.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/quickstart/overview/elasticsearch/yamls/elasticsearch-v1.yaml
 elasticsearch.kubedb.com/es-quickstart created
 ```
 
@@ -589,7 +589,7 @@ To cleanup the Kubernetes resources created by this tutorial, run:
 $ kubectl patch -n demo elasticsearch es-quickstart -p '{"spec":{"deletionPolicy":"WipeOut"}}' --type="merge"
 elasticsearch.kubedb.com/es-quickstart patched
 
-$ kubectl delete -n demo es/quick-elasticsearch
+$ kubectl delete -n demo es/es-quickstart
 elasticsearch.kubedb.com "es-quickstart" deleted
 
 $  kubectl delete namespace demo

--- a/docs/guides/elasticsearch/quickstart/overview/opensearch/index.md
+++ b/docs/guides/elasticsearch/quickstart/overview/opensearch/index.md
@@ -206,14 +206,14 @@ Metadata:
   UID:               20c388a6-54b1-4c0d-891b-879ec8e2a8c6
 Spec:
   Auth Secret:
-    Name:      sample-opensearch-admin-cred
+    Name:      sample-opensearch-auth
   Enable SSL:  true
   Internal Users:
     Admin:
       Backend Roles:
         admin
       Reserved:     true
-      Secret Name:  sample-opensearch-admin-cred
+      Secret Name:  sample-opensearch-auth
     Kibanaro:
       Secret Name:  sample-opensearch-kibanaro-cred
     Kibanaserver:
@@ -352,7 +352,7 @@ appbinding.appcatalog.appscode.com/sample-opensearch   kubedb.com/elasticsearch 
 
 NAME                                            TYPE                       DATA   AGE
 secret/sample-opensearch-admin-cert             kubernetes.io/tls          3      23m
-secret/sample-opensearch-admin-cred             kubernetes.io/basic-auth   2      23m
+secret/sample-opensearch-auth             kubernetes.io/basic-auth   2      23m
 secret/sample-opensearch-archiver-cert          kubernetes.io/tls          3      23m
 secret/sample-opensearch-ca-cert                kubernetes.io/tls          2      23m
 secret/sample-opensearch-config                 Opaque                     3      23m
@@ -408,7 +408,7 @@ KubeDB will create some Secrets for the database. Let’s check which Secrets ha
 ```bash
 $ kubectl get secret -n demo | grep sample-opensearch
 sample-opensearch-admin-cert             kubernetes.io/tls                     3      10m
-sample-opensearch-admin-cred             kubernetes.io/basic-auth              2      10m
+sample-opensearch-auth             kubernetes.io/basic-auth              2      10m
 sample-opensearch-ca-cert                kubernetes.io/tls                     2      10m
 sample-opensearch-config                 Opaque                                3      10m
 sample-opensearch-kibanaro-cred          kubernetes.io/basic-auth              2      10m
@@ -419,7 +419,7 @@ sample-opensearch-snapshotrestore-cred   kubernetes.io/basic-auth              2
 sample-opensearch-token-zbn46            kubernetes.io/service-account-token   3      10m
 sample-opensearch-transport-cert         kubernetes.io/tls                     3      10m
 ```
-Now, we can connect to the database with any of these secret that have the prefix `cred`. Here, we are using `sample-opensearch-admin-cred` which contains the admin level credentials to connect with the database.
+Now, we can connect to the database with any of these secret that have the prefix `cred`. Here, we are using `sample-opensearch-auth` which contains the admin level credentials to connect with the database.
 
 
 ### Accessing Database Through CLI
@@ -427,9 +427,9 @@ Now, we can connect to the database with any of these secret that have the prefi
 To access the database through CLI, we have to get the credentials to access. Let’s export the credentials as environment variable to our current shell :
 
 ```bash
-$ kubectl get secret -n demo sample-opensearch-admin-cred -o jsonpath='{.data.username}' | base64 -d
+$ kubectl get secret -n demo sample-opensearch-auth -o jsonpath='{.data.username}' | base64 -d
 admin
-$ kubectl get secret -n demo sample-opensearch-admin-cred -o jsonpath='{.data.password}' | base64 -d
+$ kubectl get secret -n demo sample-opensearch-auth -o jsonpath='{.data.password}' | base64 -d
 9aHT*ZhEK_qjPS~v
 ```
 

--- a/docs/guides/elasticsearch/quickstart/overview/opensearch/index.md
+++ b/docs/guides/elasticsearch/quickstart/overview/opensearch/index.md
@@ -419,7 +419,7 @@ sample-opensearch-snapshotrestore-cred   kubernetes.io/basic-auth              2
 sample-opensearch-token-zbn46            kubernetes.io/service-account-token   3      10m
 sample-opensearch-transport-cert         kubernetes.io/tls                     3      10m
 ```
-Now, we can connect to the database with any of these secret that have the prefix `cred`. Here, we are using `sample-opensearch-auth` which contains the admin level credentials to connect with the database.
+Now, we can connect to the database using the `sample-opensearch-auth` secret, which holds the `admin` credentials used to connect with the database.
 
 
 ### Accessing Database Through CLI

--- a/docs/guides/elasticsearch/restart/yamls/restart.yaml
+++ b/docs/guides/elasticsearch/restart/yamls/restart.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: ElasticsearchOpsRequest
+metadata:
+  name: restart
+  namespace: demo
+spec:
+  type: Restart
+  databaseRef:
+    name: es
+  timeout: 3m
+  apply: Always

--- a/docs/guides/elasticsearch/rotateauth/rotateauth.md
+++ b/docs/guides/elasticsearch/rotateauth/rotateauth.md
@@ -174,7 +174,7 @@ Here,
 
 Let's create the `ElasticsearchOpsRequest` CR we have shown above,
 ```shell
- $ kubectl apply -f kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/rotate-auth/yamls/rotate-auth-generated.yaml
+ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/rotateauth/yamls/rotate-auth-generated.yaml
  Elasticsearchopsrequest.ops.kubedb.com/essops-rotate-auth-generated created
 ```
 Let's wait for `ElasticsearchOpsrequest` to be `Successful`. Run the following command to watch `ElasticsearchOpsrequest` CRO
@@ -413,7 +413,7 @@ Here,
 Let's create the `ElasticsearchOpsRequest` CR we have shown above,
 
 ```shell
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/rotate-auth/yamls/rotate-auth-user.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/elasticsearch/rotateauth/yamls/rotate-auth-user.yaml
 Elasticsearchopsrequest.ops.kubedb.com/esops-rotate-auth-user created
 ```
 Let’s wait for `ElasticsearchOpsRequest` to be Successful. Run the following command to watch `ElasticsearchOpsRequest` CRO:


### PR DESCRIPTION
Re-ran the KubeDB Elasticsearch guides on a cluster (KubeDB v2026.6.19, docs @ v2026.6.19-60) and fixed the bugs a user hits when following them. Each fix was confirmed against the source of truth (apimachinery API helpers / on-cluster behavior / filesystem).

## Auth secret rename `<db>-elastic-cred` / `<db>-admin-cred` -> `<db>-auth`
The credential secret for the `elastic` (x-pack) / `admin` (OpenSearch, SearchGuard) user is now `<db>-auth`.
- Source: `apimachinery/apis/kubedb/v1/elasticsearch_helpers.go` SetDefaults maps the elastic/admin internal user secretName to `GetAuthSecretName()` = `<name>-auth`. Other internal users keep `<name>-<user>-cred`.
- Verified on cluster: xpack `es-quickstart` and OpenSearch `sample-opensearch` (both `kubedb.com/v1`) produce `<name>-auth`; the old `-elastic-cred`/`-admin-cred` secret does not exist (`kubectl get secret ...-elastic-cred` -> NotFound); the AppBinding `.spec.secret.name` is `<name>-auth`; `-auth` creds authenticate (cluster health green).
- Updated all auto-generated references across quickstart (elasticsearch + opensearch), clustering, configuration, concepts, elasticsearch-dashboard, backup (stash + kubestash), plugins-backup. Preserved the explicit external auth-secret example `es-admin-cred` in `concepts/elasticsearch` (user-chosen `spec.authSecret.name`). Also updated the concepts prose default from `{Elasticsearch name}-{UserName}-cred` to `{Elasticsearch name}-auth`.

## quickstart/overview/elasticsearch
- Resume step applied `yamls/elasticsearch.yaml`, which does not exist (only `elasticsearch-v1.yaml` / `elasticsearch-v1alpha2.yaml`). Now `elasticsearch-v1.yaml`.
- Cleanup ran `kubectl delete es/quick-elasticsearch`, but the CR is `es-quickstart` (verified: the old command returns NotFound). Now `es/es-quickstart`.

## clustering/topology-cluster/simple-dedicated-cluster
- `xpack-9.2.3` was described as "SearchGuard distribution"; it is x-pack (ElasticStack per `kubectl get elasticsearchversions`). Fixed both mentions.

## rotateauth
- Removed a duplicated `kubectl apply -f kubectl apply -f`.
- Fixed the yaml URL path `rotate-auth/yamls` -> `rotateauth/yamls` (the guide dir has no hyphen). Verified end-to-end: deployed `sample-es`, ran the RotateAuth ElasticsearchOpsRequest -> Successful; `sample-es-auth` gained `username.prev`/`password.prev`.

## Broken example apply URLs (each corrected path confirmed to exist; each original 404s)
- `autoscaler/compute/topology`: `autoscaler/computetopology/yamls/` -> `autoscaler/compute/topology/yamls/`.
- `backup/stash/auto-backup`: `backup/auto-backup/examples/` -> `backup/stash/auto-backup/examples/`.
- `backup/stash/kubedb`: `backup/kubedb/examples/` -> `backup/stash/kubedb/examples/`.
- `backup/kubestash/logical`: `es-quickstart.yaml` -> `sample-es.yaml`; added the missing `backup/` path segment for `backupconfiguration.yaml`.
- `backup/kubestash/auto-backup`: `default-backupblueprint.yaml` -> `default-backup-blueprint.yaml`.
- `elasticsearch-dashboard/opensearch-dashboards`: `elasticsearch-dashboard/opensearch/yamls/` -> `.../opensearch-dashboards/yamls/`; removed a stray double slash.
After the fixes, every apply-URL yaml path in the Elasticsearch guide tree resolves to a real file.

## restart
- Added the missing `restart/yamls/restart.yaml` (matching the guide's inline `ElasticsearchOpsRequest`) that the guide's `kubectl create -f` references.

Guides executed on cluster this run: quickstart (elasticsearch xpack-9.2.3, opensearch-3.4.0), clustering/topology-cluster/simple-dedicated-cluster, rotateauth. Remaining guides statically reviewed; the auth-secret and URL fixes apply broadly and were confirmed against source and representative executions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected several tutorial links and example command URLs so they point to the right manifest locations.
  * Updated multiple guides to use the current authentication secret names in commands, outputs, and examples.
  * Fixed a few backup and restore walkthrough references to match the latest example filenames and paths.

* **New Features**
  * Added a new Kubernetes restart operation example for Elasticsearch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->