### PR TITLE
docs(rabbitmq): fix stale default auth secret name (-admin-cred -> -auth)

### DIFF
--- a/docs/guides/rabbitmq/concepts/appbinding.md
+++ b/docs/guides/rabbitmq/concepts/appbinding.md
@@ -62,7 +62,7 @@ spec:
       scheme: http
     url: amqp://<username>:<password>@rabbitmq.rabbit.svc.cluster.local:5672/
   secret:
-    name: rabbitmq-admin-cred
+    name: rabbitmq-auth
   type: kubedb.com/rabbitmq
   version: 4.2.4
 ```

--- a/docs/guides/rabbitmq/quickstart/quickstart.md
+++ b/docs/guides/rabbitmq/quickstart/quickstart.md
@@ -160,7 +160,7 @@ metadata:
 spec:
   authSecret:
     kind: Secret
-    name: rm-quickstart-admin-cred
+    name: rm-quickstart-auth
   deletionPolicy: WipeOut
   healthChecker:
     failureThreshold: 3
@@ -268,16 +268,16 @@ status:
 
 ## Connect with RabbitMQ database
 
-Unless provided by the user in `.spec.authSecret.name` field, KubeDB operator creates a new Secret called `rm-quickstart-admin-cred` *(format: {rabbitmq-object-name}-admin-cred)* for storing the password for `admin` user who has administrative authorizations over `/` vhost of RabbitMQ cluster. This secret contains a `username` key which contains the *username* for RabbitMQ `admin` user and a `password` key which contains the *password* for this user.
+Unless provided by the user in `.spec.authSecret.name` field, KubeDB operator creates a new Secret called `rm-quickstart-auth` *(format: {rabbitmq-object-name}-auth)* for storing the password for `admin` user who has administrative authorizations over `/` vhost of RabbitMQ cluster. This secret contains a `username` key which contains the *username* for RabbitMQ `admin` user and a `password` key which contains the *password* for this user.
 
 If you want to use an existing secret please specify that when creating the RabbitMQ object using `spec.authSecret.name`. While creating this secret manually, make sure the secret contains these two keys containing data `username` and `password` and also make sure of using `admin` as value of `username`.
 
 Now, we need `username` and `password` to connect to this database. 
 
 ```bash
-$ kubectl get secrets -n demo rm-quickstart-admin-cred -o jsonpath='{.data.username}' | base64 -d
+$ kubectl get secrets -n demo rm-quickstart-auth -o jsonpath='{.data.username}' | base64 -d
 admin
-$ kubectl get secrets -n demo rm-quickstart-admin-cred -o jsonpath='{.data.password}' | base64 -d
+$ kubectl get secrets -n demo rm-quickstart-auth -o jsonpath='{.data.password}' | base64 -d
 password
 ```
 We can check client connectivity using an opensource load-testing tool called `perf-test`. It runs producers and consumers to continuously publish and consume messages in RabbitMQ cluster. Here's how to run it on kubernetes using the credentials and the address for operator generated primary service.
@@ -355,7 +355,7 @@ Now, run the following command to get all rabbitmq resources in `demo` namespace
 ```bash
 $ kubectl get petset,svc,secret,pvc -n demo
 NAME                              TYPE                       DATA   AGE
-secret/rm-quickstart-admin-cred   kubernetes.io/basic-auth   2      3m35s
+secret/rm-quickstart-auth   kubernetes.io/basic-auth   2      3m35s
 
 NAME                                 STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
 rm-quickstart-data-rm-quickstart-0   Bound    pvc-596bd8de-4123-40fd-a8d1-a864b9acddc2   1Gi        RWO            standard       <unset>                 6m38s
@@ -386,7 +386,7 @@ Now, run the following command to get all RabbitMQ resources in `demo` namespace
 ```bash
 $ kubectl get petset,svc,secret,pvc -n demo
 NAME                              TYPE                       DATA   AGE
-secret/rm-quickstart-admin-cred   kubernetes.io/basic-auth   2      17m
+secret/rm-quickstart-auth   kubernetes.io/basic-auth   2      17m
 ```
 
 From the above output, you can see that all RabbitMQ resources(`PetSet`, `Service`, `PVCs` etc.) are deleted except `Secret`.

