### PR TITLE
docs(ignite): refresh guides to 2.18.0 and fix bugs found by executing them

### DIFF
--- a/docs/examples/ignite/custom-config/custom-ignite.yaml
+++ b/docs/examples/ignite/custom-config/custom-ignite.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: 2.17.0
+  version: 2.18.0
   configuration:
     secretName: ignite-configuration
   storage:

--- a/docs/examples/ignite/custom-config/custom-podtemplate.yaml
+++ b/docs/examples/ignite/custom-config/custom-podtemplate.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-ignite
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 1
   podTemplate:
     spec:

--- a/docs/examples/ignite/custom-config/ignite-without-tolerations.yaml
+++ b/docs/examples/ignite/custom-config/ignite-without-tolerations.yaml
@@ -4,6 +4,6 @@ metadata:
   name: ignite-without-tolerations
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 1
   deletionPolicy: WipeOut

--- a/docs/examples/ignite/custom-config/node-selector.yaml
+++ b/docs/examples/ignite/custom-config/node-selector.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ignite-node-selector
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 1
   podTemplate:
     spec:

--- a/docs/examples/ignite/custom-config/sidecar-container.yaml
+++ b/docs/examples/ignite/custom-config/sidecar-container.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ignite-custom-sidecar
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 1
   podTemplate:
     spec:

--- a/docs/examples/ignite/custom-config/with-tolerations.yaml
+++ b/docs/examples/ignite/custom-config/with-tolerations.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ignite-with-tolerations
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 1
   podTemplate:
     spec:

--- a/docs/examples/ignite/custom-rbac/ig-custom-db-two.yaml
+++ b/docs/examples/ignite/custom-rbac/ig-custom-db-two.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "2.17.0"
+  version: "2.18.0"
   podTemplate:
     spec:
       serviceAccountName: my-custom-serviceaccount

--- a/docs/examples/ignite/custom-rbac/ig-custom-db.yaml
+++ b/docs/examples/ignite/custom-rbac/ig-custom-db.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "2.17.0"
+  version: "2.18.0"
   podTemplate:
     spec:
       serviceAccountName: my-custom-serviceaccount

--- a/docs/examples/ignite/monitoring/builtin-prom-ignite.yaml
+++ b/docs/examples/ignite/monitoring/builtin-prom-ignite.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: 2.17.0
+  version: 2.18.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/examples/ignite/monitoring/ignite.yaml
+++ b/docs/examples/ignite/monitoring/ignite.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "2.17.0"
+  version: "2.18.0"
   deletionPolicy: WipeOut
   podTemplate:
     spec:

--- a/docs/examples/ignite/private-registry/demo-2.yaml
+++ b/docs/examples/ignite/private-registry/demo-2.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "2.17.0"
+  version: "2.18.0"
   podTemplate:
     spec:
       containers:

--- a/docs/examples/ignite/quickstart/demo.yaml
+++ b/docs/examples/ignite/quickstart/demo.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: 2.17.0
+  version: 2.18.0
   storage:
     accessModes:
       - ReadWriteOnce

--- a/docs/guides/ignite/autoscaler/compute/compute-autoscale.md
+++ b/docs/guides/ignite/autoscaler/compute/compute-autoscale.md
@@ -41,7 +41,7 @@ namespace/demo created
 
 ## Autoscaling of Ignite
 
-In this section, we are going to deploy a Ignite with version `2.17.0`  Then, in the next section we will set up autoscaling for this Ignite using `IgniteAutoscaler` CRD. Below is the YAML of the `Ignite` CR that we are going to create,
+In this section, we are going to deploy a Ignite with version `2.18.0`  Then, in the next section we will set up autoscaling for this Ignite using `IgniteAutoscaler` CRD. Below is the YAML of the `Ignite` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -50,7 +50,7 @@ metadata:
   name: ignite-autoscale
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 1
   storage:
     accessModes:
@@ -67,7 +67,7 @@ spec:
         - name: ignite
           resources:
             requests:
-              cpu: "0.5m"
+              cpu: "500m"
               memory: "1Gi"
             limits:
               cpu: "1"
@@ -86,7 +86,7 @@ Now, wait until `ignite-autoscale` has status `Ready`. i.e,
 ```bash
 $ kubectl get ig -n demo
 NAME                 TYPE                  VERSION   STATUS   AGE
-ignite-autoscale     kubedb.com/v1alpha2   2.17.0     Ready    22s
+ignite-autoscale     kubedb.com/v1alpha2   2.18.0     Ready    22s
 ```
 
 Let's check the Pod containers resources,
@@ -99,7 +99,7 @@ $ kubectl get pod -n demo ignite-autoscale-0 -o json | jq '.spec.containers[].re
     "memory": "2Gi"
   },
   "requests": {
-    "cpu": "0.5m",
+    "cpu": "500m",
     "memory": "1Gi"
   }
 }
@@ -114,7 +114,7 @@ $ kubectl get ignite -n demo ignite-autoscale -o json | jq '.spec.podTemplate.sp
     "memory": "2Gi"
   },
   "requests": {
-    "cpu": "0.5m",
+    "cpu": "500m",
     "memory": "1Gi"
   }
 }
@@ -161,7 +161,7 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing compute resource autoscaling on `ignite-autoscale`.
 - `spec.compute.ignite.trigger` specifies that compute resource autoscaling is enabled for this ignite.
 - `spec.compute.ignite.podLifeTimeThreshold` specifies the minimum lifetime for at least one of the pod to initiate a vertical scaling.
-- `spec.compute.ignite.resourceDiffPercentage` specifies the minimum resource difference in percentage. The default is 10%.
+- `spec.compute.ignite.resourceDiffPercentage` specifies the minimum resource difference in percentage. The default is 50%.
   If the difference between current & recommended resource is less than ResourceDiffPercentage, Autoscaler Operator will ignore the updating.
 - `spec.compute.ignite.minAllowed` specifies the minimum allowed resources for this ignite.
 - `spec.compute.ignite.maxAllowed` specifies the maximum allowed resources for this ignite.
@@ -173,7 +173,7 @@ Let's create the `IgniteAutoscaler` CR we have shown above,
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/autoscaling/compute/ignite-autoscaler.yaml
-igniteautoscaler.autoscaling.kubedb.com/ignite-autoscaler-ops created
+igniteautoscaler.autoscaling.kubedb.com/ignite-autoscale-ops created
 ```
 
 #### Verify Autoscaling is set up successfully

--- a/docs/guides/ignite/autoscaler/storage/overview.md
+++ b/docs/guides/ignite/autoscaler/storage/overview.md
@@ -12,7 +12,7 @@ section_menu_id: guides
 
 > New to KubeDB? Please start [here](/docs/README.md).
 
-# Ignite Vertical Autoscaling
+# Ignite Storage Autoscaling
 
 This guide will give an overview on how KubeDB Autoscaler operator autoscales the database storage using `Igniteautoscaler` crd.
 

--- a/docs/guides/ignite/autoscaler/storage/storage-autoscale.md
+++ b/docs/guides/ignite/autoscaler/storage/storage-autoscale.md
@@ -58,7 +58,7 @@ Now, we are going to deploy a `Ignite` cluster using a supported version by `Kub
 
 #### Deploy Ignite Cluster
 
-In this section, we are going to deploy a Ignite cluster with version `2.17.0`.  Then, in the next section we will set up autoscaling for this database using `IgniteAutoscaler` CRD. Below is the YAML of the `Ignite` CR that we are going to create,
+In this section, we are going to deploy a Ignite cluster with version `2.18.0`.  Then, in the next section we will set up autoscaling for this database using `IgniteAutoscaler` CRD. Below is the YAML of the `Ignite` CR that we are going to create,
 
 > If you want to autoscale Ignite `Standalone`, Just remove the `spec.Replicas` from the below yaml and rest of the steps are same.
 
@@ -69,7 +69,7 @@ metadata:
   name: ignite-autoscale
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 3
   storage:
     accessModes:
@@ -109,7 +109,7 @@ Now, wait until `ignite-autoscale` has status `Ready`. i.e,
 ```bash
 $ kubectl get ignite -n demo
 NAME                 VERSION   STATUS   AGE
-ignite-autoscale     2.17.0    Ready    3m46s
+ignite-autoscale     2.18.0    Ready    3m46s
 ```
 
 Let's check volume size from petset, and from the persistent volume,
@@ -141,7 +141,7 @@ In order to set up vertical autoscaling for this replicaset database, we have to
 apiVersion: autoscaling.kubedb.com/v1alpha1
 kind: IgniteAutoscaler
 metadata:
-  name: ignite-storage-autosclaer
+  name: ignite-storage-autoscaler
   namespace: demo
 spec:
   databaseRef:
@@ -159,14 +159,14 @@ Here,
 - `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `ignite-autoscale` database.
 - `spec.storage.ignite.trigger` specifies that storage autoscaling is enabled for this database.
 - `spec.storage.ignite.usageThreshold` specifies storage usage threshold, if storage usage exceeds `20%` then storage autoscaling will be triggered.
-- `spec.storage.ignite.scalingThreshold` specifies the scaling threshold. Storage will be scaled to `20%` of the current amount.
-- `spec.storage.ignite.expansionMode` specifies the expansion mode of volume expansion `igniteOpsRequest` created by `igniteAutoscaler`. topolvm-provisioner supports online volume expansion so here `expansionMode` is set as "Online".
+- `spec.storage.ignite.scalingThreshold` specifies the scaling threshold. Storage will be scaled to `30%` of the current amount.
+- `spec.storage.ignite.expansionMode` specifies the expansion mode of volume expansion `igniteOpsRequest` created by `igniteAutoscaler`. topolvm-provisioner supports online volume expansion so here `expansionMode` is set as "Offline".
 
 Let's create the `igniteAutoscaler` CR we have shown above,
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/guides/ignite/autoscaler/storage/cluster/examples/ig-storage-autoscale-ops.yaml
-igniteautoscaler.autoscaling.kubedb.com/ignite-storage-autosclaer created
+igniteautoscaler.autoscaling.kubedb.com/ignite-storage-autoscaler created
 ```
 
 #### Storage Autoscaling is set up successfully
