### PR TITLE
Update migration docs for per-engine {DB}Migration CRDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,11 @@ jobs:
           kubectl create -f https://github.com/kubevault/installer/raw/master/crds/kubevault-crds.yaml
           kubectl create -f https://github.com/kubedb/installer/raw/master/crds/kubedb-crds.yaml
           kubectl create -f https://github.com/kubedb/installer/raw/master/bundle/manifests/installer.kubedb.com_kubedbs.yaml
-          kubectl create -f https://github.com/kubedb/apimachinery/raw/master/crds/courier.kubedb.com_migrations.yaml
+          kubectl create -f https://github.com/kubedb/apimachinery/raw/master/crds/courier.kubedb.com_postgresmigrations.yaml
+          kubectl create -f https://github.com/kubedb/apimachinery/raw/master/crds/courier.kubedb.com_mysqlmigrations.yaml
+          kubectl create -f https://github.com/kubedb/apimachinery/raw/master/crds/courier.kubedb.com_mariadbmigrations.yaml
+          kubectl create -f https://github.com/kubedb/apimachinery/raw/master/crds/courier.kubedb.com_mongodbmigrations.yaml
+          kubectl create -f https://github.com/kubedb/apimachinery/raw/master/crds/courier.kubedb.com_mssqlservermigrations.yaml
           kubectl create -f https://github.com/kubernetes-csi/external-snapshotter/raw/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
           kubectl create -f https://github.com/kubestash/installer/raw/master/crds/kubestash-crds.yaml
           # recommendation

--- a/docs/examples/mariadb/migration/mariadb-migrate.yaml
+++ b/docs/examples/mariadb/migration/mariadb-migrate.yaml
@@ -1,38 +1,36 @@
 apiVersion: courier.kubedb.com/v1alpha1
-kind: Migration
+kind: MariaDBMigration
 metadata:
   name: mariadb-migrate
   namespace: demo
 spec:
   source:
-    mariadb:
-      connectionInfo:
-        appBinding:
-          name: source-mariadb
-          namespace: demo
-        dbName: "mysql"
-        maxConnections: 100
-      schema:
-        enabled: true
-        database:
-          - shop
-        excludeDatabase: []
-      snapshot:
-        enabled: true
-        pipeline:
-          workers: 3
-          sinkers: 4
-          buffer: 12
-          write_batch_size: 200
-          read_batch_size: 1000
-      streaming:
-        enabled: true
+    connectionInfo:
+      appBinding:
+        name: source-mariadb
+        namespace: demo
+      dbName: "mysql"
+      maxConnections: 100
+    schema:
+      enabled: true
+      database:
+        - shop
+      excludeDatabase: []
+    snapshot:
+      enabled: true
+      pipeline:
+        workers: 3
+        sinkers: 4
+        buffer: 12
+        write_batch_size: 200
+        read_batch_size: 1000
+    streaming:
+      enabled: true
 
   target:
-    mariadb:
-      connectionInfo:
-        appBinding:
-          name: target-mariadb
-          namespace: demo
-        dbName: "mysql"
-        maxConnections: 100
+    connectionInfo:
+      appBinding:
+        name: target-mariadb
+        namespace: demo
+      dbName: "mysql"
+      maxConnections: 100

--- a/docs/examples/mongodb/migration/mongodb-migrate.yaml
+++ b/docs/examples/mongodb/migration/mongodb-migrate.yaml
@@ -1,22 +1,20 @@
 apiVersion: courier.kubedb.com/v1alpha1
-kind: Migration
+kind: MongoDBMigration
 metadata:
   name: mongodb-migrate
   namespace: demo
 spec:
   source:
-    mongodb:
-      connectionInfo:
-        appBinding:
-          name: mgo-source
-          namespace: demo
-      mongoshake:
-        syncMode: all
-        extraConfiguration:
-          full_sync.executor.insert_on_dup_update: "true"
+    connectionInfo:
+      appBinding:
+        name: mgo-source
+        namespace: demo
+    mongoshake:
+      syncMode: all
+      extraConfiguration:
+        full_sync.executor.insert_on_dup_update: "true"
   target:
-    mongodb:
-      connectionInfo:
-        appBinding:
-          name: mgo-destination
-          namespace: demo
+    connectionInfo:
+      appBinding:
+        name: mgo-destination
+        namespace: demo

--- a/docs/examples/mysql/migration/mysql-migrate.yaml
+++ b/docs/examples/mysql/migration/mysql-migrate.yaml
@@ -1,38 +1,36 @@
 apiVersion: courier.kubedb.com/v1alpha1
-kind: Migration
+kind: MySQLMigration
 metadata:
   name: mysql-migrate
   namespace: demo
 spec:
   source:
-    mysql:
-      connectionInfo:
-        appBinding:
-          name: source-mysql
-          namespace: demo
-        dbName: "mysql"
-        maxConnections: 100
-      schema:
-        enabled: true
-        database:
-          - shop
-        excludeDatabase: []
-      snapshot:
-        enabled: true
-        pipeline:
-          workers: 3
-          sinkers: 4
-          buffer: 12
-          write_batch_size: 200
-          read_batch_size: 1000
-      streaming:
-        enabled: true
+    connectionInfo:
+      appBinding:
+        name: source-mysql
+        namespace: demo
+      dbName: "mysql"
+      maxConnections: 100
+    schema:
+      enabled: true
+      database:
+        - shop
+      excludeDatabase: []
+    snapshot:
+      enabled: true
+      pipeline:
+        workers: 3
+        sinkers: 4
+        buffer: 12
+        write_batch_size: 200
+        read_batch_size: 1000
+    streaming:
+      enabled: true
 
   target:
-    mysql:
-      connectionInfo:
-        appBinding:
-          name: target-mysql
-          namespace: demo
-        dbName: "mysql"
-        maxConnections: 100
+    connectionInfo:
+      appBinding:
+        name: target-mysql
+        namespace: demo
+      dbName: "mysql"
+      maxConnections: 100

--- a/docs/examples/postgres/migration/postgres-migrate.yaml
+++ b/docs/examples/postgres/migration/postgres-migrate.yaml
@@ -1,31 +1,29 @@
 apiVersion: courier.kubedb.com/v1alpha1
-kind: Migration
+kind: PostgresMigration
 metadata:
   name: postgres-migrate
   namespace: demo
 spec:
   source:
-    postgres:
-      connectionInfo:
-        appBinding:
-          name: source-postgres
-          namespace: demo
-        dbName: shop
-        maxConnections: 100
-      pgDump:
-        schemaOnly: true
-      logicalReplication:
-        copyData: true
-        publication:
-          name: "pub"
-          mode: default
-        subscription:
-          name: "sub"
+    connectionInfo:
+      appBinding:
+        name: source-postgres
+        namespace: demo
+      dbName: shop
+      maxConnections: 100
+    pgDump:
+      schemaOnly: true
+    logicalReplication:
+      copyData: true
+      publication:
+        name: "pub"
+        mode: default
+      subscription:
+        name: "sub"
   target:
-    postgres:
-      connectionInfo:
-        appBinding:
-          name: target-postgres
-          namespace: demo
-        dbName: shop
-        maxConnections: 100
+    connectionInfo:
+      appBinding:
+        name: target-postgres
+        namespace: demo
+      dbName: shop
+      maxConnections: 100

--- a/docs/guides/mariadb/concepts/migrator/index.md
+++ b/docs/guides/mariadb/concepts/migrator/index.md
@@ -1,9 +1,9 @@
 ---
