### PR TITLE
docs(mysql): fix broken commands, links, and unsupported update target found by executing the guides

### DIFF
--- a/docs/guides/mysql/backup/stash/overview/index.md
+++ b/docs/guides/mysql/backup/stash/overview/index.md
@@ -85,4 +85,4 @@ The restore process consists of the following steps:
 
 ## Next Steps
 
-- Backup a standalone MySQL server using Stash by following the guides from [here](/docs/guides/mysql/backup/stash/standalone/index.md).
+- Backup a standalone MySQL server using Stash by following the [Backup & Restore Standalone MySQL](/docs/guides/mysql/backup/stash/standalone/index.md) guide.

--- a/docs/guides/mysql/backup/stash/overview/index.md
+++ b/docs/guides/mysql/backup/stash/overview/index.md
@@ -85,4 +85,4 @@ The restore process consists of the following steps:
 
 ## Next Steps
 
-- Backup a standalone MySQL server using Stash by following the guides from [here](/docs/guides/mysql/backup/stash/standalonedalone/index.md).
+- Backup a standalone MySQL server using Stash by following the guides from [here](/docs/guides/mysql/backup/stash/standalone/index.md).

--- a/docs/guides/mysql/clients/index.md
+++ b/docs/guides/mysql/clients/index.md
@@ -276,20 +276,21 @@ my-group   10.244.1.8:3306   5h49m
 You can also find the service which selects for secondary replicas have the following selector,
 
 ```bash
-$ kubectl get svc -n demo my-group-replicas -o json | jq '.spec.selector'
+$ kubectl get svc -n demo my-group-standby -o json | jq '.spec.selector'
 {
-  "app.kubernetes.io/name": "mysqls.kubedb.com",
   "app.kubernetes.io/instance": "my-group",
-  "mysql.kubedb.com/role": "secondary"
+  "app.kubernetes.io/managed-by": "kubedb.com",
+  "app.kubernetes.io/name": "mysqls.kubedb.com",
+  "kubedb.com/role": "standby"
 }
 ```
 
 If you get the endpoint of the above service, you will see the podIP of the secondary replicas,
 
 ```bash
-$ kubectl get endpoints -n demo my-group-replicas
+$ kubectl get endpoints -n demo my-group-standby
 NAME                ENDPOINTS                           AGE
-my-group-replicas   10.244.2.11:3306,10.244.2.13:3306   5h53m
+my-group-standby   10.244.2.11:3306,10.244.2.13:3306   5h53m
 ```
 
 ## Connecting Information
@@ -359,14 +360,14 @@ You can see from the above output that both write and read operations are perfor
 
 ## Connection with Secondary Replicas
 
-The secondary replica has only the permission of read operation. So the clients are able to perform only read operation using the service `my-group-replicas` which select only secondary replicas(already shown above). First, we will try to insert data into the database cluster, then we will read existing data from the cluster using `my-group-replicas` service.
+The secondary replica has only the permission of read operation. So the clients are able to perform only read operation using the service `my-group-standby` which select only secondary replicas(already shown above). First, we will try to insert data into the database cluster, then we will read existing data from the cluster using `my-group-standby` service.
 
 At first, we are going to port-forward the service to connect to the database cluster from the outside of the cluster.
 
-Let's port-forward the `my-group-replicas` service using the following command,
+Let's port-forward the `my-group-standby` service using the following command,
 
 ```bash
-$ kubectl port-forward service/my-group-replicas -n demo 8080:3306
+$ kubectl port-forward service/my-group-standby -n demo 8080:3306
 Forwarding from 127.0.0.1:8080 -> 3306
 Forwarding from [::1]:8080 -> 3306
 ```
@@ -394,7 +395,7 @@ mysql: [Warning] Using a password on the command line interface can be insecure.
 +----+-------+-------+-------+
 ```
 
-You can see from the above output that only read operations are performed successfully using secondary pod selector service named `my-group-replicas`. No data is inserted by using this service. The error `--super-read-only` indicates that the secondary pod has only read permission.
+You can see from the above output that only read operations are performed successfully using secondary pod selector service named `my-group-standby`. No data is inserted by using this service. The error `--super-read-only` indicates that the secondary pod has only read permission.
 
 ## Automatic Failover
 
@@ -427,12 +428,12 @@ NAME       ENDPOINTS          AGE
 my-group   10.244.2.13:3306   111m
 ```
 
-If you get the endpoint of the `my-group-replicas` service, you will see the podIP of the secondary replicas,
+If you get the endpoint of the `my-group-standby` service, you will see the podIP of the secondary replicas,
 
 ```bash
-$ kubectl get endpoints -n demo my-group-replicas
+$ kubectl get endpoints -n demo my-group-standby
 NAME                ENDPOINTS                           AGE
-my-group-replicas   10.244.2.11:3306,10.244.2.18:3306   112m
+my-group-standby   10.244.2.11:3306,10.244.2.18:3306   112m
 ```
 
 ## Cleaning up

--- a/docs/guides/mysql/configuration/config-file/index.md
+++ b/docs/guides/mysql/configuration/config-file/index.md
@@ -192,7 +192,7 @@ $ kubectl get pods custom-mysql-0 -n demo -o yaml | grep IP
   hostIP: 10.0.2.15
   podIP: 172.17.0.6
 
