### PR TITLE
docs(guides): add missing README landing pages for Milvus and DocumentDB

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -18,6 +18,7 @@ aliases:
 Guides to show you how to perform tasks with KubeDB:
 - [Cassandra](/docs/guides/cassandra/README.md). Shows how to manage Cassandra using KubeDB.
 - [ClickHouse](/docs/guides/clickhouse/README.md). Shows how to manage ClickHouse using KubeDB.
+- [DocumentDB](/docs/guides/documentdb/README.md). Shows how to manage DocumentDB using KubeDB.
 - [Druid](/docs/guides/druid/README.md). Shows how to manage Druid using KubeDB.
 - [Elasticsearch](/docs/guides/elasticsearch/README.md). Shows how to manage Elasticsearch & OpenSearch using KubeDB.
 - [Hazelcast](/docs/guides/hazelcast/README.md). Shows how to manage Hazelcast using KubeDB.
@@ -26,6 +27,7 @@ Guides to show you how to perform tasks with KubeDB:
 - [MariaDB](/docs/guides/mariadb). Shows how to manage MariaDB using KubeDB.
 - [Memcached](/docs/guides/memcached/README.md). Shows how to manage Memcached using KubeDB.
 - [Microsoft SQL Server](/docs/guides/mssqlserver/README.md). Shows how to manage Microsoft SQL Server using KubeDB.
+- [Milvus](/docs/guides/milvus/README.md). Shows how to manage Milvus using KubeDB.
 - [MongoDB](/docs/guides/mongodb/README.md). Shows how to manage MongoDB using KubeDB.
 - [MySQL](/docs/guides/mysql/README.md). Shows how to manage MySQL using KubeDB.
 - [Oracle](/docs/guides/oracle/README.md). Shows how to manage Oracle using KubeDB.

--- a/docs/guides/documentdb/README.md
+++ b/docs/guides/documentdb/README.md
@@ -1,0 +1,49 @@
+---
+title: DocumentDB
+menu:
+  docs_{{ .version }}:
+    identifier: dc-documentdb-guides-readme
+    name: DocumentDB
+    parent: dc-documentdb-guides
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+url: /docs/{{ .version }}/guides/documentdb/
+aliases:
+  - /docs/{{ .version }}/guides/documentdb/README/
+---
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Overview
+
+DocumentDB is a document database that speaks the MongoDB wire protocol on top of a PostgreSQL engine (via FerretDB), giving you MongoDB-compatible APIs backed by the reliability and tooling of PostgreSQL. KubeDB lets you provision and operate DocumentDB clusters on Kubernetes, handling day-2 operations such as scaling, reconfiguration, failover, and storage management through declarative `DocumentDBOpsRequest` objects.
+
+## Supported DocumentDB Features
+
+| Features                                                      | Availability |
+|---------------------------------------------------------------|:------------:|
+| Clustering (High Availability)                                |   &#10003;   |
+| Custom Configuration (`user.conf`)                            |   &#10003;   |
+| Externally manageable Auth Secret (Rotate Auth)               |   &#10003;   |
+| Persistent volume                                             |   &#10003;   |
+| Automated Vertical & Horizontal Scaling                       |   &#10003;   |
+| Automated Volume Expansion                                    |   &#10003;   |
+| Storage Migration (StorageClass to StorageClass)              |   &#10003;   |
+| Autoscaling ( Compute resources & Storage )                   |   &#10003;   |
+| Automated Failover & Disaster Recovery                        |   &#10003;   |
+| Automated Restart                                             |   &#10003;   |
+| Reconfigurable runtime configuration                          |   &#10003;   |
+
+## Supported DocumentDB Versions
+
+KubeDB supports the following DocumentDB Versions.
+- `15.12-documentdb`
+- `16.8-documentdb`
+- `17.4-documentdb`
+
+## User Guide
+
+- [Custom Configuration](/docs/guides/documentdb/configuration/using-config-file.md) using a config file.
+- [Reconfigure](/docs/guides/documentdb/reconfigure/reconfigure.md) a running DocumentDB database.
+- [Failover & Disaster Recovery](/docs/guides/documentdb/failure-and-disaster-recovery/failover.md) of a DocumentDB cluster.
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).

