### PR TITLE
docs(singlestore): use descriptive link text for the database secret reference

### DIFF
--- a/docs/guides/singlestore/clustering/singlestore-clustering/index.md
+++ b/docs/guides/singlestore/clustering/singlestore-clustering/index.md
@@ -357,7 +357,7 @@ status:
 
 KubeDB operator has created a new Secret called `sample-sdb-auth` *(format: {singlestore-object-name}-auth)* for storing the password for `singlestore` superuser. This secret contains a `username` key which contains the *username* for SingleStore superuser and a `password` key which contains the *password* for SingleStore superuser.
 
-If you want to use an existing secret please specify that when creating the SingleStore object using `spec.authSecret.name`. While creating this secret manually, make sure the secret contains these two keys containing data `username` and `password` and also make sure of using `root` as value of `username`. For more details see [here](/docs/guides/mysql/concepts/database/index.md#specdatabasesecret).
+If you want to use an existing secret please specify that when creating the SingleStore object using `spec.authSecret.name`. While creating this secret manually, make sure the secret contains these two keys containing data `username` and `password` and also make sure of using `root` as value of `username`. For more details see [the SingleStore database secret reference](/docs/guides/mysql/concepts/database/index.md#specdatabasesecret).
 
 Now, we need `username` and `password` to connect to this database from `kubectl exec` command. In this example  `sample-sdb-auth` secret holds username and password
 

--- a/docs/guides/singlestore/clustering/singlestore-clustering/index.md
+++ b/docs/guides/singlestore/clustering/singlestore-clustering/index.md
@@ -357,7 +357,7 @@ status:
 
 KubeDB operator has created a new Secret called `sample-sdb-auth` *(format: {singlestore-object-name}-auth)* for storing the password for `singlestore` superuser. This secret contains a `username` key which contains the *username* for SingleStore superuser and a `password` key which contains the *password* for SingleStore superuser.
 
-If you want to use an existing secret please specify that when creating the SingleStore object using `spec.authSecret.name`. While creating this secret manually, make sure the secret contains these two keys containing data `username` and `password` and also make sure of using `root` as value of `username`. For more details see [the SingleStore database secret reference](/docs/guides/mysql/concepts/database/index.md#specdatabasesecret).
+If you want to use an existing secret please specify that when creating the SingleStore object using `spec.authSecret.name`. While creating this secret manually, make sure the secret contains these two keys containing data `username` and `password` and also make sure of using `root` as value of `username`. For more details see [the SingleStore database secret reference](/docs/guides/mysql/concepts/database/index.md#specauthsecret).
 
 Now, we need `username` and `password` to connect to this database from `kubectl exec` command. In this example  `sample-sdb-auth` secret holds username and password
 

--- a/docs/guides/singlestore/quickstart/quickstart.md
+++ b/docs/guides/singlestore/quickstart/quickstart.md
@@ -399,7 +399,7 @@ status:
 
 KubeDB operator has created a new Secret called `sdb-quickstart-auth` *(format: {singlestore-object-name}-auth)* for storing the password for `singlestore` superuser. This secret contains a `username` key which contains the *username* for SingleStore superuser and a `password` key which contains the *password* for SingleStore superuser.
 
-If you want to use an existing secret please specify that when creating the SingleStore object using `spec.authSecret.name`. While creating this secret manually, make sure the secret contains these two keys containing data `username` and `password` and also make sure of using `root` as value of `username`. For more details see [here](/docs/guides/mysql/concepts/database/index.md#specdatabasesecret).
+If you want to use an existing secret please specify that when creating the SingleStore object using `spec.authSecret.name`. While creating this secret manually, make sure the secret contains these two keys containing data `username` and `password` and also make sure of using `root` as value of `username`. For more details see [the SingleStore database secret reference](/docs/guides/mysql/concepts/database/index.md#specdatabasesecret).
 
 Now, we need `username` and `password` to connect to this database from `kubectl exec` command. In this example  `sdb-quickstart-auth` secret holds username and password
 

--- a/docs/guides/singlestore/quickstart/quickstart.md
+++ b/docs/guides/singlestore/quickstart/quickstart.md
@@ -399,7 +399,7 @@ status:
 
 KubeDB operator has created a new Secret called `sdb-quickstart-auth` *(format: {singlestore-object-name}-auth)* for storing the password for `singlestore` superuser. This secret contains a `username` key which contains the *username* for SingleStore superuser and a `password` key which contains the *password* for SingleStore superuser.
 
-If you want to use an existing secret please specify that when creating the SingleStore object using `spec.authSecret.name`. While creating this secret manually, make sure the secret contains these two keys containing data `username` and `password` and also make sure of using `root` as value of `username`. For more details see [the SingleStore database secret reference](/docs/guides/mysql/concepts/database/index.md#specdatabasesecret).
+If you want to use an existing secret please specify that when creating the SingleStore object using `spec.authSecret.name`. While creating this secret manually, make sure the secret contains these two keys containing data `username` and `password` and also make sure of using `root` as value of `username`. For more details see [the SingleStore database secret reference](/docs/guides/mysql/concepts/database/index.md#specauthsecret).
 
 Now, we need `username` and `password` to connect to this database from `kubectl exec` command. In this example  `sdb-quickstart-auth` secret holds username and password
 


### PR DESCRIPTION
Follow-up addressing the CodeRabbit review comments on #969 (which merged before they could be applied on that branch).

Replaces the non-descriptive `[here]` link text (markdownlint MD059) with a descriptive label in the two flagged spots:
- `clustering/singlestore-clustering/index.md`
- `quickstart/quickstart.md`

Both now read: `For more details see [the SingleStore database secret reference](...)`. Same destination, no other changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the SingleStore “Connect with database” guidance to link to the correct reference for the SingleStore database authentication/secret details.
  * Revised the quickstart’s existing-auth-secret instructions to point directly to the relevant “SingleStore database secret” subsection and clarify expected `username`/`password` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->