-$ kubectl get secrets -n demo custom-mysql-auth -o jsonpath='{.data.\user}' | base64 -d
+$ kubectl get secrets -n demo custom-mysql-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
 $ kubectl get secrets -n demo custom-mysql-auth -o jsonpath='{.data.password}' | base64 -d

--- a/docs/guides/mysql/configuration/podtemplating/index.md
+++ b/docs/guides/mysql/configuration/podtemplating/index.md
@@ -175,7 +175,7 @@ $ kubectl get pods mysql-misc-config-0 -n demo -o yaml | grep IP
   hostIP: 10.0.2.15
   podIP: 172.17.0.6
 
-$ kubectl get secrets -n demo mysql-misc-config-auth -o jsonpath='{.data.\user}' | base64 -d
+$ kubectl get secrets -n demo mysql-misc-config-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
 $ kubectl get secrets -n demo mysql-misc-config-auth -o jsonpath='{.data.password}' | base64 -d

--- a/docs/guides/mysql/gitops/gitops.md
+++ b/docs/guides/mysql/gitops/gitops.md
@@ -378,7 +378,7 @@ mysql> show variables like 'read_buffer_size';
 
 ```
 At first, we will create a secret containing `user.conf` file with required configuration settings.
-To know more about this configuration file, check [here](/docs/guides/mysql/configuration/using-config-file.md)
+To know more about this configuration file, check [here](/docs/guides/mysql/configuration/config-file/index.md)
 ```yaml
 apiVersion: v1
 stringData:
@@ -809,7 +809,7 @@ mysql> SHOW VARIABLES LIKE '%require_secure_transport%';
 
 ### Update Version
 
-List MySQL versions using `kubectl get MySQLversion` and choose desired version that is compatible for umyrade from current version. Check the version constraints and ops request [here](/docs/guides/mysql/update-version/versionumyrading/index.md).
+List MySQL versions using `kubectl get MySQLversion` and choose desired version that is compatible for upgrade from current version. Check the version constraints and ops request [here](/docs/guides/mysql/update-version/overview/index.md).
 
 Let's choose `9.6.0` in this example.
 
@@ -983,10 +983,10 @@ Verify the monitoring is enabled by checking the prometheus targets.
 
 ## Next Steps
 
-- Learn MySQL [GitOps](/docs/guides/mysql/concepts/MySQL-gitops.md)
+- Learn MySQL [GitOps](/docs/guides/mysql/gitops/overview.md)
 - Learn MySQL Scaling 
   - [Horizontal Scaling](/docs/guides/mysql/scaling/horizontal-scaling/overview/index.md)
   - [Vertical Scaling](/docs/guides/mysql/scaling/vertical-scaling/overview/index.md)
-- Learn Version Update Ops Request and Constraints [here](/docs/guides/mysql/update-version/versionumyrading/index.md)
+- Learn Version Update Ops Request and Constraints [here](/docs/guides/mysql/update-version/overview/index.md)
 - Monitor your MySQL database with KubeDB using [built-in Prometheus](/docs/guides/mysql/monitoring/using-builtin-prometheus.md).
 - Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/mysql/gitops/gitops.md
+++ b/docs/guides/mysql/gitops/gitops.md
@@ -378,7 +378,7 @@ mysql> show variables like 'read_buffer_size';
 
 ```
 At first, we will create a secret containing `user.conf` file with required configuration settings.
-To know more about this configuration file, check [here](/docs/guides/mysql/configuration/config-file/index.md)
+To know more about this configuration file, check the [Run MySQL with Custom Configuration](/docs/guides/mysql/configuration/config-file/index.md) guide.
 ```yaml
 apiVersion: v1
 stringData:
@@ -809,7 +809,7 @@ mysql> SHOW VARIABLES LIKE '%require_secure_transport%';
 
 ### Update Version
 
-List MySQL versions using `kubectl get MySQLversion` and choose desired version that is compatible for upgrade from current version. Check the version constraints and ops request [here](/docs/guides/mysql/update-version/overview/index.md).
+List MySQL versions using `kubectl get MySQLversion` and choose desired version that is compatible for upgrade from current version. Check the version constraints and ops request in the [Updating MySQL Overview](/docs/guides/mysql/update-version/overview/index.md).
 
 Let's choose `9.6.0` in this example.
 
@@ -987,6 +987,6 @@ Verify the monitoring is enabled by checking the prometheus targets.
 - Learn MySQL Scaling 
   - [Horizontal Scaling](/docs/guides/mysql/scaling/horizontal-scaling/overview/index.md)
   - [Vertical Scaling](/docs/guides/mysql/scaling/vertical-scaling/overview/index.md)
-- Learn Version Update Ops Request and Constraints [here](/docs/guides/mysql/update-version/overview/index.md)
+- Learn Version Update Ops Request and Constraints in the [Updating MySQL Overview](/docs/guides/mysql/update-version/overview/index.md)
 - Monitor your MySQL database with KubeDB using [built-in Prometheus](/docs/guides/mysql/monitoring/using-builtin-prometheus.md).
 - Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/mysql/initialization/using_script.md