-title: Migration CRD
+title: MariaDBMigration CRD
 menu:
   docs_{{ .version }}:
     identifier: guides-mariadb-concepts-migrator
-    name: Migration
+    name: MariaDBMigration
     parent: guides-mariadb-concepts
     weight: 60
 menu_name: docs_{{ .version }}
@@ -12,63 +12,61 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-# Migration
+# MariaDBMigration
 
-## What is Migration
+## What is MariaDBMigration
 
-`Migration` is a Kubernetes `Custom Resource Definition` (CRD). It provides a declarative way to
+`MariaDBMigration` is a Kubernetes `Custom Resource Definition` (CRD). It provides a declarative way to
 migrate an existing database — such as one running on an external or managed instance — into a
-KubeDB-managed database. You only need to describe the source and target databases in a `Migration`
+KubeDB-managed database. You only need to describe the source and target databases in a `MariaDBMigration`
 object, and the kubedb-courier operator will run the migration Job that copies the data and keeps
 the target in sync until you cut over.
 
-`Migration` is a single shared CRD (`courier.kubedb.com/v1alpha1`). Its `spec.source` and
-`spec.target` each carry a per-database sub-spec (`mysql`, `mariadb`, `postgres`, `mongodb`). This
-page describes the `Migration` object for a **MariaDB** source and target.
+`MariaDBMigration` is the MariaDB-specific migration CRD (`courier.kubedb.com/v1alpha1`) whose
+`spec.source` and `spec.target` describe the MariaDB source and target directly. This page describes
+the `MariaDBMigration` object for a **MariaDB** source and target.
 
-## Migration Spec
+## MariaDBMigration Spec
 
-As with all other Kubernetes objects, a `Migration` needs `apiVersion`, `kind`, and `metadata`
-fields. It also needs a `.spec` section. Below is an example `Migration` object for migrating a
+As with all other Kubernetes objects, a `MariaDBMigration` needs `apiVersion`, `kind`, and `metadata`
+fields. It also needs a `.spec` section. Below is an example `MariaDBMigration` object for migrating a
 MariaDB database.
 
 ```yaml
 apiVersion: courier.kubedb.com/v1alpha1
-kind: Migration
+kind: MariaDBMigration
 metadata:
   name: mariadb-migrate
   namespace: demo
 spec:
   source:
-    mariadb:
-      connectionInfo:
-        appBinding:
-          name: source-mariadb
-          namespace: demo
-        dbName: "mysql"
-        maxConnections: 100
-      schema:
-        enabled: true
-        database: [] # databases to include
-        excludeDatabase: [] # databases to exclude
-      snapshot:
-        enabled: true
-        pipeline:
-          workers: 3
-          sinkers: 4
-          buffer: 12
-          read_batch_size: 1000
-          write_batch_size: 200
-      streaming:
-        enabled: true
+    connectionInfo:
+      appBinding:
+        name: source-mariadb
+        namespace: demo
+      dbName: "mysql"
+      maxConnections: 100
+    schema:
+      enabled: true
+      database: [] # databases to include
+      excludeDatabase: [] # databases to exclude
+    snapshot:
+      enabled: true
+      pipeline:
+        workers: 3
+        sinkers: 4
+        buffer: 12
+        read_batch_size: 1000
+        write_batch_size: 200
+    streaming:
+      enabled: true
   target:
-    mariadb:
-      connectionInfo:
-        appBinding:
-          name: target-mariadb
-          namespace: demo
-        dbName: "mysql"
-        maxConnections: 100
+    connectionInfo:
+      appBinding:
+        name: target-mariadb
+        namespace: demo
+      dbName: "mysql"
+      maxConnections: 100
   jobDefaults:
     imagePullPolicy: IfNotPresent
     backoffLimit: 6
@@ -82,17 +80,17 @@ spec:
 
 ### spec.source
 
-`spec.source` is a required field that describes the database being migrated **from**. It holds a
-per-database sub-spec; for a MariaDB migration you set `spec.source.mariadb`.
+`spec.source` is a required field that describes the database being migrated **from**. It holds the
+MariaDB source fields (`connectionInfo`, `schema`, `snapshot`, `streaming`) directly.
 
 ### spec.target
 
 `spec.target` is a required field that describes the KubeDB-managed database being migrated **into**.
-It holds a per-database sub-spec; for a MariaDB migration you set `spec.target.mariadb`.
+It holds the MariaDB target fields directly.
 
-### spec.source.mariadb.connectionInfo
+### spec.source.connectionInfo
 
-`connectionInfo` (also under `spec.target.mariadb`) tells the Migration how to connect to the MariaDB
+`connectionInfo` (also under `spec.target`) tells the MariaDBMigration how to connect to the MariaDB
 instance. There are two ways to provide the connection details — set **either** `appBinding` **or**
 `url`:
 
@@ -118,7 +116,7 @@ instance. There are two ways to provide the connection details — set **either*
 > For a `KubeDB`-managed database, an `AppBinding` is created by default, so you usually only need to
 > create one for the source. Learn more about [AppBinding](/docs/guides/mariadb/concepts/appbinding/).
 
-### spec.source.mariadb.schema
+### spec.source.schema
 
 `schema` configures the schema migration phase, which recreates database and table definitions on the
 target before any data is copied.
@@ -128,7 +126,7 @@ target before any data is copied.
   databases (`mysql`, `information_schema`, `performance_schema`, `sys`).
 - `excludeDatabase` — list of databases to exclude from migration.
 
-### spec.source.mariadb.snapshot
+### spec.source.snapshot
 
 `snapshot` configures the initial bulk snapshot phase, which copies the existing rows from the source
 to the target.
@@ -143,7 +141,7 @@ to the target.
   - `read_batch_size` — number of rows fetched per read batch from the source. Defaults to `5000`.
   - `write_batch_size` — number of rows written per batch to the target. Defaults to `500`.
 
-### spec.source.mariadb.streaming
+### spec.source.streaming
 
 `streaming` configures the change-data-capture (CDC) phase.
 
@@ -166,7 +164,7 @@ to the target.
 (a `PodTemplateSpec`). Use it to set pod-level settings such as `securityContext`, `nodeSelector`,
 `resources`, `serviceAccountName`, and so on.
 
-## Migration Status
+## MariaDBMigration Status
 
 `status` reflects the observed state of the migration.
 
@@ -178,7 +176,7 @@ to the target.
 - `status.progress` — the current progress of the migration:
   - `dbType` — the type of database being migrated.
   - `info` — additional progress information, including the current `Stage`, `Lag`, and `Progress`
-    (these are surfaced as columns in `kubectl get migration`).
+    (these are surfaced as columns in `kubectl get mariadbmigrations`).
 - `status.conditions` — an array of conditions describing the migration's state over time (for
   example, `MigratorJobTriggered`, `MigrationRunning`, `MigrationSucceeded`, `MigrationFailed`).
 

--- a/docs/guides/mariadb/migration/databaseMigration.md
+++ b/docs/guides/mariadb/migration/databaseMigration.md
@@ -29,7 +29,7 @@ This guide will show you how to use `KubeDB` Migration to migrate an existing `M
 - You should be familiar with the following `KubeDB` concepts:
     - [AppBinding](/docs/guides/mariadb/concepts/appbinding/)
     - [MariaDB](/docs/guides/mariadb/concepts/mariadb)
-    - [Migration](/docs/guides/mariadb/concepts/migrator/)
+    - [MariaDBMigration](/docs/guides/mariadb/concepts/migrator/)
     - [Migration](/docs/operatormanual/migration/)
 
 To keep everything isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
