### PR TITLE
Add Milvus 3.0.0 to supported versions

### DIFF
--- a/docs/guides/milvus/README.md
+++ b/docs/guides/milvus/README.md
@@ -44,6 +44,7 @@ KubeDB supports the following Milvus Versions.
 - `2.6.7`
 - `2.6.9`
 - `2.6.11`
+- `3.0.0`
 
 ## User Guide
 


### PR DESCRIPTION
Adds 3.0.0 to the supported Milvus versions in the guide index. Companion to kubedb/installer PR "Add Milvus 3.0.0 catalog entries" (merge together with / after it). Verified on a k3s test cluster: fresh 3.0.0 provision (standalone + distributed) and 2.6.11→3.0.0 UpdateVersion, data intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Milvus 3.0.0 to the list of supported Milvus versions in the KubeDB documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->