+++ b/docs/guides/mysql/initialization/using_script.md
@@ -205,7 +205,7 @@ spec:
 ```
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/initialization/yamls/initialize-mysql.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/initialization/yamls/initialize-semi-sync.yaml
 mysql.kubedb.com/mysql-init-script created
 ```
 
@@ -235,7 +235,7 @@ spec:
 ```
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/initialization/yamls/initialize-mysql.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/initialization/yamls/initialize-standalone.yaml
 mysql.kubedb.com/mysql-init-script created
 ```
   </div>
@@ -468,7 +468,7 @@ $ kubectl get pods mysql-init-script-0 -n demo -o yaml | grep IP
   hostIP: 10.0.2.15
   podIP: 10.244.2.9
 
-$ kubectl get secrets -n demo mysql-init-script-auth -o jsonpath='{.data.\user}' | base64 -d
+$ kubectl get secrets -n demo mysql-init-script-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
 $ kubectl get secrets -n demo mysql-init-script-auth -o jsonpath='{.data.password}' | base64 -d

--- a/docs/guides/mysql/pitr/volumesnapshot/archiver.md
+++ b/docs/guides/mysql/pitr/volumesnapshot/archiver.md
@@ -104,7 +104,7 @@ spec:
     last: 2
 ```
 ```bash
-$ kubectl apply -f  https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/pitr/yamls/retention-policy.yaml 
+$ kubectl apply -f  https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/pitr/volumesnapshot/yamls/retentionPolicy.yaml 
 retentionpolicy.storage.kubestash.com/mysql-retention-policy created
 ```
 

--- a/docs/guides/mysql/quickstart/index.md
+++ b/docs/guides/mysql/quickstart/index.md
@@ -120,7 +120,7 @@ Here,
 
 - `spec.version` is the name of the MySQLVersion CRD where the docker images are specified. In this tutorial, a MySQL `8.4.8` database is going to be created.
 - `spec.storageType` specifies the type of storage that will be used for MySQL database. It can be `Durable` or `Ephemeral`. Default value of this field is `Durable`. If `Ephemeral` is used then KubeDB will create MySQL database using `EmptyDir` volume. In this case, you don't have to specify `spec.storage` field. This is useful for testing purposes.
-- `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the StatefulSet created by KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests.
+- `spec.storage` specifies the StorageClass of PVC dynamically allocated to store data for this database. This storage spec will be passed to the PetSet created by KubeDB operator to run database pods. You can specify any StorageClass available in your cluster with appropriate resource requests.
 - `spec.terminationPolicy` or `spec.deletionPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `MySQL` crd or which resources KubeDB should keep or delete when you delete `MySQL` crd. If admission webhook is enabled, It prevents users from deleting the database as long as the `spec.terminationPolicy` is set to `DoNotTerminate`. Learn details of all `TerminationPolicy` [here](/docs/guides/mysql/concepts/database/index.md#specterminationpolicy)
 
 > Note: spec.storage section is used to create PVC for database pod. It will create PVC with storage size specified instorage.resources.requests field. Don't specify limits here. PVC does not get resized automatically.
@@ -584,7 +584,7 @@ Suppose we have a database running `mysql-quickstart` in our cluster. Now, we ar
 Run the following command to get MySQL resources,
 
 ```bash
-$ kubectl get my,sts,secret,svc,pvc -n demo
+$ kubectl get my,petset,secret,svc,pvc -n demo
 NAME                                VERSION   STATUS   AGE
 mysql.kubedb.com/mysql-quickstart   8.4.8    Halted   22m
 

--- a/docs/guides/mysql/reconfigure-tls/overview/index.md
+++ b/docs/guides/mysql/reconfigure-tls/overview/index.md
@@ -43,11 +43,11 @@ The Reconfiguring MySQL TLS process consists of the following steps:
 
 5. `KubeDB` Enterprise operator watches the `MySQLOpsRequest` CR.
 
-6. When it finds a `MySQLOpsRequest` CR, it pauses the `MySQL` object which is referred from the `MySQLOpsRequest`. So, the `KubeDB` Community operator doesn't perform any operations on the `MongoDB` object during the reconfiguring TLS process.
+6. When it finds a `MySQLOpsRequest` CR, it pauses the `MySQL` object which is referred from the `MySQLOpsRequest`. So, the `KubeDB` Community operator doesn't perform any operations on the `MySQL` object during the reconfiguring TLS process.
 
 7. Then the `KubeDB` Enterprise operator will add, remove, update or rotate TLS configuration based on the Ops Request yaml.
 
-8. Then the `KubeDB` Enterprise operator will restart all the Pods of the database so that they restart with the new TLS configuration defined in the `MongoDBOpsRequest` CR.
+8. Then the `KubeDB` Enterprise operator will restart all the Pods of the database so that they restart with the new TLS configuration defined in the `MySQLOpsRequest` CR.
 
 9. After the successful reconfiguring of the `MySQL` TLS, the `KubeDB` Enterprise operator resumes the `MySQL` object so that the `KubeDB` Community operator resumes its usual operations.
 