@@ -238,64 +238,62 @@ mariadb.kubedb.com/target-mariadb created
 
 Wait until `target-mariadb` has status `Ready`.
 
-## Apply Migration CR
+## Apply MariaDBMigration CR
 
-To migrate the database we have to create a `Migration` CR. Below is the YAML of the `Migration` CR that we are going to create:
+To migrate the database we have to create a `MariaDBMigration` CR. Below is the YAML of the `MariaDBMigration` CR that we are going to create:
 
 ```yaml
 apiVersion: courier.kubedb.com/v1alpha1
-kind: Migration
+kind: MariaDBMigration
 metadata:
   name: mariadb-migrate
   namespace: demo
 spec:
   source:
-    mariadb:
-      connectionInfo:
-        appBinding:
-          name: source-mariadb
-          namespace: demo
-        dbName: "mysql"
-        maxConnections: 100
-      schema:
-        enabled: true
-        database:
-          - shop
-        excludeDatabase: []
-      snapshot:
-        enabled: true
-        pipeline:
-          workers: 3
-          sinkers: 4
-          buffer: 12
-          write_batch_size: 200
-          read_batch_size: 1000
-      streaming:
-        enabled: true
+    connectionInfo:
+      appBinding:
+        name: source-mariadb
+        namespace: demo
+      dbName: "mysql"
+      maxConnections: 100
+    schema:
+      enabled: true
+      database:
+        - shop
+      excludeDatabase: []
+    snapshot:
+      enabled: true
+      pipeline:
+        workers: 3
+        sinkers: 4
+        buffer: 12
+        write_batch_size: 200
+        read_batch_size: 1000
+    streaming:
+      enabled: true
 
   target:
-    mariadb:
-      connectionInfo:
-        appBinding:
-          name: target-mariadb
-          namespace: demo
-        dbName: "mysql"
-        maxConnections: 100
+    connectionInfo:
+      appBinding:
+        name: target-mariadb
+        namespace: demo
+      dbName: "mysql"
+      maxConnections: 100
 ```
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mariadb/migration/mariadb-migrate.yaml
-migration.courier.kubedb.com/mariadb-migrate created
+mariadbmigration.courier.kubedb.com/mariadb-migrate created
 ```
 
-Here we scope the migration to the `shop` database (`schema.database: [shop]`), enable both the bulk snapshot and CDC streaming phases, and cap connections at 100 on each side. For a full description of every field, see the [Migration CRD reference](/docs/guides/mariadb/concepts/migrator/).
+Here we scope the migration to the `shop` database (`schema.database: [shop]`), enable both the bulk snapshot and CDC streaming phases, and cap connections at 100 on each side. For a full description of every field, see the [MariaDBMigration CRD reference](/docs/guides/mariadb/concepts/migrator/).
 
 ## Watch Migration Progress
 
-Let's wait for the `LAG` to reach near zero. Run the following command to watch `Migration` CR:
+Let's wait for the `LAG` to reach near zero. Run the following command to watch `MariaDBMigration` CR:
 
 ```bash
-Every 2.0s: kubectl get migration -n demo
+Every 2.0s: kubectl get mariadbmigrations -n demo
 
 NAME              PHASE     DBTYPE    STAGE       LAG   PROGRESS   AGE
 mariadb-migrate   Running   mariadb   Streaming   0B    100%       4h36m
@@ -363,11 +361,11 @@ The INSERT, UPDATE, and DELETE are all reflected on the target — CDC streaming
 
 Once the `LAG` drops to near zero, stop all writes to the source database. Wait until the `LAG` reaches exactly zero — at that point both databases are fully in sync.
 
-Now delete the `Migration` CR to stop the migration process:
+Now delete the `MariaDBMigration` CR to stop the migration process:
 
 ```bash
-$ kubectl delete migration -n demo mariadb-migrate
-migration.courier.kubedb.com "mariadb-migrate" deleted
+$ kubectl delete mariadbmigrations -n demo mariadb-migrate
+mariadbmigration.courier.kubedb.com "mariadb-migrate" deleted
 ```
 
 Finally, update your application's connection string to point to the target KubeDB-managed `MariaDB` database. The migration is complete.