@@ -176,10 +176,10 @@ Let's check that the `igniteautoscaler` resource is created successfully,
 ```bash
 $ kubectl get igniteautoscaler -n demo
 NAME                          AGE
-ignite-storage-autosclaer   33s
+ignite-storage-autoscaler   33s
 
 $ kubectl describe igniteautoscaler ignite-storage-autoscaler -n demo
-Name:         ignite-storage-autosclaer
+Name:         ignite-storage-autoscaler
 Namespace:    demo
 Labels:       <none>
 Annotations:  API Version:  autoscaling.kubedb.com/v1alpha1
@@ -196,7 +196,7 @@ Spec:
     Name:  ignite-autoscale
   Storage:
     ignite:
-      Scaling Threshold:  20
+      Scaling Threshold:  30
       Trigger:            On
       Usage Threshold:    20
 Events:                   <none>
@@ -242,7 +242,7 @@ Metadata:
     Block Owner Deletion:  true
     Controller:            true
     Kind:                  igniteAutoscaler
-    Name:                  ignite-storage-autosclaer
+    Name:                  ignite-storage-autoscaler
     UID:                   4f45a3b3-fc72-4d04-b52c-a770944311f6
   Resource Version:        25557
   UID:                     90763a49-a03f-407c-a233-fb20c4ab57d7
@@ -308,6 +308,6 @@ To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
 kubectl delete ignite -n demo ignite-autoscale
-kubectl delete igniteautoscaler -n demo igops-ignite-autoscale-xojkua
+kubectl delete igniteautoscaler -n demo ignite-storage-autoscaler
 kubectl delete ns demo
 ```

--- a/docs/guides/ignite/concepts/appbinding.md
+++ b/docs/guides/ignite/concepts/appbinding.md
@@ -37,7 +37,7 @@ An `AppBinding` object created by `KubeDB` for Ignite database is shown below,
   metadata:
     annotations:
       kubectl.kubernetes.io/last-applied-configuration: |
-        {"apiVersion":"appcatalog.appscode.com/v1alpha1","kind":"AppBinding","metadata":{"annotations":{},"name":"ignite-appbinding","namespace":"demo"},"spec":{"appRef":{"apiGroup":"kubedb.com","kind":"ignite","name":"ig","namespace":"demo"},"clientConfig":{"service":{"name":"ignite","namespace":"demo","port":11211,"scheme":"tcp"}},"secret":{"name":"ignite-auth"},"type":"kubedb.com/ignite","version":"2.17.0"}}
+        {"apiVersion":"appcatalog.appscode.com/v1alpha1","kind":"AppBinding","metadata":{"annotations":{},"name":"ignite-appbinding","namespace":"demo"},"spec":{"appRef":{"apiGroup":"kubedb.com","kind":"ignite","name":"ig","namespace":"demo"},"clientConfig":{"service":{"name":"ignite","namespace":"demo","port":10800,"scheme":"http"}},"secret":{"name":"ignite-auth"},"type":"kubedb.com/ignite","version":"2.18.0"}}
     creationTimestamp: "2025-04-26T09:51:57Z"
     generation: 1
     name: ignite-appbinding
@@ -55,11 +55,11 @@ An `AppBinding` object created by `KubeDB` for Ignite database is shown below,
         name: ignite
         namespace: demo
         port: 10800
-        scheme: tcp
+        scheme: http
     secret:
       name: ignite-auth
     type: kubedb.com/ignite
-    version: 2.17.0
+    version: 2.18.0
 ```
 Here, we are going to describe the sections of an `AppBinding` crd.
 

--- a/docs/guides/ignite/concepts/autoscaler.md
+++ b/docs/guides/ignite/concepts/autoscaler.md
@@ -80,10 +80,6 @@ These are the options to pass in the internally created opsRequest CRO. `opsRequ
 - `resourceDiffPercentage` specifies the minimum resource difference between recommended value and the current value in percentage. If the difference percentage is greater than this value than autoscaling will be triggered.
 - `podLifeTimeThreshold` specifies the minimum pod lifetime of at least one of the pods before triggering autoscaling.
 
-There are two more fields, those are only specifiable for the percona variant inMemory databases.
-- `inMemoryStorage.UsageThresholdPercentage` If db uses more than usageThresholdPercentage of the total memory, memoryStorage should be increased.
-- `inMemoryStorage.ScalingFactorPercentage` If db uses more than usageThresholdPercentage of the total memory, memoryStorage should be increased by this given scaling percentage.
-
 ### spec.storage
 
 `spec.storage` specifies the autoscaling configuration for the storage resources of the database components. This field consists of the following sub-field:

--- a/docs/guides/ignite/concepts/ignite-version.md
+++ b/docs/guides/ignite/concepts/ignite-version.md
@@ -28,30 +28,30 @@ As with all other Kubernetes objects, a IgniteVersion needs `apiVersion`, `kind`
 
 ```yaml
 apiVersion: catalog.kubedb.com/v1alpha1
-  kind: IgniteVersion
-  metadata:
-    annotations:
-      meta.helm.sh/release-name: kubedb-catalog
-      meta.helm.sh/release-namespace: kubedb
-    creationTimestamp: "2025-05-20T08:57:56Z"
-    generation: 1
-    labels:
-      app.kubernetes.io/instance: kubedb-catalog
-      app.kubernetes.io/managed-by: Helm
-      app.kubernetes.io/name: kubedb-catalog
-      app.kubernetes.io/version: v2025.4.30
-      helm.sh/chart: kubedb-catalog-v2025.4.30
-    name: 2.17.0
-    resourceVersion: "847947"
-    uid: be60213c-5aba-43ac-9dbf-a352005cbb0c
-  spec:
-    db:
-      image: ghcr.io/appscode-images/ignite:2.17.0
-    initContainer:
-      image: ghcr.io/kubedb/ignite-init:2.17.0-v1
-    securityContext:
-      runAsUser: 70
-    version: 2.17.0
+kind: IgniteVersion
+metadata:
+  annotations:
+    meta.helm.sh/release-name: kubedb-catalog
+    meta.helm.sh/release-namespace: kubedb
+  creationTimestamp: "2025-05-20T08:57:56Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/instance: kubedb-catalog
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kubedb-catalog
+    app.kubernetes.io/version: v2025.4.30
+    helm.sh/chart: kubedb-catalog-v2025.4.30
+  name: 2.18.0
+  resourceVersion: "847947"
+  uid: be60213c-5aba-43ac-9dbf-a352005cbb0c
+spec:
+  db:
+    image: ghcr.io/appscode-images/ignite:2.18.0
+  initContainer:
+    image: ghcr.io/kubedb/ignite-init:2.18.0-v1
+  securityContext:
+    runAsUser: 70
+  version: 2.18.0
 ```
 
 ### metadata.name

--- a/docs/guides/ignite/concepts/ignite.md
+++ b/docs/guides/ignite/concepts/ignite.md
@@ -30,7 +30,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: 2.17.0
+  version: 2.18.0
   configuration:
     secretName: ignite-configuration
   authSecret:
@@ -71,7 +71,7 @@ KubeDB uses `PodDisruptionBudget` to ensure that majority of these replicas are 
 
 `spec.version` is a required field specifying the name of the [IgniteVersion](/docs/guides/ignite/concepts/ignite-version.md) crd where the docker images are specified. Currently, when you install KubeDB, it creates the following `IgniteVersion` crds,
 
-- `2.17.0`
+- `2.18.0`
 
 ### spec.monitor
 
@@ -231,7 +231,7 @@ See [here](https://github.com/kmodules/offshoot-api/blob/kubernetes-1.16.3/api/v
 
 ### spec.deletionPolicy
 
-`deletionPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `Ignite` crd or which resources KubeDB should keep or delete when you delete `Ignite` crd. KubeDB provides following four termination policies:
+`deletionPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `Ignite` crd or which resources KubeDB should keep or delete when you delete `Ignite` crd. KubeDB provides following three termination policies:
 
 - DoNotTerminate
 - Delete (`Default`)
@@ -250,7 +250,7 @@ Following table show what KubeDB does when you delete Ignite crd for different t
 
 If you don't specify `spec.deletionPolicy` KubeDB uses `Delete` termination policy by default.
 
-## spec.helathChecker
+## spec.healthChecker
 It defines the attributes for the health checker.
 - spec.healthChecker.periodSeconds specifies how often to perform the health check.
 - spec.healthChecker.timeoutSeconds specifies the number of seconds after which the probe times out.

--- a/docs/guides/ignite/concepts/opsrequest.md
+++ b/docs/guides/ignite/concepts/opsrequest.md
@@ -197,3 +197,5 @@ A `IgniteOpsRequest` object has the following fields in the `spec` section.
 - `Reconfigure`
 - `ReconfigureTLS`
 - `Restart`
+- `RotateAuth`
+- `StorageMigration`

--- a/docs/guides/ignite/custom-configuration/using-config-file.md
+++ b/docs/guides/ignite/custom-configuration/using-config-file.md
@@ -112,7 +112,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: 2.17.0
+  version: 2.18.0
   configuration:
     secretName: ignite-configuration
   storage:
@@ -132,7 +132,7 @@ Check if the database is ready
 ```bash
 $ kubectl get ig -n demo
 NAME               VERSION   STATUS   AGE
-custom-ignite      2.17.0    Ready    17m
+custom-ignite      2.18.0    Ready    17m
 ```
 
 Now, we will check if the database has started with the custom configuration we have provided.

--- a/docs/guides/ignite/custom-configuration/using-podtemplate.md
+++ b/docs/guides/ignite/custom-configuration/using-podtemplate.md
@@ -62,7 +62,7 @@ Read about the fields in details in [PodTemplate concept](/docs/guides/ignite/co
 
 Below is the YAML for the Ignite created in this example. Here, `spec.podTemplate.spec.containers[].env` specifies additional environment variables by users.
 
-In this tutorial, we will register additional two users at starting time of Ignite. So, the fact is any environment variable with having `suffix: USERNAME` and `suffix: PASSWORD` will be key value pairs of username and password and will be registered in the `pool_passwd` file of Ignite. So we can use these users after Ignite initialize without even syncing them.
+In this tutorial, we will set additional environment variables at starting time of Ignite. Any environment variable specified in `spec.podTemplate.spec.containers[].env` will be available inside the Ignite container.
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -71,7 +71,7 @@ metadata:
   name: custom-ignite
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 1
   podTemplate:
     spec:
@@ -146,7 +146,7 @@ metadata:
   name: ignite-custom-sidecar
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 1
   podTemplate:
     spec:
@@ -195,7 +195,7 @@ kind: Ignite
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1","kind":"Ignite","metadata":{"annotations":{},"name":"ignite-custom-sidecar","namespace":"demo"},"spec":{"deletionPolicy":"WipeOut","podTemplate":{"spec":{"containers":[{"name":"ignite","resources":{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"500m","memory":"500Mi"}}},{"image":"evanraisul/custom_filebeat:latest","name":"filebeat","resources":{"limits":{"cpu":"300m","memory":"300Mi"},"requests":{"cpu":"300m","memory":"300Mi"}}}]}},"replicas":1,"version":"2.17.0"}}
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"Ignite","metadata":{"annotations":{},"name":"ignite-custom-sidecar","namespace":"demo"},"spec":{"deletionPolicy":"WipeOut","podTemplate":{"spec":{"containers":[{"name":"ignite","resources":{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"500m","memory":"500Mi"}}},{"image":"evanraisul/custom_filebeat:latest","name":"filebeat","resources":{"limits":{"cpu":"300m","memory":"300Mi"},"requests":{"cpu":"300m","memory":"300Mi"}}}]}},"replicas":1,"version":"2.18.0"}}
   creationTimestamp: "2024-12-02T10:59:59Z"
   finalizers:
   - kubedb.com