--- a/docs/guides/mysql/reconfigure-tls/reconfigure/index.md
+++ b/docs/guides/mysql/reconfigure-tls/reconfigure/index.md
@@ -31,7 +31,7 @@ KubeDB supports reconfigure i.e. add, remove, update and rotation of TLS/SSL cer
   namespace/demo created
   ```
 
-> Note: YAML files used in this tutorial are stored in [docs/guides/mysql/reconfigure-tls/yamls](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/guides/mysql folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
+> Note: YAML files used in this tutorial are stored in [docs/guides/mysql/reconfigure-tls/reconfigure/yamls](https://github.com/kubedb/docs/tree/{{< param "info.version" >}}/docs/guides/mysql/reconfigure-tls/reconfigure/yamls) folder in GitHub repository [kubedb/docs](https://github.com/kubedb/docs).
 
 ## Add TLS to a MySQL database
 
@@ -1197,7 +1197,7 @@ To cleanup the Kubernetes resources created by this tutorial, run:
 ```bash
 kubectl delete mysql -n demo mysql
 kubectl delete issuer -n demo my-issuer my-new-issuer
-kubectl delete mysqlopsrequest myops-add-tls myops-remove mops-rotate myps-change-issuer
+kubectl delete mysqlopsrequest -n demo myops-add-tls myops-remove myops-rotate myops-change-issuer
 kubectl delete ns demo
 ```
 

--- a/docs/guides/mysql/reconfigure/reconfigure-steps/index.md
+++ b/docs/guides/mysql/reconfigure/reconfigure-steps/index.md
@@ -149,7 +149,7 @@ spec:
 Let's create the `MySQL` CR we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/reconfigure/reconfigure-steps/yamls/innob-cluster.yaml
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/reconfigure/reconfigure-steps/yamls/inndob-cluster.yaml
 mysql.kubedb.com/sample-mysql created
 ```
 
@@ -522,20 +522,20 @@ Here,
 Let's create the `MySQLOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/reconfigure/yamls/reconfigure-steps/reconfigure-remove.yaml
-mysqlopsrequest.ops.kubedb.com/mdops-reconfigure-remove created
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/reconfigure/reconfigure-steps/yamls/reconfigure-remove.yaml
+mysqlopsrequest.ops.kubedb.com/myops-reconfigure-remove created
 ```
 
 #### Verify the new configuration is working
 
 If everything goes well, `KubeDB` Enterprise operator will update the `configSecret` of `MySQL` object.
 
-Let's wait for `MySQLOpsRequest` to be `Successful`.  Run the following command to watch `MariaDBOpsRequest` CR,
+Let's wait for `MySQLOpsRequest` to be `Successful`.  Run the following command to watch `MySQLOpsRequest` CR,
 
 ```bash
 $ kubectl get mysqlopsrequest --all-namespaces
 NAMESPACE   NAME                       TYPE          STATUS       AGE
-demo        mdops-reconfigure-remove   Reconfigure   Successful   2m1s
+demo        myops-reconfigure-remove   Reconfigure   Successful   2m1s
 ```
 
 Now let's connect to a mysql instance and run a mysql internal command to check the new configuration we have provided.
@@ -586,6 +586,6 @@ To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
 $ kubectl delete mysql -n demo sample-mysql
-$ kubectl delete mysqlopsrequest -n demo myops-reconfigure-config  mdops-reconfigure-remove
+$ kubectl delete mysqlopsrequest -n demo myops-reconfigure-config  myops-reconfigure-remove
 $ kubectl delete ns demo
 ```

--- a/docs/guides/mysql/reconfigure/reconfigure-steps/yamls/reconfigure-remove.yaml
+++ b/docs/guides/mysql/reconfigure/reconfigure-steps/yamls/reconfigure-remove.yaml
@@ -1,0 +1,11 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MySQLOpsRequest
+metadata:
+  name: myops-reconfigure-remove
+  namespace: demo
+spec:
+  type: Reconfigure
+  databaseRef:
+    name: sample-mysql
+  configuration:
+    removeCustomConfig: true

--- a/docs/guides/mysql/reconfigure/reconfigure-steps/yamls/reconfigure-using-secret.yaml
+++ b/docs/guides/mysql/reconfigure/reconfigure-steps/yamls/reconfigure-using-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: ops.kubedb.com/v1alpha1
+kind: MySQLOpsRequest
+metadata:
+  name: myops-reconfigure-config
+  namespace: demo
+spec:
+  type: Reconfigure
+  databaseRef:
+    name: sample-mysql
+  configuration:
+    configSecret:
+      name: new-my-configuration

--- a/docs/guides/mysql/rotate-auth/guide.md
+++ b/docs/guides/mysql/rotate-auth/guide.md
@@ -98,7 +98,7 @@ Let's wait for `MySQL` status is `Ready`. Run the following command to watch `My
 ```shell
 $ kubectl get mysql -n demo -w
 NAME             VERSION   STATUS   AGE
-mysql-quickstart 10.5.23   Ready    30m
+mysql-quickstart 9.6.0   Ready    30m
 ```
 ## Verify Authentication
 The user can verify whether they are authorized by executing a query directly in the database. To