--- a/docs/guides/mongodb/concepts/migrator.md
+++ b/docs/guides/mongodb/concepts/migrator.md
@@ -26,7 +26,7 @@ the target in sync until you cut over.
 `spec.source` and `spec.target` describe the MongoDB source and target directly. KubeDB uses
 [mongoshake](https://github.com/alibaba/MongoShake) to perform MongoDB migrations.
 
-## Migration Spec
+## MongoDBMigration Spec
 
 As with all other Kubernetes objects, a `MongoDBMigration` needs `apiVersion`, `kind`, and `metadata`
 fields. It also needs a `.spec` section. Below is an example `MongoDBMigration` object for migrating a
@@ -145,7 +145,7 @@ instance. There are two ways to provide the connection details — set **either*
 (a `PodTemplateSpec`). Use it to set pod-level settings such as `securityContext`, `nodeSelector`,
 `resources`, `serviceAccountName`, and so on.
 
-## Migration Status
+## MongoDBMigration Status
 
 `status` reflects the observed state of the migration.
 

--- a/docs/guides/mongodb/concepts/migrator.md
+++ b/docs/guides/mongodb/concepts/migrator.md
@@ -1,9 +1,9 @@
 ---
-title: Migration CRD
+title: MongoDBMigration CRD
 menu:
   docs_{{ .version }}:
     identifier: mg-migrator-concepts
-    name: Migration
+    name: MongoDBMigration
     parent: mg-concepts-mongodb
     weight: 27
 menu_name: docs_{{ .version }}
@@ -12,50 +12,47 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-# Migration
+# MongoDBMigration
 
-## What is Migration
+## What is MongoDBMigration
 
-`Migration` is a Kubernetes `Custom Resource Definition` (CRD). It provides a declarative way to
+`MongoDBMigration` is a Kubernetes `Custom Resource Definition` (CRD). It provides a declarative way to
 migrate an existing database — such as one running on an external or managed instance — into a
-KubeDB-managed database. You only need to describe the source and target databases in a `Migration`
+KubeDB-managed database. You only need to describe the source and target databases in a `MongoDBMigration`
 object, and the kubedb-courier operator will run the migration Job that copies the data and keeps
 the target in sync until you cut over.
 
-`Migration` is a single shared CRD (`courier.kubedb.com/v1alpha1`). Its `spec.source` and
-`spec.target` each carry a per-database sub-spec (`mysql`, `mariadb`, `postgres`, `mongodb`). This
-page describes the `Migration` object for a **MongoDB** source and target. KubeDB uses
+`MongoDBMigration` is the MongoDB-specific migration CRD (`courier.kubedb.com/v1alpha1`) whose
+`spec.source` and `spec.target` describe the MongoDB source and target directly. KubeDB uses
 [mongoshake](https://github.com/alibaba/MongoShake) to perform MongoDB migrations.
 
 ## Migration Spec
 
-As with all other Kubernetes objects, a `Migration` needs `apiVersion`, `kind`, and `metadata`
-fields. It also needs a `.spec` section. Below is an example `Migration` object for migrating a
+As with all other Kubernetes objects, a `MongoDBMigration` needs `apiVersion`, `kind`, and `metadata`
+fields. It also needs a `.spec` section. Below is an example `MongoDBMigration` object for migrating a
 MongoDB database.
 
 ```yaml
 apiVersion: courier.kubedb.com/v1alpha1
-kind: Migration
+kind: MongoDBMigration
 metadata:
   name: mongodb-migrate
   namespace: demo
 spec:
   source:
-    mongodb:
-      connectionInfo:
-        appBinding:
-          name: mgo-source
-          namespace: demo
-      mongoshake:
-        syncMode: all
-        extraConfiguration:
-          full_sync.executor.insert_on_dup_update: "true"
+    connectionInfo:
+      appBinding:
+        name: mgo-source
+        namespace: demo
+    mongoshake:
+      syncMode: all
+      extraConfiguration:
+        full_sync.executor.insert_on_dup_update: "true"
   target:
-    mongodb:
-      connectionInfo:
-        appBinding:
-          name: mgo-destination
-          namespace: demo
+    connectionInfo:
+      appBinding:
+        name: mgo-destination
+        namespace: demo
   jobDefaults:
     imagePullPolicy: IfNotPresent
     backoffLimit: 6
@@ -69,17 +66,15 @@ spec:
 
 ### spec.source
 
-`spec.source` is a required field that describes the database being migrated **from**. It holds a
-per-database sub-spec; for a MongoDB migration you set `spec.source.mongodb`.
+`spec.source` is a required field that describes the MongoDB database being migrated **from**.
 
 ### spec.target
 
-`spec.target` is a required field that describes the KubeDB-managed database being migrated **into**.
-It holds a per-database sub-spec; for a MongoDB migration you set `spec.target.mongodb`.
+`spec.target` is a required field that describes the KubeDB-managed MongoDB database being migrated **into**.
 
-### spec.source.mongodb.connectionInfo
+### spec.source.connectionInfo
 
-`connectionInfo` (also under `spec.target.mongodb`) tells the Migration how to connect to the MongoDB
+`connectionInfo` (also under `spec.target`) tells the migration how to connect to the MongoDB
 instance. There are two ways to provide the connection details — set **either** `appBinding` **or**
 `url`:
 
@@ -105,7 +100,7 @@ instance. There are two ways to provide the connection details — set **either*
 > For a `KubeDB`-managed database, an `AppBinding` is created by default, so you usually only need to
 > create one for the source. Learn more about [AppBinding](/docs/guides/mongodb/concepts/appbinding.md).
 
-### spec.source.mongodb.mongoshake
+### spec.source.mongoshake
 
 `mongoshake` configures how the migration is performed. All fields are optional unless noted.
 
@@ -162,7 +157,7 @@ instance. There are two ways to provide the connection details — set **either*
 - `status.progress` — the current progress of the migration:
   - `dbType` — the type of database being migrated.
   - `info` — additional progress information, including the current `Stage`, `Lag`, and `Progress`
-    (these are surfaced as columns in `kubectl get migration`).
+    (these are surfaced as columns in `kubectl get mongodbmigrations`).
 - `status.conditions` — an array of conditions describing the migration's state over time (for
   example, `MigratorJobTriggered`, `MigrationRunning`, `MigrationSucceeded`, `MigrationFailed`).
 

--- a/docs/guides/mongodb/migration/databaseMigration.md
+++ b/docs/guides/mongodb/migration/databaseMigration.md
@@ -258,7 +258,7 @@ mongodb.kubedb.com/mgo-destination created
 
 Wait until `mgo-destination` has status `Ready`.
 
-## Apply Migration CR
+## Apply MongoDBMigration CR
 
 To migrate the database we have to create a `MongoDBMigration` CR. KubeDB uses `mongoshake` to perform the migration. Below is the YAML of the `MongoDBMigration` CR that we are going to create:
 

--- a/docs/guides/mongodb/migration/databaseMigration.md
+++ b/docs/guides/mongodb/migration/databaseMigration.md
@@ -29,7 +29,7 @@ This guide will show you how to use `KubeDB` Migration to migrate an existing `M
 - You should be familiar with the following `KubeDB` concepts:
     - [AppBinding](/docs/guides/mongodb/concepts/appbinding.md)
     - [MongoDB](/docs/guides/mongodb/concepts/mongodb.md)
-    - [Migration](/docs/guides/mongodb/concepts/migrator.md)
+    - [MongoDBMigration](/docs/guides/mongodb/concepts/migrator.md)
     - [Migration](/docs/operatormanual/migration/)
 
 To keep everything isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
@@ -260,56 +260,54 @@ Wait until `mgo-destination` has status `Ready`.
 
 ## Apply Migration CR
 
-To migrate the database we have to create a `Migration` CR. KubeDB uses `mongoshake` to perform the migration. Below is the YAML of the `Migration` CR that we are going to create:
+To migrate the database we have to create a `MongoDBMigration` CR. KubeDB uses `mongoshake` to perform the migration. Below is the YAML of the `MongoDBMigration` CR that we are going to create:
 
 ```yaml
 apiVersion: courier.kubedb.com/v1alpha1
-kind: Migration
+kind: MongoDBMigration
 metadata:
   name: mongodb-migrate
   namespace: demo
 spec:
   source:
-    mongodb:
-      connectionInfo:
-        appBinding:
-          name: mgo-source
-          namespace: demo
-      mongoshake:
-        syncMode: all
-        extraConfiguration:
-          full_sync.executor.insert_on_dup_update: "true"
+    connectionInfo:
+      appBinding:
+        name: mgo-source
+        namespace: demo
+    mongoshake:
+      syncMode: all
+      extraConfiguration:
+        full_sync.executor.insert_on_dup_update: "true"
   target:
-    mongodb:
-      connectionInfo:
-        appBinding:
-          name: mgo-destination
-          namespace: demo
+    connectionInfo:
+      appBinding:
+        name: mgo-destination
+        namespace: demo
 ```
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mongodb/migration/mongodb-migrate.yaml
-migration.courier.kubedb.com/mongodb-migrate created
+mongodbmigration.courier.kubedb.com/mongodb-migrate created
 ```
 
 Here,
 
-**`spec.source.mongodb` / `spec.target.mongodb` — connectionInfo:**
+**`spec.source` / `spec.target` — connectionInfo:**
 - `appBinding.name` / `appBinding.namespace` — references the `AppBinding` for the source or target MongoDB instance.
 
-**`spec.source.mongodb.mongoshake` — migration configuration:**
+**`spec.source.mongoshake` — migration configuration:**
 - `syncMode: all` — performs a full data sync (snapshot + incremental oplog replay).
 - `extraConfiguration` — additional `mongoshake` configuration parameters. For example:
   - `full_sync.executor.insert_on_dup_update: "true"` — uses upsert instead of insert during full sync to handle duplicate key errors gracefully.
 
-For a full description of every field, see the [Migration CRD reference](/docs/guides/mongodb/concepts/migrator.md).
+For a full description of every field, see the [MongoDBMigration CRD reference](/docs/guides/mongodb/concepts/migrator.md).
 
 ## Watch Migration Progress
 
-Let's wait for the Migration to finish the full sync and enter the incremental sync. Run the following command to watch `Migration` CR:
+Let's wait for the Migration to finish the full sync and enter the incremental sync. Run the following command to watch `MongoDBMigration` CR:
 
 ```bash
-Every 2.0s: kubectl get migration -n demo
+Every 2.0s: kubectl get mongodbmigrations -n demo
 ```
 
 During the **full** stage, you'll see progress advancing to 100%:
@@ -450,11 +448,11 @@ The INSERT, UPDATE, and DELETE are all reflected on the target — CDC streaming
 
 Once the `LAG` drops to near zero, stop all writes to the source database. Wait until the `LAG` reaches exactly zero — at that point both databases are fully in sync.
 
-Now delete the `Migration` CR to stop the migration process:
+Now delete the `MongoDBMigration` CR to stop the migration process:
 
 ```bash
-$ kubectl delete migration -n demo mongodb-migrate
-migration.courier.kubedb.com "mongodb-migrate" deleted
+$ kubectl delete mongodbmigrations -n demo mongodb-migrate
+mongodbmigration.courier.kubedb.com "mongodb-migrate" deleted
 ```
 
 Finally, update your application's connection string to point to the target KubeDB-managed `MongoDB` database. The migration is complete.

--- a/docs/guides/mysql/concepts/migrator/index.md
+++ b/docs/guides/mysql/concepts/migrator/index.md
@@ -1,9 +1,9 @@
 ---
-title: Migration CRD
+title: MySQLMigration CRD
 menu:
   docs_{{ .version }}:
     identifier: guides-mysql-concepts-migrator
-    name: Migration
+    name: MySQLMigration
     parent: guides-mysql-concepts
     weight: 35
 menu_name: docs_{{ .version }}
@@ -12,63 +12,60 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-# Migration
+# MySQLMigration
 
-## What is Migration
+## What is MySQLMigration
 
-`Migration` is a Kubernetes `Custom Resource Definition` (CRD). It provides a declarative way to
+`MySQLMigration` is a Kubernetes `Custom Resource Definition` (CRD). It provides a declarative way to
 migrate an existing database — such as one running on AWS RDS or any external instance — into a
-KubeDB-managed database. You only need to describe the source and target databases in a `Migration`
+KubeDB-managed database. You only need to describe the source and target databases in a `MySQLMigration`
 object, and the kubedb-courier operator will run the migration Job that copies the data and keeps
 the target in sync until you cut over.
 
-`Migration` is a single shared CRD (`courier.kubedb.com/v1alpha1`). Its `spec.source` and
-`spec.target` each carry a per-database sub-spec (`mysql`, `mariadb`, `postgres`, `mongodb`). This
-page describes the `Migration` object for a **MySQL** source and target.
+`MySQLMigration` is the MySQL-specific migration CRD (`courier.kubedb.com/v1alpha1`) whose
+`spec.source` and `spec.target` describe the MySQL source and target directly.
 
-## Migration Spec
+## MySQLMigration Spec
 
-As with all other Kubernetes objects, a `Migration` needs `apiVersion`, `kind`, and `metadata`
-fields. It also needs a `.spec` section. Below is an example `Migration` object for migrating a MySQL
+As with all other Kubernetes objects, a `MySQLMigration` needs `apiVersion`, `kind`, and `metadata`
+fields. It also needs a `.spec` section. Below is an example `MySQLMigration` object for migrating a MySQL
 database.
 
 ```yaml
 apiVersion: courier.kubedb.com/v1alpha1
-kind: Migration
+kind: MySQLMigration
 metadata:
   name: mysql-migrate
   namespace: demo
 spec:
   source:
-    mysql:
-      connectionInfo:
-        appBinding:
-          name: source-mysql
-          namespace: demo
-        dbName: "mysql"
-        maxConnections: 100
-      schema:
-        enabled: true
-        database: [] # databases to include
-        excludeDatabase: [] # databases to exclude
-      snapshot:
-        enabled: true
-        pipeline:
-          workers: 3
-          sinkers: 4
-          buffer: 12
-          read_batch_size: 1000
-          write_batch_size: 200
-      streaming:
-        enabled: true
+    connectionInfo:
+      appBinding:
+        name: source-mysql
+        namespace: demo
+      dbName: "mysql"
+      maxConnections: 100
+    schema:
+      enabled: true
+      database: [] # databases to include
+      excludeDatabase: [] # databases to exclude
+    snapshot:
+      enabled: true
+      pipeline:
+        workers: 3
+        sinkers: 4
+        buffer: 12
+        read_batch_size: 1000
+        write_batch_size: 200
+    streaming:
+      enabled: true
   target:
-    mysql:
-      connectionInfo:
-        appBinding:
-          name: target-mysql
-          namespace: demo
-        dbName: "mysql"
-        maxConnections: 100
+    connectionInfo:
+      appBinding:
+        name: target-mysql
+        namespace: demo
+      dbName: "mysql"
+      maxConnections: 100
   jobDefaults:
     imagePullPolicy: IfNotPresent
     backoffLimit: 6
@@ -82,17 +79,17 @@ spec:
 
 ### spec.source
 
-`spec.source` is a required field that describes the database being migrated **from**. It holds a
-per-database sub-spec; for a MySQL migration you set `spec.source.mysql`.
+`spec.source` is a required field that describes the database being migrated **from**. It describes
+the MySQL source directly.
 
 ### spec.target
 
 `spec.target` is a required field that describes the KubeDB-managed database being migrated **into**.
-It holds a per-database sub-spec; for a MySQL migration you set `spec.target.mysql`.
+It describes the MySQL target directly.
 
-### spec.source.mysql.connectionInfo
+### spec.source.connectionInfo
 
-`connectionInfo` (also under `spec.target.mysql`) tells the Migration how to connect to the MySQL
+`connectionInfo` (also under `spec.target`) tells the MySQLMigration how to connect to the MySQL
 instance. There are two ways to provide the connection details — set **either** `appBinding` **or**
 `url`:
 
@@ -106,7 +103,7 @@ instance. There are two ways to provide the connection details — set **either*
   as an alternative to `appBinding` when you want to provide the endpoint inline instead of through an
   AppBinding.
 - `dbName` — the internal database used as the initial connection entry point.
-- `maxConnections` — limits the number of concurrent connections the Migration opens to this MySQL
+- `maxConnections` — limits the number of concurrent connections the MySQLMigration opens to this MySQL
   instance.
 - `tls` — paths to PEM files for a TLS-enabled connection. You can set the following fields:
   - `caFile` — path to the PEM-encoded CA certificate file.
@@ -118,7 +115,7 @@ instance. There are two ways to provide the connection details — set **either*
 > For a `KubeDB`-managed database, an `AppBinding` is created by default, so you usually only need to
 > create one for the source. Learn more about [AppBinding](/docs/guides/mysql/concepts/appbinding/).
 
-### spec.source.mysql.schema
+### spec.source.schema
 
 `schema` configures the schema migration phase, which recreates database and table definitions on the
 target before any data is copied.
@@ -128,7 +125,7 @@ target before any data is copied.
   system databases (`mysql`, `information_schema`, `performance_schema`, `sys`).
 - `excludeDatabase` — list of databases to exclude from migration.
 
-### spec.source.mysql.snapshot
+### spec.source.snapshot
 
 `snapshot` configures the initial bulk snapshot phase, which copies the existing rows from the source
 to the target.
@@ -143,7 +140,7 @@ to the target.
   - `read_batch_size` — number of rows fetched per read batch from the source. Defaults to `5000`.
   - `write_batch_size` — number of rows written per batch to the target. Defaults to `500`.
 
-### spec.source.mysql.streaming
+### spec.source.streaming
 
 `streaming` configures the change-data-capture (CDC) phase.
 
@@ -154,7 +151,7 @@ to the target.
 
 `spec.jobDefaults` is an optional field that sets default settings for the migration Job.
 
-- `imagePullPolicy` — the image pull policy for the Migration Job. Defaults to `IfNotPresent`.
+- `imagePullPolicy` — the image pull policy for the MySQLMigration Job. Defaults to `IfNotPresent`.
 - `backoffLimit` — the number of retries before the Job is marked as failed. Defaults to `6`.
 - `ttlSecondsAfterFinished` — the TTL (in seconds) for cleaning up a completed Job.
 - `activeDeadlineSeconds` — the duration (in seconds) relative to its start time that the Job may be
@@ -166,7 +163,7 @@ to the target.
 (a `PodTemplateSpec`). Use it to set pod-level settings such as `securityContext`, `nodeSelector`,
 `resources`, `serviceAccountName`, and so on.
 
-## Migration Status
+## MySQLMigration Status
 
 `status` reflects the observed state of the migration.
 
@@ -178,7 +175,7 @@ to the target.
 - `status.progress` — the current progress of the migration:
   - `dbType` — the type of database being migrated.
   - `info` — additional progress information, including the current `Stage`, `Lag`, and `Progress`
-    (these are surfaced as columns in `kubectl get migration`).
+    (these are surfaced as columns in `kubectl get mysqlmigrations`).
 - `status.conditions` — an array of conditions describing the migration's state over time (for
   example, `MigratorJobTriggered`, `MigrationRunning`, `MigrationSucceeded`, `MigrationFailed`).
 

--- a/docs/guides/mysql/migration/databaseMigration.md
+++ b/docs/guides/mysql/migration/databaseMigration.md
@@ -29,7 +29,7 @@ This guide will show you how to use `KubeDB` Migration to migrate an existing `M
 - You should be familiar with the following `KubeDB` concepts:
     - [AppBinding](/docs/guides/mysql/concepts/appbinding/)
     - [MySQL](/docs/guides/mysql/concepts/mysqldatabase)
-    - [Migration](/docs/guides/mysql/concepts/migrator/)
+    - [MySQLMigration](/docs/guides/mysql/concepts/migrator/)
     - [Migration](/docs/operatormanual/migration/)
 
 To keep everything isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
@@ -237,64 +237,62 @@ mysql.kubedb.com/target-mysql created
 
 Wait untill target-mysql has status `Ready`
 
-## Apply Migration CR
+## Apply MySQLMigration CR
 
-To Migrate database we have to create a `Migration` CR. Below is the YAML of the `Migration` CR that we are going to create,
+To Migrate database we have to create a `MySQLMigration` CR. Below is the YAML of the `MySQLMigration` CR that we are going to create,
 
 ```yaml
 apiVersion: courier.kubedb.com/v1alpha1
-kind: Migration
+kind: MySQLMigration
 metadata:
   name: mysql-migrate
   namespace: demo
 spec:
   source:
-    mysql:
-      connectionInfo:
-        appBinding:
-          name: source-mysql
-          namespace: demo
-        dbName: "mysql"
-        maxConnections: 100
-      schema:
-        enabled: true
-        database:
-          - shop
-        excludeDatabase: []
-      snapshot:
-        enabled: true
-        pipeline:
-          workers: 3
-          sinkers: 4
-          buffer: 12
-          write_batch_size: 200
-          read_batch_size: 1000
-      streaming:
-        enabled: true
+    connectionInfo:
+      appBinding:
+        name: source-mysql
+        namespace: demo
+      dbName: "mysql"
+      maxConnections: 100
+    schema:
+      enabled: true
+      database:
+        - shop
+      excludeDatabase: []
+    snapshot:
+      enabled: true
+      pipeline:
+        workers: 3
+        sinkers: 4
+        buffer: 12
+        write_batch_size: 200
+        read_batch_size: 1000
+    streaming:
+      enabled: true
 
   target:
-    mysql:
-      connectionInfo:
-        appBinding:
-          name: target-mysql
-          namespace: demo
-        dbName: "mysql"
-        maxConnections: 100
+    connectionInfo:
+      appBinding:
+        name: target-mysql
+        namespace: demo
+      dbName: "mysql"
+      maxConnections: 100
 ```
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/mysql/migration/mysql-migrate.yaml
-migration.courier.kubedb.com/mysql-migrate created
+mysqlmigration.courier.kubedb.com/mysql-migrate created
 ```
 
-Here we scope the migration to the `shop` database (`schema.database: [shop]`), enable both the bulk snapshot and CDC streaming phases, and cap connections at 100 on each side. For a full description of every field, see the [Migration CRD reference](/docs/guides/mysql/concepts/migrator/).
+Here we scope the migration to the `shop` database (`schema.database: [shop]`), enable both the bulk snapshot and CDC streaming phases, and cap connections at 100 on each side. For a full description of every field, see the [MySQLMigration CRD reference](/docs/guides/mysql/concepts/migrator/).
 
 ## Watch Migration Progress
 
-Let's wait for the `LAG` to reach near zero. Run the following command to watch `Migration` CR:
+Let's wait for the `LAG` to reach near zero. Run the following command to watch `MySQLMigration` CR:
 
 ```bash
-Every 2.0s: kubectl get migration -n demo 
+Every 2.0s: kubectl get mysqlmigrations -n demo 
 
 NAME            PHASE     DBTYPE   STAGE       LAG   PROGRESS   AGE
 mysql-migrate   Running   mysql    Streaming   0B    100%       4h36m
@@ -362,11 +360,11 @@ The INSERT, UPDATE, and DELETE are all reflected on the target — CDC streaming
 
 Once the `LAG` drops to near zero, stop all writes to the source database. Wait until the `LAG` reaches exactly zero — at that point both databases are fully in sync.
 
-Now delete the `Migration` CR to stop the migration process:
+Now delete the `MySQLMigration` CR to stop the migration process:
 
 ```bash
-$ kubectl delete migration -n demo mysql-migrate
-migration.courier.kubedb.com "mysql-migrate" deleted
+$ kubectl delete mysqlmigrations -n demo mysql-migrate
+mysqlmigration.courier.kubedb.com "mysql-migrate" deleted
 ```
 
 Finally, update your application's connection string to point to the target KubeDB-managed `MySQL` database. The migration is complete.

--- a/docs/guides/postgres/concepts/migrator.md
+++ b/docs/guides/postgres/concepts/migrator.md
@@ -25,7 +25,7 @@ the target in sync until you cut over.
 `PostgresMigration` is the PostgreSQL-specific migration CRD (`courier.kubedb.com/v1alpha1`) whose
 `spec.source` and `spec.target` describe the PostgreSQL source and target directly.
 
-## Migration Spec
+## PostgresMigration Spec
 
 As with all other Kubernetes objects, a `PostgresMigration` needs `apiVersion`, `kind`, and `metadata`
 fields. It also needs a `.spec` section. Below is an example `PostgresMigration` object for migrating a
@@ -43,7 +43,7 @@ spec:
       appBinding:
         name: source-postgres
         namespace: demo
-      dbName: postgres
+      dbName: shop
       maxConnections: 100
     pgDump:
       schemaOnly: true
@@ -59,7 +59,7 @@ spec:
       appBinding:
         name: target-postgres
         namespace: demo
-      dbName: postgres
+      dbName: shop
       maxConnections: 100
   jobDefaults:
     imagePullPolicy: IfNotPresent
@@ -158,7 +158,7 @@ from the source. These fields map directly to `pg_dump` command-line options.
 (a `PodTemplateSpec`). Use it to set pod-level settings such as `securityContext`, `nodeSelector`,
 `resources`, `serviceAccountName`, and so on.
 
-## Migration Status
+## PostgresMigration Status
 
 `status` reflects the observed state of the migration.
 

--- a/docs/guides/postgres/concepts/migrator.md
+++ b/docs/guides/postgres/concepts/migrator.md
@@ -1,9 +1,9 @@
 ---
-title: Migration CRD
+title: PostgresMigration CRD
 menu:
   docs_{{ .version }}:
     identifier: pg-migrator-concepts
-    name: Migration
+    name: PostgresMigration
     parent: pg-concepts-postgres
     weight: 26
 menu_name: docs_{{ .version }}
@@ -12,58 +12,55 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-# Migration
+# PostgresMigration
 
-## What is Migration
+## What is PostgresMigration
 
-`Migration` is a Kubernetes `Custom Resource Definition` (CRD). It provides a declarative way to
+`PostgresMigration` is a Kubernetes `Custom Resource Definition` (CRD). It provides a declarative way to
 migrate an existing database — such as one running on an external or managed instance — into a
-KubeDB-managed database. You only need to describe the source and target databases in a `Migration`
+KubeDB-managed database. You only need to describe the source and target databases in a `PostgresMigration`
 object, and the kubedb-courier operator will run the migration Job that copies the data and keeps
 the target in sync until you cut over.
 
-`Migration` is a single shared CRD (`courier.kubedb.com/v1alpha1`). Its `spec.source` and
-`spec.target` each carry a per-database sub-spec (`mysql`, `mariadb`, `postgres`, `mongodb`). This
-page describes the `Migration` object for a **PostgreSQL** source and target.
+`PostgresMigration` is the PostgreSQL-specific migration CRD (`courier.kubedb.com/v1alpha1`) whose
+`spec.source` and `spec.target` describe the PostgreSQL source and target directly.
 
 ## Migration Spec
 
-As with all other Kubernetes objects, a `Migration` needs `apiVersion`, `kind`, and `metadata`
-fields. It also needs a `.spec` section. Below is an example `Migration` object for migrating a
+As with all other Kubernetes objects, a `PostgresMigration` needs `apiVersion`, `kind`, and `metadata`
+fields. It also needs a `.spec` section. Below is an example `PostgresMigration` object for migrating a
 PostgreSQL database.
 
 ```yaml
 apiVersion: courier.kubedb.com/v1alpha1
-kind: Migration
+kind: PostgresMigration
 metadata:
   name: postgres-migrate
   namespace: demo
 spec:
   source:
-    postgres:
-      connectionInfo:
-        appBinding:
-          name: source-postgres
-          namespace: demo
-        dbName: postgres
-        maxConnections: 100
-      pgDump:
-        schemaOnly: true
-      logicalReplication:
-        copyData: true
-        publication:
-          name: "pub"
-          mode: default
-        subscription:
-          name: "sub"
+    connectionInfo:
+      appBinding:
+        name: source-postgres
+        namespace: demo
+      dbName: postgres
+      maxConnections: 100
+    pgDump:
+      schemaOnly: true
+    logicalReplication:
+      copyData: true
+      publication:
+        name: "pub"
+        mode: default
+      subscription:
+        name: "sub"
   target:
-    postgres:
-      connectionInfo:
-        appBinding:
-          name: target-postgres
-          namespace: demo
-        dbName: postgres
-        maxConnections: 100
+    connectionInfo:
+      appBinding:
+        name: target-postgres
+        namespace: demo
+      dbName: postgres
+      maxConnections: 100
   jobDefaults:
     imagePullPolicy: IfNotPresent
     backoffLimit: 6
@@ -77,17 +74,17 @@ spec:
 
 ### spec.source
 
-`spec.source` is a required field that describes the database being migrated **from**. It holds a
-per-database sub-spec; for a PostgreSQL migration you set `spec.source.postgres`.
+`spec.source` is a required field that describes the database being migrated **from**. It holds the
+PostgreSQL source fields directly under `spec.source`.
 
 ### spec.target
 
 `spec.target` is a required field that describes the KubeDB-managed database being migrated **into**.
-It holds a per-database sub-spec; for a PostgreSQL migration you set `spec.target.postgres`.
+It holds the PostgreSQL target fields directly under `spec.target`.
 
-### spec.source.postgres.connectionInfo
+### spec.source.connectionInfo
 
-`connectionInfo` (also under `spec.target.postgres`) tells the Migration how to connect to the
+`connectionInfo` (also under `spec.target`) tells the PostgresMigration how to connect to the
 PostgreSQL instance. There are two ways to provide the connection details — set **either**
 `appBinding` **or** `url`:
 
@@ -113,7 +110,7 @@ PostgreSQL instance. There are two ways to provide the connection details — se
 > For a `KubeDB`-managed database, an `AppBinding` is created by default, so you usually only need to
 > create one for the source. Learn more about [AppBinding](/docs/guides/postgres/concepts/appbinding.md).
 
-### spec.source.postgres.pgDump
+### spec.source.pgDump
 
 `pgDump` configures the schema migration phase, which uses `pg_dump` to extract object definitions
 from the source. These fields map directly to `pg_dump` command-line options.
@@ -126,7 +123,7 @@ from the source. These fields map directly to `pg_dump` command-line options.
 - `extraOptions` — additional raw `pg_dump` command-line flags not explicitly modeled by the fields
   above.
 
-### spec.source.postgres.logicalReplication
+### spec.source.logicalReplication
 
 `logicalReplication` configures the data copy and streaming phases using PostgreSQL
 [logical replication](https://www.postgresql.org/docs/current/logical-replication.html).
@@ -173,7 +170,7 @@ from the source. These fields map directly to `pg_dump` command-line options.
 - `status.progress` — the current progress of the migration:
   - `dbType` — the type of database being migrated.
   - `info` — additional progress information, including the current `Stage`, `Lag`, and `Progress`
-    (these are surfaced as columns in `kubectl get migration`).
+    (these are surfaced as columns in `kubectl get postgresmigrations`).
 - `status.conditions` — an array of conditions describing the migration's state over time (for
   example, `MigratorJobTriggered`, `MigrationRunning`, `MigrationSucceeded`, `MigrationFailed`).
 

--- a/docs/guides/postgres/migration/databaseMigration.md
+++ b/docs/guides/postgres/migration/databaseMigration.md
@@ -37,7 +37,7 @@ A brief downtime occurs only during the final cutover when application endpoints
 - You should be familiar with the following `KubeDB` concepts:
     - [AppBinding](/docs/guides/postgres/concepts/appbinding.md)
     - [PostgreSQL](/docs/guides/postgres/concepts/postgres.md)
-    - [Migration](/docs/guides/postgres/concepts/migrator.md)
+    - [PostgresMigration](/docs/guides/postgres/concepts/migrator.md)
     - [Migration](/docs/operatormanual/migration/)
 
 To keep everything isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
@@ -231,55 +231,53 @@ Wait until `target-postgres` has status `Ready`.
 
 ## Apply Migration CR
 
-To migrate the database we have to create a `Migration` CR. Below is the YAML of the `Migration` CR that we are going to create:
+To migrate the database we have to create a `PostgresMigration` CR. Below is the YAML of the `PostgresMigration` CR that we are going to create:
 
 ```yaml
 apiVersion: courier.kubedb.com/v1alpha1
-kind: Migration
+kind: PostgresMigration
 metadata:
   name: postgres-migrate
   namespace: demo
 spec:
   source:
-    postgres:
-      connectionInfo:
-        appBinding:
-          name: source-postgres
-          namespace: demo
-        dbName: shop
-        maxConnections: 100
-      pgDump:
-        schemaOnly: true
-      logicalReplication:
-        copyData: true
-        publication:
-          name: "pub"
-          mode: default
-        subscription:
-          name: "sub"
+    connectionInfo:
+      appBinding:
+        name: source-postgres
+        namespace: demo
+      dbName: shop
+      maxConnections: 100
+    pgDump:
+      schemaOnly: true
+    logicalReplication:
+      copyData: true
+      publication:
+        name: "pub"
+        mode: default
+      subscription:
+        name: "sub"
   target:
-    postgres:
-      connectionInfo:
-        appBinding:
-          name: target-postgres
-          namespace: demo
-        dbName: shop
-        maxConnections: 100
+    connectionInfo:
+      appBinding:
+        name: target-postgres
+        namespace: demo
+      dbName: shop
+      maxConnections: 100
 ```
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/postgres/migration/postgres-migrate.yaml
-migration.courier.kubedb.com/postgres-migrate created
+postgresmigration.courier.kubedb.com/postgres-migrate created
 ```
 
-Here we connect to and migrate the `shop` database. Schema is extracted via `pg_dump` (`pgDump.schemaOnly: true`) and data is replicated using PostgreSQL logical replication with publication `pub` on the source and subscription `sub` on the target. For a full description of every field, see the [Migration CRD reference](/docs/guides/postgres/concepts/migrator.md).
+Here we connect to and migrate the `shop` database. Schema is extracted via `pg_dump` (`pgDump.schemaOnly: true`) and data is replicated using PostgreSQL logical replication with publication `pub` on the source and subscription `sub` on the target. For a full description of every field, see the [PostgresMigration CRD reference](/docs/guides/postgres/concepts/migrator.md).
 
 ## Watch Migration Progress
 
-Let's wait for the `LAG` to reach near zero. Run the following command to watch `Migration` CR:
+Let's wait for the `LAG` to reach near zero. Run the following command to watch `PostgresMigration` CR:
 
 ```bash
-Every 2.0s: kubectl get migration -n demo
+Every 2.0s: kubectl get postgresmigrations -n demo
 
 NAME               PHASE     DBTYPE     STAGE       LAG   PROGRESS   AGE
 postgres-migrate   Running   postgres   Streaming   0B    100%       4h36m
@@ -341,11 +339,11 @@ The INSERT, UPDATE, and DELETE are all reflected on the target — logical repli
 
 Once the `LAG` drops to near zero, stop all writes to the source database. Wait until the `LAG` reaches exactly zero — at that point both databases are fully in sync.
 
-Now delete the `Migration` CR to stop the migration process:
+Now delete the `PostgresMigration` CR to stop the migration process:
 
 ```bash
-$ kubectl delete migration -n demo postgres-migrate
-migration.courier.kubedb.com "postgres-migrate" deleted
+$ kubectl delete postgresmigrations -n demo postgres-migrate
+postgresmigration.courier.kubedb.com "postgres-migrate" deleted
 ```
 
 Finally, update your application's connection string to point to the target KubeDB-managed `PostgreSQL` database. The migration is complete.

--- a/docs/guides/postgres/migration/databaseMigration.md
+++ b/docs/guides/postgres/migration/databaseMigration.md
@@ -229,7 +229,7 @@ postgres.kubedb.com/target-postgres created
 
 Wait until `target-postgres` has status `Ready`.
 
-## Apply Migration CR
+## Apply PostgresMigration CR
 
 To migrate the database we have to create a `PostgresMigration` CR. Below is the YAML of the `PostgresMigration` CR that we are going to create:
 

--- a/docs/operatormanual/migration/README.md
+++ b/docs/operatormanual/migration/README.md
@@ -33,10 +33,14 @@ Add `--set kubedb-courier.enabled=true` to the standard [KubeDB helm install](/d
 
 ### Upgrade Existing Install
 
-The Migration CRD is required to apply the Migration CR. Helm upgrade command doesn't apply CRD. So apply it manually:
+Each database has its own migration CRD (`PostgresMigration`, `MySQLMigration`, `MariaDBMigration`, `MongoDBMigration`, `MSSQLServerMigration`). The Helm upgrade command doesn't apply CRDs, so apply the one for the database you are migrating (or all of them) manually:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubedb/apimachinery/refs/heads/master/crds/courier.kubedb.com_migrations.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubedb/apimachinery/refs/heads/master/crds/courier.kubedb.com_postgresmigrations.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubedb/apimachinery/refs/heads/master/crds/courier.kubedb.com_mysqlmigrations.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubedb/apimachinery/refs/heads/master/crds/courier.kubedb.com_mariadbmigrations.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubedb/apimachinery/refs/heads/master/crds/courier.kubedb.com_mongodbmigrations.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubedb/apimachinery/refs/heads/master/crds/courier.kubedb.com_mssqlservermigrations.yaml
 ```
 
 Add `--set kubedb-courier.enabled=true` to the [Kubedb helm upgrade](/docs/setup/upgrade/index.md) 
@@ -44,7 +48,7 @@ Add `--set kubedb-courier.enabled=true` to the [Kubedb helm upgrade](/docs/setup
 
 ## Migration Steps
 
-1. **Create a Migration CR** with your source connection details and target KubeDB database reference. Migration starts automatically.
+1. **Create a migration CR** for your database — `PostgresMigration`, `MySQLMigration`, `MariaDBMigration`, `MongoDBMigration`, or `MSSQLServerMigration` — with your source connection details and target KubeDB database reference. Migration starts automatically.
 2. **Source stays live** — the KubeDB Migration first copies the schema, then takes an initial bulk snapshot of your data. Your source database continues to accept reads and writes throughout.
 3. **Streaming phase begins** — once the snapshot is complete, KubeDB streams ongoing changes from the source using CDC (change-data capture). 
 4. **Stop writes to the source** — when the streaming lag approaches zero, stop source database write


### PR DESCRIPTION
## What

Follow-up to the courier Migration duck-type split (kubedb/courier, kubedb/migrator, kubedb/installer). The single `Migration` CRD was replaced by per-engine CRDs — `PostgresMigration`, `MySQLMigration`, `MariaDBMigration`, `MongoDBMigration` — so the migration docs added in #887 are updated to match.

## Changes

- **Migration CR manifests** (examples + inline YAML) use the engine-specific `kind`, and hold the source/target fields directly — the `spec.source.<engine>` / `spec.target.<engine>` nesting level is gone.
- **Concept pages** (`concepts/migrator*`): titles, headings, intro, `spec.source`/`spec.target` field-reference sections, and front-matter names updated to the per-engine CRD.
- **Migration guides** (`migration/databaseMigration.md`): `kubectl get/delete` and apply-output resource names switched to the per-engine plurals (`postgresmigrations`, etc.); prose and reference links updated.
- **Operator manual** (`operatormanual/migration/README.md`): manual-upgrade step applies the five per-engine CRDs.

Databases covered: PostgreSQL, MySQL, MariaDB, MongoDB (the engines documented in #887).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated migration guides, concept pages, and examples to use database-specific migration resources (MariaDB, MongoDB, MySQL, Postgres) with the newer API kind and a flattened `spec.source`/`spec.target` layout.
  * Refreshed walkthrough commands, progress/status references, and cleanup steps to match the new resource names.
  * Updated the operator manual to install and create the correct database-specific migration CRDs.
* **Chores**
  * Adjusted CI to install the full set of database-specific migration CRDs (including MSSQLServer) instead of a single generic manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->