@@ -250,7 +250,7 @@ spec:
         fsGroup: 999
       serviceAccountName: ignite-custom-sidecar
   replicas: 1
-  version: 2.17.0
+  version: 2.18.0
 status:
   conditions:
   - lastTransitionTime: "2024-12-02T10:59:59Z"
@@ -343,7 +343,7 @@ metadata:
   name: ignite-node-selector
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 1
   podTemplate:
     spec:
@@ -432,7 +432,7 @@ metadata:
   name: ignite-without-tolerations
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 1
   deletionPolicy: WipeOut
 ```
@@ -456,7 +456,7 @@ Namespace:        demo
 Priority:         0
 Service Account:  default
 Node:             <none>
-Labels:           app.kubernetes.io/component=connection-pooler
+Labels:           app.kubernetes.io/component=database
                   app.kubernetes.io/instance=ignite-without-tolerations
                   app.kubernetes.io/managed-by=kubedb.com
                   app.kubernetes.io/name=ignites.kubedb.com
@@ -470,7 +470,7 @@ IPs:              <none>
 Controlled By:    PetSet/ignite-without-tolerations
 Containers:
   ignite:
-    Image:           ghcr.io/appscode-images/ignite:2.17.0
+    Image:           ghcr.io/appscode-images/ignite:2.18.0
     Ports:           10800/TCP
     Host Ports:      0/TCP, 0/TCP
     SeccompProfile:  RuntimeDefault
@@ -508,7 +508,7 @@ volumes:
       items:
       - key: node-configuration.xml
         path: node-configuration.xml
-      secretName: ignite-quickstart-config
+      secretName: ignite-without-tolerations-1d3146
   - name: kube-api-access-62rc6
     projected:
       defaultMode: 420
@@ -530,8 +530,8 @@ volumes:
 Node-Selectors:               <none>
 Tolerations:                  node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                               node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
-Topology Spread Constraints:  kubernetes.io/hostname:ScheduleAnyway when max skew 1 is exceeded for selector app.kubernetes.io/component=connection-pooler,app.kubernetes.io/instance=ignite-without-tolerations,app.kubernetes.io/managed-by=kubedb.com,app.kubernetes.io/name=ignites.kubedb.com
-                              topology.kubernetes.io/zone:ScheduleAnyway when max skew 1 is exceeded for selector app.kubernetes.io/component=connection-pooler,app.kubernetes.io/instance=ignite-without-tolerations,app.kubernetes.io/managed-by=kubedb.com,app.kubernetes.io/name=ignites.kubedb.com
+Topology Spread Constraints:  kubernetes.io/hostname:ScheduleAnyway when max skew 1 is exceeded for selector app.kubernetes.io/component=database,app.kubernetes.io/instance=ignite-without-tolerations,app.kubernetes.io/managed-by=kubedb.com,app.kubernetes.io/name=ignites.kubedb.com
+                              topology.kubernetes.io/zone:ScheduleAnyway when max skew 1 is exceeded for selector app.kubernetes.io/component=database,app.kubernetes.io/instance=ignite-without-tolerations,app.kubernetes.io/managed-by=kubedb.com,app.kubernetes.io/name=ignites.kubedb.com
 Events:
   Type     Reason             Age                   From                Message
   ----     ------             ----                  ----                -------
@@ -549,7 +549,7 @@ metadata:
   name: ignite-with-tolerations
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 1
   podTemplate:
     spec:
@@ -587,7 +587,7 @@ We can successfully verify that our pod was scheduled to the node which it has t
 To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
-kubectl delete -n demo pp custom-sidecar node-selector with-tolerations without-tolerations
+kubectl delete -n demo ig custom-ignite ignite-custom-sidecar ignite-node-selector ignite-with-tolerations ignite-without-tolerations
 kubectl delete ns demo
 ```
 

--- a/docs/guides/ignite/custom-rbac/using-custom-rbac.md
+++ b/docs/guides/ignite/custom-rbac/using-custom-rbac.md
@@ -39,7 +39,7 @@ If a service account name is given, but there's no existing service account by t
 
 If a service account name is given, and there's an existing service account by that name, the KubeDB operator will use that existing service account. Since this service account is not managed by KubeDB, users are responsible for providing necessary access permissions manually.
 
-This guide will show you how to create custom `Service Account`, `Role`, and `RoleBinding` for a Ignite instance named `quick-ignite` to provide the bare minimum access permissions.
+This guide will show you how to create custom `Service Account`, `Role`, and `RoleBinding` for a Ignite instance named `ignite-quickstart` to provide the bare minimum access permissions.
 
 ## Custom RBAC for Ignite
 
@@ -67,7 +67,7 @@ secrets:
 - name: myserviceaccount-token-t8zxd
 ```
 
-Now, we need to create a role that has necessary access permissions for the Ignite instance named `quick-ignite`.
+Now, we need to create a role that has necessary access permissions for the Ignite instance named `ignite-quickstart`.
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/custom-rbac/ig-custom-role.yaml
@@ -144,7 +144,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "2.17.0"
+  version: "2.18.0"
   podTemplate:
     spec:
       serviceAccountName: my-custom-serviceaccount
@@ -160,7 +160,7 @@ spec:
   deletionPolicy: DoNotTerminate
 ```
 
-Now, wait a few minutes. the KubeDB operator will create necessary petset, services, secret etc. If everything goes well, we should see that a pod with the name `quick-ignite-0` has been created.
+Now, wait a few minutes. the KubeDB operator will create necessary petset, services, secret etc. If everything goes well, we should see that a pod with the name `ignite-quickstart-0` has been created.
 
 Check that the pod is running:
 
@@ -180,7 +180,7 @@ Now, create Ignite crd `minute-ignite` using the existing service account name `
 
 ```bash
 $ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/custom-rbac/ig-custom-db-two.yaml
-ignite.kubedb.com/ignite-quickstart created
+ignite.kubedb.com/minute-ignite created
 ```
 
 Below is the YAML for the Ignite crd we just created.
@@ -193,7 +193,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "2.17.0"
+  version: "2.18.0"
   podTemplate:
     spec:
       serviceAccountName: my-custom-serviceaccount

--- a/docs/guides/ignite/monitoring/overview.md
+++ b/docs/guides/ignite/monitoring/overview.md
@@ -54,7 +54,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "2.17.0"
+  version: "2.18.0"
   deletionPolicy: WipeOut
   podTemplate:
     spec:
@@ -83,7 +83,7 @@ spec:
             cpu: 250m
 ```
 
-Assume that above Ignite is configured to use basic authentication. So, exporter image also need to provide password to collect metrics. We have provided it through `spec.monitor.args` field.
+Assume that above Ignite is configured to use basic authentication. So, exporter image also need to provide password to collect metrics. We have provided it through `spec.monitor.prometheus.exporter.args` field.
 
 Here, we have specified that we are going to monitor this server using Prometheus operator through `spec.monitor.agent: prometheus.io/operator`. KubeDB will create a `ServiceMonitor` crd in `monitoring` namespace and this `ServiceMonitor` will have `release: prometheus` label.
 

--- a/docs/guides/ignite/monitoring/using-builtin-prometheus.md
+++ b/docs/guides/ignite/monitoring/using-builtin-prometheus.md
@@ -46,11 +46,11 @@ At first, let's deploy a Ignite server with monitoring enabled. Below is the Ign
 apiVersion: kubedb.com/v1alpha2
 kind: Ignite
 metadata:
-  name: ignite-quickstart
+  name: builtin-prom-ignite
   namespace: demo
 spec:
   replicas: 3
-  version: 2.17.0
+  version: 2.18.0
   storage:
     accessModes:
       - ReadWriteOnce
@@ -78,7 +78,7 @@ Now, wait for the database to go into `Ready` state.
 ```bash
 $ kubectl get ig -n demo builtin-prom-ignite
 NAME                 VERSION    STATUS    AGE
-builtin-prom-ignite   1.6.22     Ready     30s
+builtin-prom-ignite   2.18.0     Ready     30s
 ```
 
 KubeDB will create a separate stats service with name `{Ignite crd name}-stats` for monitoring purpose.
@@ -86,8 +86,8 @@ KubeDB will create a separate stats service with name `{Ignite crd name}-stats` 
 ```bash
 $ kubectl get svc -n demo --selector="app.kubernetes.io/instance=builtin-prom-ignite"
 NAME                       TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)     AGE
-builtin-prom-ignite        ClusterIP   10.96.168.132   <none>        11211/TCP   20s
-builtin-prom-ignite-pods   ClusterIP   None            <none>        11211/TCP   20s
+builtin-prom-ignite        ClusterIP   10.96.168.132   <none>        8080/TCP,10800/TCP,47500/TCP,47100/TCP   20s
+builtin-prom-ignite-pods   ClusterIP   None            <none>        8080/TCP,10800/TCP,47500/TCP,47100/TCP   20s
 builtin-prom-ignite-stats  ClusterIP   10.96.40.60     <none>        56790/TCP   20s
 ```
 
@@ -102,7 +102,7 @@ Labels:            app.kubernetes.io/component=database
                    app.kubernetes.io/managed-by=kubedb.com
                    app.kubernetes.io/name=ignites.kubedb.com
                    kubedb.com/role=stats
-Annotations:       monitoring.appscode.com/agent: prometheus.io/operator
+Annotations:       monitoring.appscode.com/agent: prometheus.io/builtin
 Selector:          app.kubernetes.io/instance=builtin-prom-ignite,app.kubernetes.io/managed-by=kubedb.com,app.kubernetes.io/name=ignites.kubedb.com
 Type:              ClusterIP
 IP Family Policy:  SingleStack