@@ -173,18 +173,18 @@ Here,
 
 Let's create the `MySQLOpsRequest` CR we have shown above,
 ```shell
- $ kubectl apply -f https://github.com/kubedb/docs/raw/{{ .version }}/docs/examples/mysql/rotate-auth/rotate-auth-generated.yaml
+ $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mysql/rotate-auth/rotate-auth-generated.yaml
  MySQLOpsRequest.ops.kubedb.com/myops-rotate-auth-generated created
 ```
 Let's wait for `MySQLOpsRequest` to be `Successful`. Run the following command to watch `MySQLOpsRequest` CRO
 ```shell
- $ kubectl get MySQLOpsRequest-n demo
+ $ kubectl get mysqlopsrequest -n demo
 NAME                          TYPE         STATUS       AGE
 myops-rotate-auth-generated   RotateAuth   Successful   82s
 ```
 If we describe the `MySQLOpsRequest` we will get an overview of the steps that were followed.
 ```shell
-$ kubectl describe MySQLOpsRequest-n demo myops-rotate-auth-generated
+$ kubectl describe mysqlopsrequest -n demo myops-rotate-auth-generated
 Name:         myops-rotate-auth-generated
 Namespace:    demo
 Labels:       <none>
@@ -369,20 +369,20 @@ Here,
 Let's create the `MySQLOpsRequest` CR we have shown above,
 
 ```shell
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{ .version }}/docs/examples/mysql/rotate-auth/rotate-auth-user.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mysql/rotate-auth/rotate-auth-user.yaml
 MySQLOpsRequest.ops.kubedb.com/myops-rotate-auth-user created
 ```
 Let’s wait for `MySQLOpsRequest` to be Successful. Run the following command to watch `MySQLOpsRequest` CRO:
 
 ```shell
-$ kubectl get MySQLOpsRequest-n demo
+$ kubectl get mysqlopsrequest -n demo
 NAME                          TYPE         STATUS       AGE
 myops-rotate-auth-generated   RotateAuth   Successful   35m
 myops-rotate-auth-user        RotateAuth   Successful   2m18s
 ```
 We can see from the above output that the `MySQLOpsRequest` has succeeded. If we describe the `MySQLOpsRequest` we will get an overview of the steps that were followed.
 ```shell
-$ kubectl describe MySQLOpsRequest-n demo myops-rotate-auth-user 
+$ kubectl describe mysqlopsrequest -n demo myops-rotate-auth-user 
 Name:         myops-rotate-auth-user
 Namespace:    demo
 Labels:       <none>
@@ -534,7 +534,7 @@ To clean up the Kubernetes resources you can delete the CRD or namespace.
 Alternatively, you can delete individual resources by name. To do so, run:
 
 ```shell
-$ kubectl delete MySQLOpsRequestmyops-rotate-auth-generated myops-rotate-auth-user -n demo
+$ kubectl delete mysqlopsrequest myops-rotate-auth-generated myops-rotate-auth-user -n demo
 MySQLOpsRequest.ops.kubedb.com "myops-rotate-auth-generated" "myops-rotate-auth-user" deleted
 $ kubectl delete secret -n demo mysql-quickstart-auth-user
 secret "mysql-quickstart-auth-user" deleted
@@ -545,7 +545,7 @@ secret "mysql-quickstart-auth " deleted
 
 ## Next Steps
 
-- Learn about [backup and restore](/docs/guides/mysql/backup/overview/index.md) SQL Server using KubeStash.
-- Want to set up SQL Server Availability Group clusters? Check how to [Configure SQL Server Availability Gruop Cluster](/docs/guides/mysql/clustering/ag_cluster.md)
-- Detail concepts of [Mysql object](/docs/guides/mysql/concepts/mysql.md).
+- Learn about [backup and restore](/docs/guides/mysql/backup/kubestash/overview/index.md) MySQL using KubeStash.
+- Want to set up a MySQL cluster? Check how to configure a [MySQL Group Replication](/docs/guides/mysql/clustering/group-replication/index.md).
+- Detail concepts of [MySQL object](/docs/guides/mysql/concepts/database/index.md).
 - Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/mysql/update-version/majorversion/group-replication/index.md
+++ b/docs/guides/mysql/update-version/majorversion/group-replication/index.md
@@ -145,7 +145,7 @@ spec:
   version: 8.4.8
 ```
 
-The above `spec.updateConstraints.denylist` of `8.4.8` is showing that updating below version of `8.4.8` is not possible for both group replication and standalone. That means, it is possible to update any version above `8.4.8`. Here, we are going to create a `MySQL` Group Replication using MySQL  `8.4.8`. Then we are going to update this version to `9.6.0`.
+The above `spec.updateConstraints` of `8.4.8` is showing that for both group replication and standalone, updating below version of `8.4.8` is not possible (denylist) and updating is allowed within the range `>= 8.4.8, <= 9.1.0` (allowlist). Here, we are going to create a `MySQL` Group Replication using MySQL  `8.4.8`. Then we are going to update this version to `9.1.0`.
 
 **Deploy MySQL Group Replication:**
 
@@ -244,7 +244,7 @@ We are ready to apply updating on this `MySQL` group replication.
 
 #### UpdateVesion
 
-Here, we are going to update the `MySQL` group replication from `8.4.8` to `9.6.0`.
+Here, we are going to update the `MySQL` group replication from `8.4.8` to `9.1.0`.
 
 **Create MySQLOpsRequest:**
 