--- a/docs/guides/milvus/README.md
+++ b/docs/guides/milvus/README.md
@@ -1,0 +1,51 @@
+---
+title: Milvus
+menu:
+  docs_{{ .version }}:
+    identifier: milvus-guides-readme
+    name: Milvus
+    parent: milvus-guides
+    weight: 10
+menu_name: docs_{{ .version }}
+section_menu_id: guides
+url: /docs/{{ .version }}/guides/milvus/
+aliases:
+  - /docs/{{ .version }}/guides/milvus/README/
+---
+> New to KubeDB? Please start [here](/docs/README.md).
+
+# Overview
+
+Milvus is an open-source vector database built to power embedding similarity search and AI applications. It stores, indexes, and queries billions of high-dimensional vectors, making it a core building block for retrieval-augmented generation, recommendation, and semantic search workloads. KubeDB can provision Milvus in both **standalone** and **distributed** topologies, managing its external dependencies — object storage for segments/logs and an etcd metadata store — throughout the database life cycle.
+
+## Supported Milvus Features
+
+| Features                                                      | Availability |
+|---------------------------------------------------------------|:------------:|
+| Standalone & Distributed topologies                           |   &#10003;   |
+| Managed external dependencies (object storage, etcd)          |   &#10003;   |
+| Custom Configuration                                          |   &#10003;   |
+| Monitoring using Prometheus and Grafana                       |   &#10003;   |
+| Authentication & Authorization (TLS)                          |   &#10003;   |
+| Externally manageable Auth Secret (Rotate Auth)               |   &#10003;   |
+| Persistent volume                                             |   &#10003;   |
+| Automated Vertical & Horizontal Scaling                       |   &#10003;   |
+| Automated Volume Expansion                                    |   &#10003;   |
+| Storage Migration (StorageClass to StorageClass)              |   &#10003;   |
+| Autoscaling ( Compute resources & Storage )                   |   &#10003;   |
+| Reconfigurable TLS Certificates (Add, Remove, Rotate, Update) |   &#10003;   |
+| Automated Version Update                                      |   &#10003;   |
+| Automated Restart                                             |   &#10003;   |
+
+## Supported Milvus Versions
+
+KubeDB supports the following Milvus Versions.
+- `2.6.7`
+- `2.6.9`
+- `2.6.11`
+
+## User Guide
+
+- [Standalone Quickstart](/docs/guides/milvus/quickstart/standalone.md) with KubeDB Operator.
+- [Distributed Quickstart](/docs/guides/milvus/quickstart/distributed.md) with KubeDB Operator.
+- Want to hack on KubeDB? Check our [contribution guidelines](/docs/CONTRIBUTING.md).


### PR DESCRIPTION
## What

Adds the missing `README.md` landing pages for **Milvus** and **DocumentDB**, and links them from `guides/README.md`.

## Why

Each guide's landing page renders from its `README.md` (via the `_index.md` menu entry). `milvus/` and `documentdb/` only had `_index.md`, so their guide links 404'd — unlike e.g. `rabbitmq/` which has both.

## Changes

- `docs/guides/milvus/README.md` — overview, feature table, supported versions (`2.6.7/2.6.9/2.6.11`), quickstart links.
- `docs/guides/documentdb/README.md` — overview, feature table, supported versions (`15.12/16.8/17.4-documentdb`), config/reconfigure/failover links.
- `docs/guides/README.md` — added DocumentDB and Milvus entries (alphabetical).

All 30 DB guide dirs now have a `README.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new Guides entries for **DocumentDB** and **Milvus**.
  * Published dedicated guide pages for both databases, including overviews, supported features, version compatibility, and quickstart links.
* **Documentation**
  * Expanded the main Guides list to surface the new database documentation pages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->