@@ -269,7 +269,7 @@ data:
 Let's create above `ConfigMap`,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/v2024.8.21/docs/examples/monitoring/builtin-prometheus/prom-config.yaml
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/monitoring/builtin-prometheus/prom-config.yaml
 configmap/prometheus-config created
 ```
 

--- a/docs/guides/ignite/monitoring/using-prometheus-operator.md
+++ b/docs/guides/ignite/monitoring/using-prometheus-operator.md
@@ -45,7 +45,7 @@ The following diagram shows how KubeDB Provisioner operator monitor `Ignite` usi
 
 ## Find out required labels for ServiceMonitor
 
-We need to know the labels used to select `ServiceMonitor` by a `Prometheus` crd. We are going to provide these labels in `spec.monitor.prometheus.labels` field of Ignite crd so that KubeDB creates `ServiceMonitor` object accordingly.
+We need to know the labels used to select `ServiceMonitor` by a `Prometheus` crd. We are going to provide these labels in `spec.monitor.prometheus.serviceMonitor.labels` field of Ignite crd so that KubeDB creates `ServiceMonitor` object accordingly.
 
 At first, let's find out the available Prometheus server in our cluster.
 
@@ -168,7 +168,7 @@ status:
   updatedReplicas: 1
 ```
 
-Notice the `spec.serviceMonitorSelector` section. Here, `release: prometheus` label is used to select `ServiceMonitor` crd. So, we are going to use this label in `spec.monitor.prometheus.labels` field of Ignite crd.
+Notice the `spec.serviceMonitorSelector` section. Here, `release: prometheus` label is used to select `ServiceMonitor` crd. So, we are going to use this label in `spec.monitor.prometheus.serviceMonitor.labels` field of Ignite crd.
 
 ## Deploy Ignite with Monitoring Enabled
 
@@ -182,7 +182,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 1
-  version: "2.17.0"
+  version: "2.18.0"
   deletionPolicy: WipeOut
   podTemplate:
     spec:
@@ -206,11 +206,10 @@ spec:
 
 Here,
 - `monitor.agent:  prometheus.io/operator` indicates that we are going to monitor this server using Prometheus operator.
-- `monitor.prometheus.namespace: monitoring` specifies that KubeDB should create `ServiceMonitor` in `monitoring` namespace.
 
-- `monitor.prometheus.labels` specifies that KubeDB should create `ServiceMonitor` with these labels.
+- `monitor.prometheus.serviceMonitor.labels` specifies that KubeDB should create `ServiceMonitor` with these labels. The `ServiceMonitor` is created in the same namespace as the database.
 
-- `monitor.prometheus.interval` indicates that the Prometheus server should scrape metrics from this database with 10 seconds interval.
+- `monitor.prometheus.serviceMonitor.interval` indicates that the Prometheus server should scrape metrics from this database with 10 seconds interval.
 
 Let's create the Ignite object that we have shown above,
 
@@ -224,7 +223,7 @@ Now, wait for the database to go into `Running` state.
 ```bash
 $ kubectl get ig -n demo ignite
 NAME        VERSION   STATUS   AGE
-ignite      2.17.0    Ready    2m
+ignite      2.18.0    Ready    2m
 ```
 
 KubeDB will create a separate stats service with name `{Ignite crd name}-stats` for monitoring purpose.
@@ -232,8 +231,8 @@ KubeDB will create a separate stats service with name `{Ignite crd name}-stats` 
 ```bash
 $ kubectl get svc -n demo --selector="app.kubernetes.io/instance=ignite"
 NAME              TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)     AGE
-ignite            ClusterIP   10.96.91.51   <none>        11211/TCP   3m9s
-ignite-pods       ClusterIP   None          <none>        11211/TCP   3m9s
+ignite            ClusterIP   10.96.91.51   <none>        8080/TCP,10800/TCP,47500/TCP,47100/TCP   3m9s
+ignite-pods       ClusterIP   None          <none>        8080/TCP,10800/TCP,47500/TCP,47100/TCP   3m9s
 ignite-stats      ClusterIP   10.96.50.21   <none>        56790/TCP   3m9s
 ```
 
@@ -319,7 +318,7 @@ spec:
 
 Notice that the `ServiceMonitor` has label `release: prometheus` that we had specified in Ignite crd.
 
-Also notice that the `ServiceMonitor` has selector which match the labels we have seen in the `ignite-stats` service. It also, target the `prom-http` port that we have seen in the stats service.
+Also notice that the `ServiceMonitor` has selector which match the labels we have seen in the `ignite-stats` service. It also, target the `metrics` port that we have seen in the stats service.
 
 ## Verify Monitoring Metrics
 
@@ -341,7 +340,7 @@ Forwarding from 127.0.0.1:9090 -> 9090
 Forwarding from [::1]:9090 -> 9090
 ```
 
-Now, we can access the dashboard at `localhost:9090`. Open [http://localhost:9090](http://localhost:9090) in your browser. You should see `prom-http` endpoint of `ignite-stats` service as one of the targets.
+Now, we can access the dashboard at `localhost:9090`. Open [http://localhost:9090](http://localhost:9090) in your browser. You should see `metrics` endpoint of `ignite-stats` service as one of the targets.
 
 <p align="center">
   <img alt="Prometheus Target" src="/docs/images/ignite/monitoring/ig-coreos-prom-target.png" style="padding:10px">
@@ -366,7 +365,7 @@ kubectl delete -n monitoring service prometheus-operated
 
 # cleanup prometheus operator resources
 kubectl delete -n monitoring deployment prometheus-operator
-kubectl delete -n dmeo serviceaccount prometheus-operator
+kubectl delete -n demo serviceaccount prometheus-operator
 kubectl delete clusterrolebinding prometheus-operator
 kubectl delete clusterrole prometheus-operator
 

--- a/docs/guides/ignite/private-registry/using-private-registry.md
+++ b/docs/guides/ignite/private-registry/using-private-registry.md
@@ -27,9 +27,9 @@ KubeDB operator supports using private Docker registry. This tutorial will show 
 - You have to push the required images from KubeDB's [Docker hub account](https://hub.docker.com/r/kubedb/) into your private registry. For ignite, push `DB_IMAGE`, `EXPORTER_IMAGE` of following IgniteVersions, where `deprecated` is not true, to your private registry.
 
   ```bash
-  $ kubectl get igniteversions -n kube-system  -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,DB_IMAGE:.spec.db.image,EXPORTER_IMAGE:.spec.exporter.image,DEPRECATED:.spec.deprecated
+  $ kubectl get igniteversions  -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,DB_IMAGE:.spec.db.image,EXPORTER_IMAGE:.spec.exporter.image,DEPRECATED:.spec.deprecated
   NAME     VERSION   DB_IMAGE                                          EXPORTER_IMAGE                                          DEPRECATED
-  2.17.0   2.17.0    ghcr.io/appscode-images/ignite:2.17.0             ghcr.io/kubedb/ignite-init:2.17.0-v1                    <none>
+  2.18.0   2.18.0    ghcr.io/appscode-images/ignite:2.18.0             ghcr.io/kubedb/ignite-init:2.18.0-v1                    <none>
   ```
 
 - Update KubeDB catalog for private Docker registry. Ex:
@@ -38,13 +38,13 @@ KubeDB operator supports using private Docker registry. This tutorial will show 
   apiVersion: catalog.kubedb.com/v1alpha1
   kind: IgniteVersion
   metadata:
-    name: 2.17.0
+    name: 2.18.0
   spec:
     db:
-      image: PRIVATE_REGISTRY/ignite:2.17.0
+      image: PRIVATE_REGISTRY/ignite:2.18.0
     securityContext:
       runAsUser: 70
-    version: 2.17.0
+    version: 2.18.0
   ```
 
 - To keep things isolated, this tutorial uses a separate namespace called `demo` throughout this tutorial. Run the following command to prepare your cluster for this tutorial:
@@ -90,7 +90,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: "2.17.0"
+  version: "2.18.0"
   podTemplate:
     spec:
       containers:
@@ -118,16 +118,12 @@ To check if the images pulled successfully from the repository, see if the `Igni
 ```bash
 $ kubectl get pods -n demo -w
 NAME                             READY     STATUS              RESTARTS   AGE
-ig-pvt-reg-694d4d44df-bwtk8      0/1       ContainerCreating   0          18s
-ig-pvt-reg-694d4d44df-tkqc4      0/1       ContainerCreating   0          17s
-ig-pvt-reg-694d4d44df-zhj4l      0/1       ContainerCreating   0          17s
-ig-pvt-reg-694d4d44df-bwtk8      1/1       Running             0          25s
-ig-pvt-reg-694d4d44df-zhj4l      1/1       Running             0          26s
-ig-pvt-reg-694d4d44df-tkqc4      1/1       Running             0          27s
+ig-pvt-reg-0                     0/1       ContainerCreating   0          18s
+ig-pvt-reg-0                     1/1       Running             0          25s
 
 $ kubectl get ig -n demo
 NAME            VERSION    STATUS    AGE
-ig-pvt-reg      2.17.0     Running   59s
+ig-pvt-reg      2.18.0     Running   59s
 ```
 
 ## Cleaning up

--- a/docs/guides/ignite/private-registry/using-private-registry.md
+++ b/docs/guides/ignite/private-registry/using-private-registry.md
@@ -24,11 +24,11 @@ KubeDB operator supports using private Docker registry. This tutorial will show 
 
 - You will also need a docker private [registry](https://docs.docker.com/registry/) or [private repository](https://docs.docker.com/docker-hub/repos/#private-repositories).  In this tutorial we will use private repository of [docker hub](https://hub.docker.com/).
 
-- You have to push the required images from KubeDB's [Docker hub account](https://hub.docker.com/r/kubedb/) into your private registry. For ignite, push `DB_IMAGE`, `EXPORTER_IMAGE` of following IgniteVersions, where `deprecated` is not true, to your private registry.
+- You have to push the required images from KubeDB's [Docker hub account](https://hub.docker.com/r/kubedb/) into your private registry. For ignite, push `DB_IMAGE`, `INIT_IMAGE` of following IgniteVersions, where `deprecated` is not true, to your private registry.
 
   ```bash