@@ -261,19 +261,19 @@ spec:
   databaseRef:
     name: my-group
   updateVersion:
-    targetVersion: "9.6.0"
+    targetVersion: "9.1.0"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies expected version `9.6.0` after updating.
+- `spec.updateVersion.targetVersion` specifies expected version `9.1.0` after updating.
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/update-version/majorversion/group-replication/yamls/update_major_version_group.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/update-version/majorversion/group-replication/yamls/upgrade_major_version_group.yaml
 mysqlopsrequest.ops.kubedb.com/my-update-major-group created
 ```
 

--- a/docs/guides/mysql/update-version/majorversion/group-replication/index.md
+++ b/docs/guides/mysql/update-version/majorversion/group-replication/index.md
@@ -318,7 +318,7 @@ Spec:
     Name:  my-group
   Type:    UpdateVersion
   UpdateVersion:
-    Target Version:  8.0.36
+    Target Version:  9.1.0
 Status:
   Conditions:
     Last Transition Time:  2022-06-30T07:55:16Z
@@ -367,15 +367,15 @@ Now, we are going to verify whether the `MySQL` and `PetSet` and it's `Pod` have
 
 ```bash
 $ kubectl get my -n demo my-group -o=jsonpath='{.spec.version}{"\n"}'
-8.0.36
+9.1.0
 
 $ kubectl get petset -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.template.spec.containers[1].image'
-"kubedb/mysql:8.0.36"
+"kubedb/mysql:9.1.0"
 
 $ kubectl get pod -n demo -l app.kubernetes.io/name=mysqls.kubedb.com,app.kubernetes.io/instance=my-group -o json | jq '.items[].spec.containers[1].image'
-"kubedb/mysql:8.0.36"
-"kubedb/mysql:8.0.36"
-"kubedb/mysql:8.0.36"
+"kubedb/mysql:9.1.0"
+"kubedb/mysql:9.1.0"
+"kubedb/mysql:9.1.0"
 ```
 
 Let's also check the PetSet pods have joined the `MySQL` group replication,
@@ -392,9 +392,9 @@ mysql: [Warning] Using a password on the command line interface can be insecure.
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
 | CHANNEL_NAME              | MEMBER_ID                            | MEMBER_HOST                       | MEMBER_PORT | MEMBER_STATE | MEMBER_ROLE | MEMBER_VERSION | MEMBER_COMMUNICATION_STACK |
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
-| group_replication_applier | b0e71e0c-f849-11ec-a315-46392c50e39c | my-group-1.my-group-pods.demo.svc |        3306 | ONLINE       | PRIMARY     | 8.0.36         | XCom                       |
-| group_replication_applier | b34b16d7-f849-11ec-9362-a2f432876ee4 | my-group-2.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.36         | XCom                       |
-| group_replication_applier | b5542a4a-f849-11ec-9a75-3e8abd17fee6 | my-group-0.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 8.0.36         | XCom                       |
+| group_replication_applier | b0e71e0c-f849-11ec-a315-46392c50e39c | my-group-1.my-group-pods.demo.svc |        3306 | ONLINE       | PRIMARY     | 9.1.0          | XCom                       |
+| group_replication_applier | b34b16d7-f849-11ec-9362-a2f432876ee4 | my-group-2.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 9.1.0          | XCom                       |
+| group_replication_applier | b5542a4a-f849-11ec-9a75-3e8abd17fee6 | my-group-0.my-group-pods.demo.svc |        3306 | ONLINE       | SECONDARY   | 9.1.0          | XCom                       |
 +---------------------------+--------------------------------------+-----------------------------------+-------------+--------------+-------------+----------------+----------------------------+
 
 ```

--- a/docs/guides/mysql/update-version/majorversion/group-replication/yamls/upgrade_major_version_group.yaml
+++ b/docs/guides/mysql/update-version/majorversion/group-replication/yamls/upgrade_major_version_group.yaml
@@ -8,4 +8,4 @@ spec:
   databaseRef:
     name: my-group
   updateVersion:
-    targetVersion: "9.6.0"
+    targetVersion: "9.1.0"

--- a/docs/guides/mysql/update-version/majorversion/standalone/index.md
+++ b/docs/guides/mysql/update-version/majorversion/standalone/index.md
@@ -238,7 +238,7 @@ spec:
 
 Here,
 
-- `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
+- `spec.databaseRef.name` specifies that we are performing operation on `my-standalone` MySQL database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
 - `spec.updateVersion.targetVersion` specifies expected version `9.1.0` after updating.
 
@@ -284,7 +284,7 @@ Spec:
     Name:  my-standalone
   Type:    UpdateVersion
   UpdateVersion:
-    TargetVersion:  8.0.36
+    TargetVersion:  9.1.0
 Status:
   Conditions:
     Last Transition Time:  2022-06-30T07:55:16Z
@@ -330,13 +330,13 @@ Now, we are going to verify whether the `MySQL`, `PetSet` and it's `Pod` have up
 
 ```bash
 $ kubectl get my -n demo my-standalone -o=jsonpath='{.spec.version}{"\n"}'