--- a/docs/guides/rabbitmq/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/rabbitmq/reconfigure-tls/reconfigure-tls.md
@@ -75,10 +75,10 @@ rm      4.2.4     Ready     10m
 
 
 ```bash
-$ kubectl get secrets -n demo rm-admin-cred -o jsonpath='{.data.username}' | base64 -d
+$ kubectl get secrets -n demo rm-auth -o jsonpath='{.data.username}' | base64 -d
 root
 
-$ kubectl get secrets -n demo rm-admin-cred -o jsonpath='{.data.password}' | base64 -d
+$ kubectl get secrets -n demo rm-auth -o jsonpath='{.data.password}' | base64 -d
 U6(h_pYrekLZ2OOd
 
 We can verify from the above output that TLS is disabled for this database.

--- a/docs/guides/rabbitmq/reconfigure/reconfigure.md
+++ b/docs/guides/rabbitmq/reconfigure/reconfigure.md
@@ -100,10 +100,10 @@ Now, we will check if the database has started with the custom configuration we 
 
 First we need to get the username and password to connect to a RabbitMQ instance,
 ```bash
-$ kubectl get secrets -n demo rm-cluster-admin-cred -o jsonpath='{.data.username}' | base64 -d
+$ kubectl get secrets -n demo rm-cluster-auth -o jsonpath='{.data.username}' | base64 -d
 admin
 
-$ kubectl get secrets -n demo rm-cluster-admin-cred  -o jsonpath='{.data.password}' | base64 -d
+$ kubectl get secrets -n demo rm-cluster-auth  -o jsonpath='{.data.password}' | base64 -d
 m6lXjZugrC4VEpB8
 ```
 


### PR DESCRIPTION
## Summary

Follow-up docs refresh for RabbitMQ, found by re-executing every guide on a live cluster (KubeDB v2026.6.19, single-node k3s). The default RabbitMQ auth secret was renamed from `<name>-admin-cred` to `<name>-auth`, but several guides still referenced the old name, so the documented `kubectl get secret ...` reads return nothing and the AppBinding sample points at a non-existent secret.

Source of truth: `apimachinery/apis/kubedb/v1alpha2/rabbitmq_helpers.go` `DefaultUserCredSecretName()` now returns `NameWithSuffix(OffshootName(), "auth")` (changed in apimachinery "Fix RabbitMQ Default Authsecret name" #1367).

Verified on cluster: deploying `rm-quickstart`, `rm-cluster`, `rm`, and `rabbitmq` each produced a `<name>-auth` secret (`kubernetes.io/basic-auth`, keys `username`/`password`, username `admin`). No `-admin-cred` secret is ever created. `spec.authSecret.name` on each CR resolved to `<name>-auth`.

## Fixes (guide: wrong -> right)

- `quickstart/quickstart.md`: `rm-quickstart-admin-cred` -> `rm-quickstart-auth` (spec.authSecret sample, prose + `{...}-admin-cred` format, both secret reads, two `kubectl get ...` output blocks). Verified: `rm-quickstart-auth` exists; username `admin`, `rabbitmqctl list_users` shows `admin [administrator]`.
- `reconfigure/reconfigure.md`: `rm-cluster-admin-cred` -> `rm-cluster-auth`. Verified by executing the reconfigure guide end to end (custom-config deploy + Reconfigure OpsRequest Successful); `rm-cluster-auth` present.
- `reconfigure-tls/reconfigure-tls.md`: `rm-admin-cred` -> `rm-auth`. Verified: deploying `rm` yields `rm-auth`.
- `concepts/appbinding.md`: sample AppBinding `secret.name: rabbitmq-admin-cred` -> `rabbitmq-auth`. Verified: deploying `rabbitmq` yields `rabbitmq-auth`.

No em-dashes. Only the four docs files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RabbitMQ guides and quickstart examples to use the new authentication Secret names.
  * Revised command examples and verification steps so users can copy the correct `kubectl` commands.
  * Aligned sample outputs and manifest snippets with the renamed Secret references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->