-  $ kubectl get igniteversions  -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,DB_IMAGE:.spec.db.image,EXPORTER_IMAGE:.spec.exporter.image,DEPRECATED:.spec.deprecated
-  NAME     VERSION   DB_IMAGE                                          EXPORTER_IMAGE                                          DEPRECATED
+  $ kubectl get igniteversions  -o=custom-columns=NAME:.metadata.name,VERSION:.spec.version,DB_IMAGE:.spec.db.image,INIT_IMAGE:.spec.initContainer.image,DEPRECATED:.spec.deprecated
+  NAME     VERSION   DB_IMAGE                                          INIT_IMAGE                                              DEPRECATED
   2.18.0   2.18.0    ghcr.io/appscode-images/ignite:2.18.0             ghcr.io/kubedb/ignite-init:2.18.0-v1                    <none>
   ```
 
@@ -42,6 +42,8 @@ KubeDB operator supports using private Docker registry. This tutorial will show 
   spec:
     db:
       image: PRIVATE_REGISTRY/ignite:2.18.0
+    initContainer:
+      image: PRIVATE_REGISTRY/ignite-init:2.18.0-v1
     securityContext:
       runAsUser: 70
     version: 2.18.0

--- a/docs/guides/ignite/quickstart/quickstart.md
+++ b/docs/guides/ignite/quickstart/quickstart.md
@@ -41,12 +41,12 @@ demo      Active    1s
 
 ## Find Available IgniteVersion
 
-When you have installed KubeDB, it has created `IgniteVersion` crd for all supported Ignite versions. Check 0
+When you have installed KubeDB, it has created `IgniteVersion` crd for all supported Ignite versions. Check it out.
 
 ```bash
 $ kubectl get igniteversions
 NAME        VERSION    DB_IMAGE                                            DEPRECATED   AGE