-8.0.36
+9.1.0
 
 $ kubectl get petset -n demo my-standalone -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-mysql:8.0.36
+mysql:9.1.0
 
 $ kubectl get pod -n demo my-standalone-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-mysql:8.0.36
+mysql:9.1.0
 ```
 
 You can see above that our `MySQL`standalone has been updated with the new version. It verifies that we have successfully updated our standalone.

--- a/docs/guides/mysql/update-version/majorversion/standalone/index.md
+++ b/docs/guides/mysql/update-version/majorversion/standalone/index.md
@@ -34,7 +34,7 @@ $ kubectl create ns demo
 namespace/demo created
 ```
 
-> **Note:** YAML files used in this tutorial are stored in [docs/guides/mysql/update-version/majorversion/standalone/yamls](/docs/guides/mysql/update-version/majorversion/standalone/yamls) directory of [kubedb/docs](https://github.com/kube/docs) repository.
+> **Note:** YAML files used in this tutorial are stored in [docs/guides/mysql/update-version/majorversion/standalone/yamls](/docs/guides/mysql/update-version/majorversion/standalone/yamls) directory of [kubedb/docs](https://github.com/kubedb/docs) repository.
 
 ### Apply Version updating on Standalone
 
@@ -145,7 +145,7 @@ spec:
   version: 8.4.8
 ```
 
-The above `spec.updateConstraints.denylist` is showing that updating below version of `8.4.8` is not possible for both standalone and group replication. That means, it is possible to update any version above `8.4.8`. Here, we are going to create a `MySQL` standalone using MySQL  `8.4.8`. Then we are going to update this version to `9.6.0`.
+The above `spec.updateConstraints` is showing that for both standalone and group replication, updating below version of `8.4.8` is not possible (denylist) and updating is allowed within the range `>= 8.4.8, <= 9.1.0` (allowlist). Here, we are going to create a `MySQL` standalone using MySQL  `8.4.8`. Then we are going to update this version to `9.1.0`.
 
 **Deploy MySQL standalone:**
 
@@ -216,7 +216,7 @@ We are ready to apply updating on this `MySQL` standalone.
 
 #### UpdateVersion
 
-Here, we are going to update `MySQL` standalone from `8.4.8` to `9.6.0`.
+Here, we are going to update `MySQL` standalone from `8.4.8` to `9.1.0`.
 
 **Create MySQLOpsRequest:**
 
@@ -233,19 +233,19 @@ spec:
     name: my-standalone
   type: UpdateVersion
   updateVersion:
-    targetVersion: "9.6.0"
+    targetVersion: "9.1.0"
 ```
 
 Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `my-group` MySQL database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies expected version `9.6.0` after updating.
+- `spec.updateVersion.targetVersion` specifies expected version `9.1.0` after updating.
 
 Let's create the `MySQLOpsRequest` cr we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/update-version/majorversion/standalone/yamls/update_major_version_standalone.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/update-version/majorversion/standalone/yamls/upgrade_major_version_standalone.yaml
 mysqlopsrequest.ops.kubedb.com/my-update-major-standalone created
 ```
 

--- a/docs/guides/mysql/update-version/majorversion/standalone/yamls/upgrade_major_version_standalone.yaml
+++ b/docs/guides/mysql/update-version/majorversion/standalone/yamls/upgrade_major_version_standalone.yaml
@@ -8,4 +8,4 @@ spec:
     name: my-standalone
   type: UpdateVersion
   updateVersion:
-    targetVersion: "9.6.0"
+    targetVersion: "9.1.0"

--- a/docs/guides/mysql/update-version/minorversion/group-replication/index.md
+++ b/docs/guides/mysql/update-version/minorversion/group-replication/index.md
@@ -276,7 +276,7 @@ Here,
 Let's create the `MySQLOpsRequest` cr we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/update-version/minorversion/group-replication/yamls/update_minor_version_group.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/update-version/minorversion/group-replication/yamls/upgrade_minor_version_group.yaml
 mysqlopsrequest.ops.kubedb.com/my-update-minor-group created
 ```
 

--- a/docs/guides/mysql/update-version/minorversion/standalone/index.md
+++ b/docs/guides/mysql/update-version/minorversion/standalone/index.md
@@ -34,7 +34,7 @@ $ kubectl create ns demo
 namespace/demo created
 ```
 
-> **Note:** YAML files used in this tutorial are stored in [docs/guides/mysql/update-version/minorversion/standalone/yamls](/docs/guides/mysql/update-version/minorversion/standalone/yamls) directory of [kubedb/docs](https://github.com/kube/docs) repository.
+> **Note:** YAML files used in this tutorial are stored in [docs/guides/mysql/update-version/minorversion/standalone/yamls](/docs/guides/mysql/update-version/minorversion/standalone/yamls) directory of [kubedb/docs](https://github.com/kubedb/docs) repository.
 
 ### Apply Version updating on Standalone
 
@@ -245,7 +245,7 @@ Here,
 Let's create the `MySQLOpsRequest` cr we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/update-version/minorversion/standalone/yamls/update_minor_version_standalone.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/mysql/update-version/minorversion/standalone/yamls/upgrade_minor_version_standalone.yaml
 mysqlopsrequest.ops.kubedb.com/my-update-minor-standalone created
 ```
 


### PR DESCRIPTION
This is a follow-up docs-refresh for MySQL: a full re-run against current master, executing the guides on a live KubeDB v2026.6.19 cluster (kubectl dba v0.52.0). Each fix below was verified against the source of truth (the committed example YAMLs, the on-cluster CRD/catalog, or observed operator behavior).

## Functional (empirically verified on cluster)

- **update-version, major standalone + group-replication**: `targetVersion` `9.6.0` -> `9.1.0`. The cluster 8.4.8 `MySQLVersion.spec.updateConstraints.allowlist` is `>= 8.4.8, <= 9.1.0`, and the operator rejects `8.4.8 -> 9.6.0` with `admission webhook ... upgrade from version 8.4.8 to 9.6.0 is not supported`. Verified `8.4.8 -> 9.1.0` runs to `Successful`. (Minor updates 9.4.0 -> 9.6.0 are within the 9.4.0 allowlist and left unchanged.)
- **rotate-auth**: fixed concatenated/broken kubectl commands (`kubectl get MySQLOpsRequest-n demo`, `kubectl describe MySQLOpsRequest-n demo`, `kubectl delete MySQLOpsRequestmyops-...`) to valid forms. RotateAuth (operator-generated) was executed end to end: new credential works, `password.prev` retains the old password, old password is denied.

## Broken apply / create URLs (file did not exist at the referenced path)

- **update-version (all 4 guides)**: `.../yamls/update_*_version_*.yaml` -> `upgrade_*_version_*.yaml` (matches the committed files).
- **initialization/using_script**: `initialize-mysql.yaml` -> `initialize-semi-sync.yaml` (Semi-sync tab) and `initialize-standalone.yaml` (Standalone tab).
- **pitr/volumesnapshot/archiver**: `pitr/yamls/retention-policy.yaml` -> `pitr/volumesnapshot/yamls/retentionPolicy.yaml`.
- **reconfigure/reconfigure-steps**: `innob-cluster.yaml` -> `inndob-cluster.yaml`; canonicalized the swapped `reconfigure/yamls/reconfigure-steps/...` path; and **added the two example ops YAMLs that were referenced but missing** (`reconfigure-using-secret.yaml`, `reconfigure-remove.yaml`), created from the YAML already shown inline in the guide (schema validated with `kubectl apply --dry-run=server`).
- **rotate-auth**: `raw/{{ .version }}/docs/examples/...` -> `raw/{{< param "info.version" >}}/docs/examples/...` (`{{ .version }}` is not a shortcode and renders literally).

## Wrong secret-read keys

- **configuration/config-file**, **configuration/podtemplating**, **initialization/using_script**: `jsonpath='{.data.\user}'` -> `'{.data.username}'` (verified: the backslash form returns empty; `username` returns `root`).

## Wrong service name / selector

- **clients**: the read/secondary service is `my-group-standby` (the guide used `my-group-replicas`, which does not exist); corrected the standby service selector output to the real `kubedb.com/role: standby`.

## Broken internal links and copy-paste from other databases

- **rotate-auth** Next Steps: `SQL Server` copy-paste + broken links -> MySQL links (`backup/kubestash/overview`, `clustering/group-replication`, `concepts/database`); stale `10.5.23` (a MariaDB version) in sample output -> `9.6.0`.
- **reconfigure-tls/reconfigure**: malformed yamls note link; wrong cleanup op names (`mops-rotate` -> `myops-rotate`, `myps-change-issuer` -> `myops-change-issuer`, added `-n demo`).
- **reconfigure-tls/overview**: `MongoDB` / `MongoDBOpsRequest` -> `MySQL` / `MySQLOpsRequest`.
- **reconfigure/reconfigure-steps**: `mdops-reconfigure-remove` -> `myops-reconfigure-remove`; `MariaDBOpsRequest` -> `MySQLOpsRequest`.
- **backup/stash/overview**: `standalonedalone` -> `standalone`.
- **gitops**: `update-version/versionumyrading/index.md` -> `update-version/overview/index.md`; `concepts/MySQL-gitops.md` -> `gitops/overview.md`; `configuration/using-config-file.md` -> `configuration/config-file/index.md`; prose "umyrade" -> "upgrade".
- **update-version/{major,minor}/standalone**: repo link `github.com/kube/docs` -> `github.com/kubedb/docs`.

## Stale / wrong terms

- **quickstart**: `kubectl get my,sts,...` -> `petset`; prose `StatefulSet` -> `PetSet`.

Guides executed live: quickstart, clustering/group-replication, scaling/vertical-scaling/standalone, update-version/major standalone, rotate-auth. All other guides were statically verified against the committed YAMLs and the on-cluster catalog/CRDs. Env-gap guides (volume-expansion, autoscaler, prometheus-operator, storage-migration, legacy Stash) were not runnable on this single-`local-path` cluster and were scanned only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected several MySQL guide links, file paths, and example commands.
  * Updated connection and initialization instructions to use the right service names, resource names, and secret field references.
  * Fixed reconfiguration, backup, and restore examples so the listed commands and YAML references match the intended workflows.
  * Refreshed version upgrade examples and targets to reflect the current supported release path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->