-2.17.0      2.17.0     ghcr.io/appscode-images/ignite:2.17.0                            2h
+2.18.0      2.18.0     ghcr.io/appscode-images/ignite:2.18.0                            2h
 ```
 
 ## Create a Ignite server
@@ -61,7 +61,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: 2.17.0
+  version: 2.18.0
   storage:
     accessModes:
       - ReadWriteOnce
@@ -79,7 +79,7 @@ ignite.kubedb.com/ignite-quickstart created
 Here,
 
 - `spec.replicas` is an optional field that specifies the number of desired Instances/Replicas of Ignite server. It defaults to 1.
-- `spec.version` is the version of Ignite server. In this tutorial, a Ignite 2.17.0 database is going to be created.
+- `spec.version` is the version of Ignite server. In this tutorial, a Ignite 2.18.0 database is going to be created.
 - `.spec.podTemplate.spec.containers[].resources` is an optional field that specifies how much CPU and memory (RAM) each Container needs. To learn details about Managing Compute Resources for Containers, please visit [here](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/).
 - `spec.deletionPolicy` gives flexibility whether to `nullify`(reject) the delete operation of `Ignite` crd or which resources KubeDB should keep or delete when you delete `Ignite` crd. If admission webhook is enabled, It prevents users from deleting the database as long as the `spec.deletionPolicy` is set to `DoNotTerminate`. Learn details of all `DeletionPolicy` [here](/docs/guides/ignite/concepts/ignite.md#specdeletionpolicy)
 
@@ -87,7 +87,7 @@ KubeDB operator watches for `Ignite` objects using Kubernetes api. When a `Ignit
 ```bash
 $ kubectl get ig -n demo
 NAME                TYPE                  VERSION   STATUS   AGE
-ignite-quickstart   kubedb.com/v1alpha2   2.17.0    Ready    2m
+ignite-quickstart   kubedb.com/v1alpha2   2.18.0    Ready    2m
 
 $ kubectl describe ig -n demo ignite-quickstart
 Name:         ignite-quickstart
@@ -154,7 +154,7 @@ Spec:
       Requests:
         Storage:  1Gi
   Storage Type:   Durable
-  Version:        2.17.0
+  Version:        2.18.0
 Status:
   Conditions:
     Last Transition Time:  2025-05-30T08:52:28Z
@@ -221,7 +221,7 @@ kind: Ignite
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"kubedb.com/v1alpha2","kind":"Ignite","metadata":{"annotations":{},"name":"ignite-quickstart","namespace":"demo"},"spec":{"deletionPolicy":"WipeOut","replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}}},"version":"2.17.0"}}
+      {"apiVersion":"kubedb.com/v1alpha2","kind":"Ignite","metadata":{"annotations":{},"name":"ignite-quickstart","namespace":"demo"},"spec":{"deletionPolicy":"WipeOut","replicas":3,"storage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}}},"version":"2.18.0"}}
   creationTimestamp: "2025-05-30T08:52:28Z"
   finalizers:
   - kubedb.com/ignite
@@ -281,7 +281,7 @@ spec:
       requests:
         storage: 1Gi
   storageType: Durable
-  version: 2.17.0
+  version: 2.18.0
 status:
   conditions:
   - lastTransitionTime: "2025-05-30T08:52:28Z"
@@ -366,7 +366,7 @@ When `deletionPolicy` is set to `DoNotTerminate`, KubeDB takes advantage of `Val
 
 ```bash
 $ kubectl delete ig ignite-quickstart -n demo
-Error from server (Forbidden): admission webhook "ignitewebhook.validators.kubedb.com" denied the request: ignite demo/ignite-quickstart is can't terminated. To delete, change spec.deletionPolicy
+The Ignite "ignite-quickstart" is invalid: spec.deletionPolicy: Invalid value: "ignite-quickstart": Can not delete as terminationPolicy is set to "DoNotTerminate"
 ```
 Learn details of all `DeletionPolicy` [here](/docs/guides/ignite/concepts/ignite.md#specdeletionpolicy).
 
@@ -389,7 +389,6 @@ Now, run the following command to get all ignite resources in `demo` namespaces,
 $ kubectl get petset,svc,secret,pvc -n demo
 NAME                              TYPE                       DATA   AGE
 secret/ignite-quickstart-auth     kubernetes.io/basic-auth   2      27m
-secret/ignite-quickstart-config   Opaque                     1      27m
 ```
 
 From the above output, you can see that all ignite resources(`PetSet`, `Service` etc.) are deleted except `Secret`.

--- a/docs/guides/ignite/reconfigure-tls/reconfigure-tls.md
+++ b/docs/guides/ignite/reconfigure-tls/reconfigure-tls.md
@@ -39,7 +39,7 @@ Here, We are going to create a Ignite database without TLS and then reconfigure 
 
 ### Deploy Ignite without TLS
 
-In this section, we are going to deploy a Ignite Replicaset database without TLS. In the next few sections we will reconfigure TLS using `IgniteOpsRequest` CRD. Below is the YAML of the `Ignite` CR that we are going to create,
+In this section, we are going to deploy an Ignite database without TLS. In the next few sections we will reconfigure TLS using `IgniteOpsRequest` CRD. Below is the YAML of the `Ignite` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -48,7 +48,7 @@ metadata:
   name: ig
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 3
   storage:
     storageClassName: "standard"
@@ -71,7 +71,7 @@ Now, wait until `ig` has status `Ready`. i.e,
 ```bash
 $ kubectl get ig -n demo
 NAME    VERSION    STATUS    AGE
-ig      2.17.0     Ready     10m
+ig      2.18.0     Ready     10m
 ```
 
 ```bash
@@ -109,7 +109,7 @@ $ kubectl create secret tls ignite-ca \
 secret/ignite-ca created
 ```
 
-Now, Let's create an `Issuer` using the `mongo-ca` secret that we have just created. The `YAML` file looks like this:
+Now, Let's create an `Issuer` using the `ignite-ca` secret that we have just created. The `YAML` file looks like this:
 
 ```yaml
 apiVersion: cert-manager.io/v1
@@ -234,7 +234,7 @@ Metadata:
     Operation:       Update
     Time:            2025-03-11T13:32:19Z
   Resource Version:  488264
-  Self Link:         /apis/ops.kubedb.com/v1alpha1/namespaces/demo/Igniteopsrequests/mops-add-tls
+  Self Link:         /apis/ops.kubedb.com/v1alpha1/namespaces/demo/igniteopsrequests/igops-add-tls
   UID:               0024ec16-0d43-4686-a2d7-1cdeb96e41a5
 Spec:
   Database Ref:
@@ -246,11 +246,11 @@ Spec:
         Organizational Units:
           client
         Organizations:
-          mongo
+          ignite
     Issuer Ref:
       API Group:  cert-manager.io
       Kind:       Issuer
-      Name:       mg-issuer
+      Name:       ig-issuer
   Type:           ReconfigureTLS
 Status:
   Conditions:
@@ -267,11 +267,11 @@ Status:
     Status:                True
     Type:                  TLSAdded
     Last Transition Time:  2025-03-11T13:34:25Z
-    Message:               Successfully Restarted ReplicaSet nodes
+    Message:               Successfully restarted all nodes
     Observed Generation:   1
-    Reason:                RestartReplicaSet
+    Reason:                RestartNodes
     Status:                True
-    Type:                  RestartReplicaSet
+    Type:                  RestartNodes
     Last Transition Time:  2025-03-11T13:34:25Z
     Message:               Successfully Reconfigured TLS
     Observed Generation:   1
@@ -286,7 +286,7 @@ Events:
   Normal  PauseDatabase      2m10s  KubeDB Ops-manager operator  Pausing Ignite demo/ig
   Normal  PauseDatabase      2m10s  KubeDB Ops-manager operator  Successfully paused Ignite demo/ig
   Normal  TLSAdded           2m10s  KubeDB Ops-manager operator  Successfully Updated StatefulSets
-  Normal  RestartReplicaSet  10s    KubeDB Ops-manager operator  Successfully Restarted ReplicaSet nodes
+  Normal  RestartNodes  10s    KubeDB Ops-manager operator  Successfully restarted all nodes
   Normal  ResumeDatabase     10s    KubeDB Ops-manager operator  Resuming Ignite demo/ig
   Normal  ResumeDatabase     10s    KubeDB Ops-manager operator  Successfully resumed Ignite demo/ig
   Normal  Successful         10s    KubeDB Ops-manager operator  Successfully Reconfigured TLS
@@ -331,8 +331,8 @@ Here,
 Let's create the `IgniteOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/Ignite/reconfigure-tls/igops-rotate.yaml
-Igniteopsrequest.ops.kubedb.com/igops-rotate created
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/reconfigure-tls/igops-rotate.yaml
+igniteopsrequest.ops.kubedb.com/igops-rotate created
 ```
 
 #### Verify Certificate Rotated Successfully
@@ -340,7 +340,7 @@ Igniteopsrequest.ops.kubedb.com/igops-rotate created
 Let's wait for `IgniteOpsRequest` to be `Successful`.  Run the following command to watch `IgniteOpsRequest` CRO,
 
 ```bash
-$ kubectl get Igniteopsrequest -n demo
+$ kubectl get igniteopsrequest -n demo
 Every 2.0s: kubectl get igniteopsrequest -n demo
 NAME           TYPE             STATUS        AGE
 igops-rotate    ReconfigureTLS   Successful    112s
@@ -420,11 +420,11 @@ Status:
     Status:                True
     Type:                  CertificateIssuingSuccessful
     Last Transition Time:  2025-03-11T16:19:45Z
-    Message:               Successfully Restarted ReplicaSet nodes
+    Message:               Successfully restarted all nodes
     Observed Generation:   1
-    Reason:                RestartReplicaSet
+    Reason:                RestartNodes
     Status:                True
-    Type:                  RestartReplicaSet
+    Type:                  RestartNodes
     Last Transition Time:  2025-03-11T16:19:45Z
     Message:               Successfully Reconfigured TLS
     Observed Generation:   1
@@ -437,7 +437,7 @@ Events:
   Type    Reason                        Age    From                        Message
   ----    ------                        ----   ----                        -------
   Normal  CertificateIssuingSuccessful  2m10s  KubeDB Ops-manager operator  Successfully Issued New Certificates
-  Normal  RestartReplicaSet             25s    KubeDB Ops-manager operator  Successfully Restarted ReplicaSet nodes
+  Normal  RestartNodes             25s    KubeDB Ops-manager operator  Successfully restarted all nodes
   Normal  Successful                    25s    KubeDB Ops-manager operator  Successfully Reconfigured TLS
 ```
 
@@ -476,7 +476,7 @@ $ kubectl create secret tls ig-new-ca \
 secret/ig-new-ca created
 ```
 
-Now, Let's create a new `Issuer` using the `mongo-new-ca` secret that we have just created. The `YAML` file looks like this:
+Now, Let's create a new `Issuer` using the `ig-new-ca` secret that we have just created. The `YAML` file looks like this:
 
 ```yaml
 apiVersion: cert-manager.io/v1
@@ -599,7 +599,7 @@ Spec:
     Issuer Ref:
       API Group:  cert-manager.io
       Kind:       Issuer
-      Name:       mg-new-issuer
+      Name:       ig-new-issuer
   Type:           ReconfigureTLS
 Status:
   Conditions:
@@ -616,11 +616,11 @@ Status:
     Status:                True
     Type:                  CertificateIssuingSuccessful
     Last Transition Time:  2025-03-11T16:29:37Z
-    Message:               Successfully Restarted ReplicaSet nodes
+    Message:               Successfully restarted all nodes
     Observed Generation:   1
-    Reason:                RestartReplicaSet
+    Reason:                RestartNodes
     Status:                True
-    Type:                  RestartReplicaSet
+    Type:                  RestartNodes
     Last Transition Time:  2025-03-11T16:29:37Z
     Message:               Successfully Reconfigured TLS
     Observed Generation:   1
@@ -633,7 +633,7 @@ Events:
   Type    Reason                        Age    From                        Message
   ----    ------                        ----   ----                        -------
   Normal  CertificateIssuingSuccessful  2m27s  KubeDB Ops-manager operator  Successfully Issued New Certificates
-  Normal  RestartReplicaSet             42s    KubeDB Ops-manager operator  Successfully Restarted ReplicaSet nodes
+  Normal  RestartNodes             42s    KubeDB Ops-manager operator  Successfully restarted all nodes
   Normal  Successful                    42s    KubeDB Ops-manager operator  Successfully Reconfigured TLS
 ```
 
@@ -659,7 +659,7 @@ Below is the YAML of the `IgniteOpsRequest` CRO that we are going to create,
 apiVersion: ops.kubedb.com/v1alpha1
 kind: IgniteOpsRequest
 metadata:
-  name: mops-remove
+  name: igops-remove
   namespace: demo
 spec:
   type: ReconfigureTLS
@@ -678,8 +678,8 @@ Here,
 Let's create the `IgniteOpsRequest` CR we have shown above,
 
 ```bash
-$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/reconfigure-tls/mops-remove.yaml
-igniteopsrequest.ops.kubedb.com/mops-remove created
+$ kubectl apply -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/reconfigure-tls/igops-remove.yaml
+igniteopsrequest.ops.kubedb.com/igops-remove created
 ```
 
 #### Verify TLS Removed Successfully
@@ -690,14 +690,14 @@ Let's wait for `IgniteOpsRequest` to be `Successful`.  Run the following command
 $ kubectl get igniteopsrequest -n demo
 Every 2.0s: kubectl get igniteopsrequest -n demo
 NAME          TYPE             STATUS        AGE
-mops-remove   ReconfigureTLS   Successful    105s
+igops-remove   ReconfigureTLS   Successful    105s
 ```
 
 We can see from the above output that the `IgniteOpsRequest` has succeeded. If we describe the `IgniteOpsRequest` we will get an overview of the steps that were followed.
 
 ```bash
-$ kubectl describe igniteopsrequest -n demo mops-remove
-Name:         mops-remove
+$ kubectl describe igniteopsrequest -n demo igops-remove
+Name:         igops-remove
 Namespace:    demo
 Labels:       <none>
 Annotations:  <none>
@@ -738,7 +738,7 @@ Metadata:
     Operation:       Update
     Time:            2025-03-11T16:35:32Z
   Resource Version:  525550
-  Self Link:         /apis/ops.kubedb.com/v1alpha1/namespaces/demo/Igniteopsrequests/mops-remove
+  Self Link:         /apis/ops.kubedb.com/v1alpha1/namespaces/demo/igniteopsrequests/igops-remove
   UID:               99184cc4-1595-4f0f-b8eb-b65c5d0e86a6
 Spec:
   Database Ref:
@@ -761,11 +761,11 @@ Status:
     Status:                True
     Type:                  TLSRemoved
     Last Transition Time:  2025-03-11T16:37:07Z
-    Message:               Successfully Restarted ReplicaSet nodes
+    Message:               Successfully restarted all nodes
     Observed Generation:   1
-    Reason:                RestartReplicaSet
+    Reason:                RestartNodes
     Status:                True
-    Type:                  RestartReplicaSet
+    Type:                  RestartNodes
     Last Transition Time:  2025-03-11T16:37:07Z
     Message:               Successfully Reconfigured TLS
     Observed Generation:   1
@@ -780,7 +780,7 @@ Events:
   Normal  PauseDatabase      2m5s  KubeDB Ops-manager operator  Pausing Ignite demo/ig
   Normal  PauseDatabase      2m5s  KubeDB Ops-manager operator  Successfully paused Ignite demo/ig
   Normal  TLSRemoved         2m5s  KubeDB Ops-manager operator  Successfully Updated StatefulSets
-  Normal  RestartReplicaSet  35s   KubeDB Ops-manager operator  Successfully Restarted ReplicaSet nodes
+  Normal  RestartNodes  35s   KubeDB Ops-manager operator  Successfully restarted all nodes
   Normal  ResumeDatabase     35s   KubeDB Ops-manager operator  Resuming Ignite demo/ig
   Normal  ResumeDatabase     35s   KubeDB Ops-manager operator  Successfully resumed Ignite demo/ig
   Normal  Successful         35s   KubeDB Ops-manager operator  Successfully Reconfigured TLS

--- a/docs/guides/ignite/reconfigure/overview.md
+++ b/docs/guides/ignite/reconfigure/overview.md
@@ -45,7 +45,7 @@ The Reconfiguring Ignite process consists of the following steps:
 
 6. When it finds a `IgniteOpsRequest` CR, it halts the `Ignite` object which is referred from the `IgniteOpsRequest`. So, the `KubeDB` Provisioner  operator doesn't perform any operations on the `Ignite` object during the reconfiguring process.  
 
-7. Then the `KubeDB` Ops-manager operator will replace the existing configuration with the new configuration provided or merge the new configuration with the existing configuration according to the `MogoDBOpsRequest` CR.
+7. Then the `KubeDB` Ops-manager operator will replace the existing configuration with the new configuration provided or merge the new configuration with the existing configuration according to the `IgniteOpsRequest` CR.
 
 8. Then the `KubeDB` Ops-manager operator will restart the related PetSet Pods so that they restart with the new configuration defined in the `IgniteOpsRequest` CR.
 

--- a/docs/guides/ignite/reconfigure/reconfigure.md
+++ b/docs/guides/ignite/reconfigure/reconfigure.md
@@ -40,7 +40,7 @@ Now, we are going to deploy a  `Ignite` cluster using a supported version by `Ku
 
 ### Prepare Ignite Database
 
-Now, we are going to deploy a `Ignite` cluster with version `2.17.0`.
+Now, we are going to deploy a `Ignite` cluster with version `2.18.0`.
 
 ### Deploy Ignite
 
@@ -62,7 +62,7 @@ metadata:
   name: ig-cluster
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -87,7 +87,7 @@ Now, wait until `ig-cluster` has status `Ready`. i.e,
 ```bash
 $ kubectl get ig -n demo
 NAME            TYPE                  VERSION   STATUS   AGE
-ig-cluster      kubedb.com/v1alpha2   2.17.0    Ready    79m
+ig-cluster      kubedb.com/v1alpha2   2.18.0    Ready    79m
 ```
 
 Now, we will check if the database has started with the custom configuration we have provided.
@@ -133,7 +133,7 @@ spec:
 
 Here,
 
-- `spec.databaseRef.name` specifies that we are reconfiguring `igps-reconfigure` database.
+- `spec.databaseRef.name` specifies that we are reconfiguring `ig-cluster` database.
 - `spec.type` specifies that we are performing `Reconfigure` on our database.
 - `spec.configuration.configSecret.name` specifies the name of the new secret.
 - Have a look [here](/docs/guides/ignite/concepts/opsrequest.md#specconfiguration) on the respective sections to understand the `readinessCriteria`, `timeout` & `apply` fields.

--- a/docs/guides/ignite/restart/restart.md
+++ b/docs/guides/ignite/restart/restart.md
@@ -42,7 +42,7 @@ metadata:
   name: ig
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 3
   storageType: Durable
   storage:
@@ -104,7 +104,7 @@ kind: IgniteOpsRequest
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"ops.kubedb.com/v1alpha1","kind":"IgniteOpsRequest","metadata":{"annotations":{},"name":"restart","namespace":"demo"},"spec":{"apply":"Always","databaseRef":{"name":"mongo"},"readinessCriteria":{"objectsCountDiffPercentage":15,"oplogMaxLagSeconds":10},"timeout":"3m","type":"Restart"}}
+      {"apiVersion":"ops.kubedb.com/v1alpha1","kind":"IgniteOpsRequest","metadata":{"annotations":{},"name":"restart","namespace":"demo"},"spec":{"apply":"Always","databaseRef":{"name":"ig"},"timeout":"3m","type":"Restart"}}
   creationTimestamp: "2022-10-31T08:54:45Z"
   generation: 1
   name: restart
@@ -126,11 +126,11 @@ status:
     status: "True"
     type: Restart
   - lastTransitionTime: "2022-10-31T08:57:05Z"
-    message: Successfully Restarted ReplicaSet nodes
+    message: Successfully restarted all nodes
     observedGeneration: 1
-    reason: RestartReplicaSet
+    reason: RestartNodes
     status: "True"
-    type: RestartReplicaSet
+    type: RestartNodes
   - lastTransitionTime: "2022-10-31T08:57:05Z"
     message: Successfully restarted all nodes of Ignite
     observedGeneration: 1

--- a/docs/guides/ignite/rotate-auth/overview.md
+++ b/docs/guides/ignite/rotate-auth/overview.md
@@ -19,8 +19,8 @@ This guide will give an overview on how KubeDB Ops-manager operator Rotate Authe
 ## Before You Begin
 
 - You should be familiar with the following `KubeDB` concepts:
-    - [Ignite](/docs/guides/ignite/concepts/ignite/index.md)
-    - [IgniteOpsRequest](/docs/guides/ignite/concepts/opsrequest/index.md)
+    - [Ignite](/docs/guides/ignite/concepts/ignite.md)
+    - [IgniteOpsRequest](/docs/guides/ignite/concepts/opsrequest.md)
 
 ## How Rotate Ignite Authentication Configuration Process Works
 

--- a/docs/guides/ignite/rotate-auth/rotateauth.md
+++ b/docs/guides/ignite/rotate-auth/rotateauth.md
@@ -19,8 +19,8 @@ section_menu_id: guides
 ## Before You Begin
 
 - You should be familiar with the following `KubeDB` concepts:
-    - [Ignite](/docs/guides/ignite/concepts/ignite/index.md)
-    - [IgniteOpsRequest](/docs/guides/ignite/concepts/ignite/index.md)
+    - [Ignite](/docs/guides/ignite/concepts/ignite.md)
+    - [IgniteOpsRequest](/docs/guides/ignite/concepts/opsrequest.md)
 
 - At first, you need to have a Kubernetes cluster, and the kubectl command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
 
@@ -45,7 +45,7 @@ metadata:
   namespace: demo
 spec:
   replicas: 3
-  version: 2.17.0
+  version: 2.18.0
   storage:
     accessModes:
       - ReadWriteOnce
@@ -65,13 +65,13 @@ Now, wait until ignite-quickstart has status Ready. i.e,
 ```shell
 $ kubectl get ignite -n demo -w
 NAME            VERSION   STATUS   AGE
-ignite-quickstart   2.16.0    Ready    30m
+ignite-quickstart   2.18.0    Ready    30m
 ```
 ## Verify authentication
 The user can verify whether they are authorized by executing a query directly in the database. To do this, the user needs `username` and `password` in order to connect to the database using the `kubectl exec` command. Below is an example showing how to retrieve the credentials from the Secret.
 
 ````shell
-$ ubectl get ignite -n demo ignite-quickstart -ojson | jq .spec.authSecret.name
+$ kubectl get ignite -n demo ignite-quickstart -ojson | jq .spec.authSecret.name
 "ignite-quickstart-auth"
 $  kubectl get secret -n demo ignite-quickstart-auth -o=jsonpath='{.data.username}' | base64 -d
 ignite⏎                                                                                    

--- a/docs/guides/ignite/scaling/horizontal-scaling/horizontal-scaling.md
+++ b/docs/guides/ignite/scaling/horizontal-scaling/horizontal-scaling.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a `Ignite` using a supported version by `KubeDB` op
 
 ### Deploy Ignite 
 
-In this section, we are going to deploy a Ignite. We are going to deploy a `Ignite` with version `2.17.0`. Then, in the next section we will scale the ignite using `IgniteOpsRequest` CRD. Below is the YAML of the `Ignite` CR that we are going to create,
+In this section, we are going to deploy a Ignite. We are going to deploy a `Ignite` with version `2.18.0`. Then, in the next section we will scale the ignite using `IgniteOpsRequest` CRD. Below is the YAML of the `Ignite` CR that we are going to create,
 
 ```yaml
 apiVersion: kubedb.com/v1alpha2
@@ -51,7 +51,7 @@ metadata:
   name: ignite
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   replicas: 3
   storage:
     accessModes:
@@ -75,7 +75,7 @@ Now, wait until `ignite` has status `Ready`. i.e,
 ```bash
 $ kubectl get ig -n demo
 NAME            TYPE                  VERSION   STATUS   AGE
-ignite          kubedb.com/v1alpha2   2.17.0    Ready    2m
+ignite          kubedb.com/v1alpha2   2.18.0    Ready    2m
 ```
 
 Let's check the number of replicas this ignite has from the Ignite object, number of pods the PetSet have,
@@ -388,7 +388,7 @@ $ kubectl get ig -n demo ignite -o json | jq '.spec.replicas'
 $ kubectl get petset -n demo ignite -o json | jq '.spec.replicas'
 2
 ```
-From all the above outputs we can see that the replicas of the ignite is `2`. That means we have successfully scaled up the replicas of the Ignite.
+From all the above outputs we can see that the replicas of the ignite is `2`. That means we have successfully scaled down the replicas of the Ignite.
 
 ## Cleaning Up
 

--- a/docs/guides/ignite/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/ignite/scaling/vertical-scaling/vertical-scaling.md
@@ -42,7 +42,7 @@ Here, we are going to deploy a  `Ignite` using a supported version by `KubeDB` o
 
 ### Prepare Ignite Database
 
-Now, we are going to deploy a `Ignite` database with version `2.17.0`.
+Now, we are going to deploy a `Ignite` database with version `2.18.0`.
 
 ### Deploy Ignite 
 
@@ -55,7 +55,7 @@ metadata:
   name: ig
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   storageType: Durable
   storage:
     storageClassName: "standard"
@@ -78,7 +78,7 @@ Now, wait until `ig` has status `Ready`. i.e,
 ```bash
 $ kubectl get ig -n demo
 NAME            VERSION    STATUS    AGE
-ig   2.17.0      Ready     5m56s
+ig   2.18.0      Ready     5m56s
 ```
 
 Let's check the Pod containers resources,
@@ -134,7 +134,7 @@ spec:
 
 Here,
 
-- `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `igps-vscale` database.
+- `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `igops-vscale` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
 - `spec.VerticalScaling.Node` specifies the desired resources after scaling.
 - Have a look [here](/docs/guides/ignite/concepts/opsrequest.md#spectimeout) on the respective sections to understand the `timeout` & `apply` fields.

--- a/docs/guides/ignite/scaling/vertical-scaling/vertical-scaling.md
+++ b/docs/guides/ignite/scaling/vertical-scaling/vertical-scaling.md
@@ -134,9 +134,9 @@ spec:
 
 Here,
 
-- `spec.databaseRef.name` specifies that we are performing vertical scaling operation on `igops-vscale` database.
+- `spec.databaseRef.name` specifies that we are performing vertical scaling operation on the `ig` database.
 - `spec.type` specifies that we are performing `VerticalScaling` on our database.
-- `spec.VerticalScaling.Node` specifies the desired resources after scaling.
+- `spec.verticalScaling.node` specifies the desired resources after scaling.
 - Have a look [here](/docs/guides/ignite/concepts/opsrequest.md#spectimeout) on the respective sections to understand the `timeout` & `apply` fields.
 
 Let's create the `IgniteOpsRequest` CR we have shown above,

--- a/docs/guides/ignite/update-version/overview.md
+++ b/docs/guides/ignite/update-version/overview.md
@@ -19,8 +19,8 @@ This guide will give you an overview on how KubeDB Ops-manager operator update t
 ## Before You Begin
 
 - You should be familiar with the following `KubeDB` concepts:
-    - [Ignite](/docs/guides/ignite/concepts/ignite/index.md)
-    - [IgniteOpsRequest](/docs/guides/ignite/concepts/opsrequest/index.md)
+    - [Ignite](/docs/guides/ignite/concepts/ignite.md)
+    - [IgniteOpsRequest](/docs/guides/ignite/concepts/opsrequest.md)
 
 ## How update version Process Works
 

--- a/docs/guides/ignite/update-version/update-version.md
+++ b/docs/guides/ignite/update-version/update-version.md
@@ -23,8 +23,8 @@ This guide will show you how to use `KubeDB` Ops-manager operator to update the 
 - Install `KubeDB` Provisioner and Ops-manager operator in your cluster following the steps [here](/docs/setup/README.md).
 
 - You should be familiar with the following `KubeDB` concepts:
-    - [Ignite](/docs/guides/ignite/concepts/ignite/index.md)
-    - [IgniteOpsRequest](/docs/guides/ignite/concepts/opsrequest/index.md)
+    - [Ignite](/docs/guides/ignite/concepts/ignite.md)
+    - [IgniteOpsRequest](/docs/guides/ignite/concepts/opsrequest.md)
     - [Updating Overview](/docs/guides/ignite/update-version/overview.md)
 
 To keep everything isolated, we are going to use a separate namespace called `demo` throughout this tutorial.
@@ -38,7 +38,7 @@ namespace/demo created
 
 ## Prepare Ignite Cluster
 
-Now, we are going to deploy an `Ignite` cluster with version `2.16.0`.
+Now, we are going to deploy an `Ignite` cluster with version `2.17.0`.
 
 ### Deploy Ignite
 
@@ -51,7 +51,7 @@ metadata:
   name: ignite-quickstart
   namespace: demo
 spec:
-  version: "2.16.0"
+  version: "2.17.0"
   replicas: 3
   storage:
     resources:
@@ -75,14 +75,14 @@ Now, wait until `ignite-quickstart` has status `Ready`. i.e,
 ```bash
 $ kubectl get ignite -n demo
 NAME                VERSION    STATUS    AGE
-ignite-quickstart   2.16.0     Ready     109s
+ignite-quickstart   2.17.0     Ready     109s
 ```
 
 We are now ready to apply the `IgniteOpsRequest` CR to update this database.
 
 ### Update Ignite Version
 
-Here, we are going to update `Ignite` cluster from `2.16.0` to `2.17.0`.
+Here, we are going to update `Ignite` cluster from `2.17.0` to `2.18.0`.
 
 #### Create IgniteOpsRequest:
 
@@ -99,7 +99,7 @@ spec:
     name: ignite-quickstart
   type: UpdateVersion
   updateVersion:
-    targetVersion: 2.17.0
+    targetVersion: 2.18.0
   timeout: 5m
   apply: IfReady
 ```
@@ -108,8 +108,8 @@ Here,
 
 - `spec.databaseRef.name` specifies that we are performing operation on `ignite-quickstart` Ignite database.
 - `spec.type` specifies that we are going to perform `UpdateVersion` on our database.
-- `spec.updateVersion.targetVersion` specifies the expected version of the database `2.17.0`.
-- Have a look [here](/docs/guides/ignite/concepts/opsrequest/index.md#spectimeout) on the respective sections to understand the `readinessCriteria`, `timeout` & `apply` fields.
+- `spec.updateVersion.targetVersion` specifies the expected version of the database `2.18.0`.
+- Have a look [here](/docs/guides/ignite/concepts/opsrequest.md#spectimeout) on the respective sections to understand the `readinessCriteria`, `timeout` & `apply` fields.
 
 Let's create the `IgniteOpsRequest` CR we have shown above,
 
@@ -153,7 +153,7 @@ Spec:
   Timeout:  5m
   Type:     UpdateVersion
   Update Version:
-    Target Version:  2.17.0
+    Target Version:  2.18.0
 Status:
   Conditions:
     Last Transition Time:  2024-10-23T10:46:27Z
@@ -240,13 +240,13 @@ Now, we are going to verify whether the `Ignite` and the related `PetSets` and t
 
 ```bash
 $ kubectl get ignite -n demo ignite-quickstart -o=jsonpath='{.spec.version}{"\n"}'
-2.17.0
+2.18.0
 
 $ kubectl get petset -n demo ignite-quickstart -o=jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-ghcr.io/appscode-images/ignite:2.17.0
+ghcr.io/appscode-images/ignite:2.18.0
 
 $ kubectl get pods -n demo ignite-quickstart-0 -o=jsonpath='{.spec.containers[0].image}{"\n"}'
-ghcr.io/appscode-images/ignite:2.17.0
+ghcr.io/appscode-images/ignite:2.18.0
 ```
 
 You can see from above, our `Ignite` cluster has been updated with the new version. So, the updateVersion process is successfully completed.

--- a/docs/guides/ignite/volume-expansion/volume-expansion.md
+++ b/docs/guides/ignite/volume-expansion/volume-expansion.md
@@ -54,7 +54,7 @@ longhorn (default)   kubernetes.io/gce-pd   Delete          Immediate           
 
 We can see from the output the `longhorn` storage class has `ALLOWVOLUMEEXPANSION` field as true. So, this storage class supports volume expansion. We can use it.
 
-Now, we are going to deploy a `Ignite` standalone database with version `2.17.0`.
+Now, we are going to deploy a `Ignite` standalone database with version `2.18.0`.
 
 #### Deploy Ignite standalone
 
@@ -67,7 +67,7 @@ metadata:
   name: ig-standalone
   namespace: demo
 spec:
-  version: "2.17.0"
+  version: "2.18.0"
   storageType: Durable
   storage:
     storageClassName: "longhorn"
@@ -81,8 +81,8 @@ spec:
 Let's create the `Ignite` CR we have shown above,
 
 ```bash
-$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/Ignite/volume-expansion/ig-standalone.yaml
-Ignite.kubedb.com/ig-standalone created
+$ kubectl create -f https://github.com/kubedb/docs/raw/{{< param "info.version" >}}/docs/examples/ignite/volume-expansion/ig-standalone.yaml
+ignite.kubedb.com/ig-standalone created
 ```
 
 Now, wait until `ig-standalone` has status `Ready`. i.e,
@@ -90,7 +90,7 @@ Now, wait until `ig-standalone` has status `Ready`. i.e,
 ```bash
 $ kubectl get ig -n demo
 NAME            VERSION     STATUS    AGE
-ig-standalone   2.17.0      Ready     2m53s
+ig-standalone   2.18.0      Ready     2m53s
 ```
 
 Let's check volume size from PetSet, and from the persistent volume,
@@ -197,7 +197,7 @@ $ kubectl describe igniteopsrequest -n demo igops-volume-exp-standalone
       Status:                True
       Type:                  VolumeExpansion
       Last Transition Time:  2020-08-25T17:50:03Z
-      Message:               Successfully Resumed Ignite: ig
+      Message:               Successfully Resumed Ignite: ig-standalone
       Observed Generation:   1
       Reason:                ResumeDatabase
       Status:                True
@@ -222,12 +222,12 @@ $ kubectl describe igniteopsrequest -n demo igops-volume-exp-standalone
 Now, we are going to verify from the `Statefulset`, and the `Persistent Volume` whether the volume of the database has expanded to meet the desired state, Let's check,
 
 ```bash
-$ kubectl get petset -n demo ig -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
+$ kubectl get petset -n demo ig-standalone -o json | jq '.spec.volumeClaimTemplates[].spec.resources.requests.storage'
 "2Gi"
 
 $ kubectl get pv -n demo
 NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                          STORAGECLASS   REASON   AGE
-pvc-d0b07657-a012-4384-862a-b4e437774287   2Gi        RWO            Delete           Bound    demo/datadir-ig-0   longhorn                4m29s
+pvc-d0b07657-a012-4384-862a-b4e437774287   2Gi        RWO            Delete           Bound    demo/datadir-ig-standalone-0   longhorn                4m29s
 ```
 
 The above output verifies that we have successfully expanded the volume of the Ignite database.
@@ -237,6 +237,6 @@ The above output verifies that we have successfully expanded the volume of the I
 To clean up the Kubernetes resources created by this tutorial, run:
 
 ```bash
-kubectl delete ig -n demo ig
+kubectl delete ig -n demo ig-standalone
 kubectl delete igniteopsrequest -n demo igops-volume-exp-standalone
 ```


### PR DESCRIPTION
Ran the Ignite guides on a live KubeDB v2026.6.19 cluster as a new user would, caught every place the docs were wrong, and fixed each one against the source of truth (apimachinery API/ops/autoscaler types, the ignite operator, the cli) or observed cluster behavior. 39 files changed (28 guide docs + 11 example YAMLs, all under `docs/guides/ignite` and `docs/examples/ignite`).

## Verified on the cluster (2.18.0)

- Provisioning, connection, and SQL via `sqlline` (quickstart), plus DoNotTerminate / Delete / WipeOut behavior.
- Ops requests: Restart (reason `RestartNodes`), HorizontalScaling, VerticalScaling, RotateAuth (adds `username.prev`/`password.prev`), and UpdateVersion 2.17.0 to 2.18.0. All Successful.
- builtin-Prometheus stats service `*-stats`, port `metrics:56790`, agent annotation `prometheus.io/builtin`.
- The corrected example YAMLs pass `kubectl apply --dry-run=server`.

## Fixes by class

**Version refresh (maintainer directive + catalog).** Standardize the ignite version to `2.18.0` across all guides and example YAMLs. update-version now upgrades `2.17.0` to `2.18.0` (`2.16.0` is not in the catalog, so the old doc could not run). Confirmed `2.18.0` provisions and reaches Ready.

**Wrong ports / names.** Service ports `11211` (Memcached copy-paste) to the real Ignite ports `8080/10800/47500/47100` in both monitoring guides and `concepts/appbinding.md`; stats port name `prom-http` to `metrics`; builtin agent annotation `prometheus.io/operator` to `prometheus.io/builtin`; stale `VERSION 1.6.22` to `2.18.0`; CRD name made consistent (`builtin-prom-ignite`).

**MongoDB / PgBouncer copy-paste residue.** `MogoDBOpsRequest` to `IgniteOpsRequest`; `mongo-ca`/`mg-issuer`/`mg-new-issuer` to `ignite-ca`/`ig-issuer`/`ig-new-issuer`; `mops-*` op names to `igops-*`; `RestartReplicaSet`/"Restarted ReplicaSet nodes" to `RestartNodes`/"restarted all nodes" (verified on cluster); `databaseRef.name: mongo` to `ig` and removed the non-existent `readinessCriteria`/`oplogMaxLagSeconds` fields; `connection-pooler` component label to `database`; removed PgBouncer `pool_passwd` prose.

**Broken links.** `concepts/*/index.md` to `concepts/*.md` (rotate-auth, update-version).

**Command typos that error.** `ubectl` to `kubectl`; `-n dmeo` to `-n demo`; capital-I `Igniteopsrequest` to `igniteopsrequest`; PgBouncer shortname `pp` to `ig`; wrong object names in verify/cleanup commands (`ig` to `ig-standalone`, `datadir-ig-0` to `datadir-ig-standalone-0`, autoscaler name typo `autosclaer` to `autoscaler`); capital-`Ignite` example URL paths to lowercase.

**Field / value / concept errors (source-confirmed).** config secret name `<name>-config` to the real `<name>-<uid-suffix>`; AppBinding scheme `tcp` to `http`; DoNotTerminate error output updated to the real message; Delete-policy output now shows only the surviving auth secret; `spec.monitor.args` to `spec.monitor.prometheus.exporter.args`; `monitor.prometheus.labels`/`.interval` to `.serviceMonitor.labels`/`.interval` and removed the non-existent `monitor.prometheus.namespace`; `helathChecker` to `healthChecker`; added `RotateAuth` and `StorageMigration` to the opsrequest `spec.type` list; autoscaler `resourceDiffPercentage` default `10%` to `50%`, `cpu: 0.5m` to `500m`; mis-indented `IgniteVersion` sample YAML fixed; scale-down section prose "scaled up" to "scaled down"; storage-autoscaler threshold/expansionMode prose reconciled with the YAML.

## Coverage notes

Some guides could not be fully re-executed on this cluster (fixes are source-confirmed and, for examples, dry-run validated): volume-expansion (only a non-expandable `local-path` storage class), monitoring/using-prometheus-operator (Prometheus operator not installed), and the autoscaler guides (autoscaler stack not installed). All other guides were executed.

No em-dashes. No unrelated files touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Ignite examples and walkthroughs throughout the docs to reflect version 2.18.0.
  * Refreshed autoscaling, monitoring, reconfigure (including TLS), restart, update-version, horizontal/vertical scaling, quickstart, and private-registry guides with corrected example values, commands, and expected outputs.
  * Corrected various documentation details including resource names, ports/exporter configuration notes, and cleanup/verification snippets.
  * Expanded supported IgniteOpsRequest operations and fixed concept link paths across the rotate-auth and update-version flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->